### PR TITLE
Fix width and height only allowing ints (and soften lag spikes)

### DIFF
--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -32,8 +32,8 @@ func sync_data() -> void:
 
 
 func tags_to_string() -> void:
-	var w := data.w
-	var h := data.h
+	var w := data.width
+	var h := data.height
 	# Opening
 	string = '<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}"'.format(
 			{"w": w, "h": h})
@@ -69,8 +69,11 @@ func string_to_tags() -> void:
 				attribute_dict[parser.get_attribute_name(i)] = parser.get_attribute_value(i)
 			
 			if node_name == "svg":
-				data.w = attribute_dict["width"] if attribute_dict.has("width") else 0
-				data.h = attribute_dict["height"] if attribute_dict.has("height") else 0
+				var new_w: float = attribute_dict["width"].to_float() if\
+						attribute_dict.has("width") else 0.0
+				var new_h: float = attribute_dict["height"].to_float() if\
+						attribute_dict.has("height") else 0.0
+				data.set_dimensions(new_w, new_h)
 			else:
 				var tag: SVGTag
 				match node_name:

--- a/src/data_classes/SVGData.gd
+++ b/src/data_classes/SVGData.gd
@@ -7,21 +7,34 @@ signal tag_deleted(idx: int)
 signal tag_moved
 signal changed_unknown
 
-var w := 16.0:
-	set(new_w):
-		if w != new_w:
-			w = new_w
-			resized.emit()
-
-var h := 16.0:
-	set(new_h):
-		if h != new_h:
-			h = new_h
-			resized.emit()
-
+var width := 16.0
+var height := 16.0
 var tags: Array[SVGTag]
 
-func emit_attribute_changed():
+
+func set_dimensions(new_width: float, new_height: float) -> void:
+	var is_width_different := width != new_width
+	var is_height_different := height != new_height
+	# Ensure the signal is not emitted unless dimensions have really changed.
+	if is_width_different or is_height_different:
+		if is_width_different:
+			width = new_width
+		if is_height_different:
+			height = new_height
+		resized.emit()
+
+func set_width(new_width: float) -> void:
+	if width != new_width:
+		width = new_width
+		resized.emit()
+
+func set_height(new_height: float) -> void:
+	if height != new_height:
+		height = new_height
+		resized.emit()
+
+
+func emit_attribute_changed() -> void:
 	attribute_changed.emit()
 
 

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -18,8 +18,8 @@ func _ready() -> void:
 
 func full_update() -> void:
 	# Draw a SVG out of the shapes.
-	var w := SVG.data.w
-	var h := SVG.data.h
+	var w := SVG.data.width
+	var h := SVG.data.height
 	var svg := '<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}"'.format(
 			{"w": w, "h": h})
 	svg += ' xmlns="http://www.w3.org/2000/svg">'
@@ -88,10 +88,10 @@ func _draw() -> void:
 			draw_circle(coords_to_canvas(handle.pos), 2.25 / zoom, Color.WHITE)
 
 func coords_to_canvas(pos: Vector2) -> Vector2:
-	return size / Vector2(SVG.data.w, SVG.data.h) * pos
+	return size / Vector2(SVG.data.width, SVG.data.height) * pos
 
 func canvas_to_coords(pos: Vector2) -> Vector2:
-	return pos * Vector2(SVG.data.w, SVG.data.h) / size
+	return pos * Vector2(SVG.data.width, SVG.data.height) / size
 
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -14,8 +14,8 @@ func _ready() -> void:
 
 
 func update_viewbox() -> void:
-	$MainConfiguration/ViewBoxEdit/WidthEdit.value = SVG.data.w
-	$MainConfiguration/ViewBoxEdit/HeightEdit.value = SVG.data.h
+	$MainConfiguration/ViewBoxEdit/WidthEdit.value = SVG.data.width
+	$MainConfiguration/ViewBoxEdit/HeightEdit.value = SVG.data.height
 
 func full_rebuild() -> void:
 	update_viewbox()
@@ -47,9 +47,9 @@ func add_path() -> void:
 func add_line() -> void:
 	SVG.data.add_tag(SVGTagLine.new())
 
-func _change_view_box(w: int, h: int) -> void:
-	SVG.data.w = w
-	SVG.data.h = h
+func _change_view_box(w: float, h: float) -> void:
+	SVG.data.width = w
+	SVG.data.height = h
 
 
 func _on_tag_container_gui_input(event: InputEvent) -> void:

--- a/src/ui_parts/view_box_edit.gd
+++ b/src/ui_parts/view_box_edit.gd
@@ -1,6 +1,6 @@
 extends HBoxContainer
 
-signal view_box_changed(w: int, h: int)
+signal view_box_changed(w: float, h: float)
 
 @onready var width_edit: Control = $WidthEdit
 @onready var height_edit: Control = $HeightEdit
@@ -9,8 +9,8 @@ func emit_view_box_changed(_new_value := -1.0) -> void:
 	view_box_changed.emit(width_edit.value, height_edit.value)
 
 func _ready() -> void:
-	height_edit.value = SVG.data.h
+	height_edit.value = SVG.data.height
 	height_edit.value_changed.connect(emit_view_box_changed)
-	width_edit.value = SVG.data.w
+	width_edit.value = SVG.data.width
 	width_edit.value_changed.connect(emit_view_box_changed)
 	emit_view_box_changed()

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -44,12 +44,12 @@ func zoom_out() -> void:
 	center_frame()
 
 func zoom_reset() -> void:
-	zoom_level = float(nearest_po2(int(256 / maxf(SVG.data.w, SVG.data.h))))
+	zoom_level = float(nearest_po2(int(256 / maxf(SVG.data.width, SVG.data.height))))
 	center_frame()
 
 
 func resize() -> void:
-	display.size = Vector2(SVG.data.w, SVG.data.h)
+	display.size = Vector2(SVG.data.width, SVG.data.height)
 	center_frame()
 
 func center_frame() -> void:

--- a/translations/.~lock.translation_sheet.csv#
+++ b/translations/.~lock.translation_sheet.csv#
@@ -1,1 +1,0 @@
-,volter,volter,13.10.2023 01:11,file:///home/volter/.config/libreoffice/4;


### PR DESCRIPTION
Also allows to change width and height at once and only emit the `resized()` signal once: This notably improves lag spikes.