### PR TITLE
Prevent approximations that leads to inconsistency in the svg showing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Godot 4+ specific ignores
 .godot/
+.DS_Store

--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -10,7 +10,7 @@ var data := SVGData.new()
 func tags_to_string(superscaled := false, add_xmlns := true) -> String:
 	var w := data.w
 	var h := data.h
-	var scale := 1024.0 / maxi(w, h) if (superscaled and w != 0 and h != 0) else 1.0
+	var scale := 128.0 if superscaled  else 1.0
 	# Opening
 	string = '<svg width="{w}" height="{h}" viewBox="({w} {h})"'.format(
 			{"w": w * scale, "h": h * scale})
@@ -56,6 +56,6 @@ func update() -> void:
 	code_editor.text = tags_to_string()
 	# Update the display.
 	if FileAccess.file_exists(display_path):
-		var image := Image.load_from_file(display_path)
+		var image := Image.load_from_file(display_path) # when/if godot expose the scale argument of this function it could be used to replace superscaled argument.
 		var image_texture := ImageTexture.create_from_image(image)
 		texture_node.texture = image_texture


### PR DESCRIPTION
Fixes #5 (at least initial report)
I just made the scaling be always the same instead of trying to make the size of the image a fixed value.
added a not the scale argument of `load_from_file`
Also added to the gitignore a macos specific file that should not be commited.