### PR TITLE
Unify attribute editors

### DIFF
--- a/src/interface_elements/AttributeEditor.gd
+++ b/src/interface_elements/AttributeEditor.gd
@@ -1,0 +1,4 @@
+class_name AttributeEditor extends Control
+
+var attribute: SVGAttribute
+var attribute_name: String

--- a/src/interface_elements/color_field.gd
+++ b/src/interface_elements/color_field.gd
@@ -1,11 +1,8 @@
-extends HBoxContainer
+extends AttributeEditor
 
 @onready var color_button: Button = $Button
 @onready var color_edit: LineEdit = $LineEdit
 @onready var color_picker: Popup = $ColorPopup
-
-var attribute: SVGAttribute
-var attribute_name: String
 
 signal value_changed(new_value: String)
 var value: String:
@@ -23,7 +20,7 @@ func _ready() -> void:
 	color_edit.tooltip_text = attribute_name
 
 func validate(new_value: String, old_value: String) -> String:
-	if new_value == "none" or  (new_value.is_valid_html_color() and\
+	if new_value == "none" or (new_value.is_valid_html_color() and\
 	not new_value.begins_with("#")):
 		return new_value
 	else:

--- a/src/interface_elements/color_field.tscn
+++ b/src/interface_elements/color_field.tscn
@@ -183,11 +183,6 @@ layout_mode = 2
 tooltip_text = "Node2D color"
 color_hex = "8da5f3"
 
-[node name="Node2DDark" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
-layout_mode = 2
-tooltip_text = "Node2D dark color"
-color_hex = "4b70ea"
-
 [node name="Control" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
 layout_mode = 2
 tooltip_text = "Control color"

--- a/src/interface_elements/enum_field.gd
+++ b/src/interface_elements/enum_field.gd
@@ -1,7 +1,4 @@
-extends VBoxContainer
-
-var attribute: SVGEnumAttribute
-var attribute_name: String
+extends AttributeEditor
 
 @onready var value_picker: Popup = $EnumPopup
 @onready var indicator: LineEdit = $MainLine/LineEdit

--- a/src/interface_elements/flag_field.gd
+++ b/src/interface_elements/flag_field.gd
@@ -1,5 +1,7 @@
 extends Button
 
+# Flags don't show up in any supported attributes, so it's not an AttributeEditor.
+
 signal value_changed(new_value: int)
 var value: int:
 	set(new_value):

--- a/src/interface_elements/number_field.gd
+++ b/src/interface_elements/number_field.gd
@@ -1,4 +1,4 @@
-extends HBoxContainer
+extends AttributeEditor
 
 @onready var up: Button = %Up
 @onready var up_buildup_timer: Timer = %Up/Timer
@@ -12,9 +12,6 @@ var min_value := 0.0
 var max_value := 1024.0
 var step := 1.0
 var is_float := true
-
-var attribute: SVGAttribute
-var attribute_name: String
 
 signal value_changed(new_value: float)
 var value: float:

--- a/src/interface_elements/path_field.gd
+++ b/src/interface_elements/path_field.gd
@@ -1,10 +1,7 @@
-extends VBoxContainer
+extends AttributeEditor
 
 const NumberField = preload("number_field.tscn")
 const FlagField = preload("flag_field.tscn")
-
-var attribute: SVGAttribute
-var attribute_name: String
 
 @onready var command_picker: Popup = $PathPopup
 @onready var line_edit: LineEdit = $MainLine/LineEdit

--- a/src/interface_elements/tag_editor.gd
+++ b/src/interface_elements/tag_editor.gd
@@ -28,7 +28,7 @@ func _ready() -> void:
 	label.text = tag.title
 	for attribute_key in tag.attributes:
 		var attribute_value: SVGAttribute = tag.attributes[attribute_key]
-		var input_field: Control
+		var input_field: AttributeEditor
 		match attribute_value.type:
 			SVGAttribute.Type.INT:
 				input_field = NumberField.instantiate()


### PR DESCRIPTION
Perhaps values and related signals can also be added to this abstract class someday, but for now it's better to keep the static typing until GDScript maybe adds a solution for this situation.