### PR TITLE
Simplify interface.gd

### DIFF
--- a/src/data_classes/SVGAttribute.gd
+++ b/src/data_classes/SVGAttribute.gd
@@ -6,7 +6,7 @@ var type: Type
 var value: Variant
 var default: Variant
 
-func _init(new_type: Type, new_default: Variant):
+func _init(new_type: Type, new_default: Variant, new_init : Variant = null):
 	type = new_type
 	default = new_default
-	value = new_default
+	value = new_init if new_init != null else new_default

--- a/src/data_classes/SVGTagCircle.gd
+++ b/src/data_classes/SVGTagCircle.gd
@@ -5,7 +5,7 @@ func _init():
 	attributes = {
 		"cx": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
 		"cy": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
-		"r": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
+		"r": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0, 1.0),
 		"fill": SVGAttribute.new(SVGAttribute.Type.COLOR, "000"),
 		"stroke": SVGAttribute.new(SVGAttribute.Type.COLOR, "none"),
 		"stroke-width": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 1.0),

--- a/src/data_classes/SVGTagEllipse.gd
+++ b/src/data_classes/SVGTagEllipse.gd
@@ -5,8 +5,8 @@ func _init():
 	attributes = {
 		"cx": SVGAttribute.new(SVGAttribute.Type.FLOAT, 0.0),
 		"cy": SVGAttribute.new(SVGAttribute.Type.FLOAT, 0.0),
-		"rx": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
-		"ry": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
+		"rx": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0, 1.0),
+		"ry": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0, 1.0),
 		"fill": SVGAttribute.new(SVGAttribute.Type.COLOR, "000"),
 		"stroke": SVGAttribute.new(SVGAttribute.Type.COLOR, "none"),
 		"stroke-width": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 1.0),

--- a/src/data_classes/SVGTagRect.gd
+++ b/src/data_classes/SVGTagRect.gd
@@ -5,8 +5,8 @@ func _init():
 	attributes = {
 		"x": SVGAttribute.new(SVGAttribute.Type.FLOAT, 0.0),
 		"y": SVGAttribute.new(SVGAttribute.Type.FLOAT, 0.0),
-		"width": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
-		"height": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
+		"width": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0, 1.0),
+		"height": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0, 1.0),
 		"rx": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
 		"ry": SVGAttribute.new(SVGAttribute.Type.UFLOAT, 0.0),
 		"fill": SVGAttribute.new(SVGAttribute.Type.COLOR, "000"),

--- a/src/interface_elements/interface.gd
+++ b/src/interface_elements/interface.gd
@@ -4,53 +4,27 @@ const TagEditor = preload("tag_editor.tscn")
 
 @onready var shapes: VBoxContainer = $Shapes
 
+func add_shape(shape : GDScript) -> void :
+	print(shape)
+	var shape_editor := TagEditor.instantiate()
+	shape_editor.tag_index = SVG.data.tags.size()
+	shape_editor.deleted.connect(_on_tag_deleted)
+	shape_editor.tag = shape.new()
+	shapes.add_child(shape_editor) 
+
+# In the end all connection should go directly to add_shape with argument in binds 
+# But right now there is a bug preventing it so keeping them here for now
 func add_circle() -> void:
-	var circle_editor := TagEditor.instantiate()
-	circle_editor.tag_index = SVG.data.tags.size()
-	circle_editor.deleted.connect(_on_tag_deleted)
-	var circle := SVGTagCircle.new()
-	for attribute in circle.attributes:
-		match attribute:
-			"r": circle.attributes[attribute].value = 1.0
-			_: circle.attributes[attribute].value = circle.attributes[attribute].default
-	circle_editor.tag = circle
-	shapes.add_child(circle_editor)
+	add_shape(SVGTagCircle)
 
 func add_ellipse() -> void:
-	var ellipse_editor := TagEditor.instantiate()
-	ellipse_editor.tag_index = SVG.data.tags.size()
-	ellipse_editor.deleted.connect(_on_tag_deleted)
-	var ellipse := SVGTagEllipse.new()
-	for attribute in ellipse.attributes:
-		match attribute:
-			"rx": ellipse.attributes[attribute].value = 1.0
-			"ry": ellipse.attributes[attribute].value = 1.0
-			_: ellipse.attributes[attribute].value = ellipse.attributes[attribute].default
-	ellipse_editor.tag = ellipse
-	shapes.add_child(ellipse_editor)
+	add_shape(SVGTagEllipse)
 
 func add_rect() -> void:
-	var rect_editor := TagEditor.instantiate()
-	rect_editor.tag_index = SVG.data.tags.size()
-	rect_editor.deleted.connect(_on_tag_deleted)
-	var rect := SVGTagRect.new()
-	for attribute in rect.attributes:
-		match attribute:
-			"width": rect.attributes[attribute].value = 1.0
-			"height": rect.attributes[attribute].value = 1.0
-			_: rect.attributes[attribute].value = rect.attributes[attribute].default
-	rect_editor.tag = rect
-	shapes.add_child(rect_editor)
+	add_shape(SVGTagRect)
 
 func add_path() -> void:
-	var path_editor := TagEditor.instantiate()
-	path_editor.tag_index = SVG.data.tags.size()
-	path_editor.deleted.connect(_on_tag_deleted)
-	var path := SVGTagPath.new()
-	for attribute in path.attributes:
-		path.attributes[attribute].value = path.attributes[attribute].default
-	path_editor.tag = path
-	shapes.add_child(path_editor)
+	add_shape(SVGTagPath)
 
 func _change_view_box(w: int, h: int) -> void:
 	SVG.data.w = w


### PR DESCRIPTION
This is a pass to simplify interface.gd as there was multiple function doing the same thing. Moreover it moved intinialisation of value to the Init of tag by creating a new optional argument that if he is not null change initial value of the property.