### PR TITLE
Improve performance of large SVGs

### DIFF
--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -6,6 +6,8 @@ const about_menu = preload("about_menu.tscn")
 const NumberField = preload("res://src/small_editors/number_field.tscn")
 
 @onready var zoom_reset_button: Button = %ZoomReset
+@onready var zoom_in_button: Button = %ZoomIn
+@onready var zoom_out_button: Button = %ZoomOut
 @onready var viewport: SubViewport = $ViewportContainer/Viewport
 @onready var controls: TextureRect = %Checkerboard/Controls
 @onready var grid_visuals: Control = $ViewportContainer/Viewport/SnapLines
@@ -14,10 +16,16 @@ const NumberField = preload("res://src/small_editors/number_field.tscn")
 @onready var more_button: Button = %LeftMenu/MoreOptions
 @onready var more_popup: Popup = %LeftMenu/MorePopup
 
-func update_zoom_label(zoom_level: float) -> void:
+func update_zoom_widget(zoom_level: float) -> void:
 	await get_tree().process_frame
 	zoom_reset_button.text = String.num(zoom_level * 100,
 			2 if zoom_level < 0.1 else 1 if zoom_level < 10.0 else 0) + "%"
+	zoom_out_button.disabled = (zoom_level <= viewport.min_zoom)
+	zoom_out_button.mouse_default_cursor_shape = Control.CURSOR_ARROW\
+			if zoom_out_button.disabled else Control.CURSOR_POINTING_HAND
+	zoom_in_button.disabled = (zoom_level >= viewport.max_zoom)
+	zoom_in_button.mouse_default_cursor_shape = Control.CURSOR_ARROW\
+			if zoom_in_button.disabled else Control.CURSOR_POINTING_HAND
 
 
 func _on_settings_pressed() -> void:

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -1,5 +1,12 @@
 extends TextureRect
 
+var zoom := 1.0:
+	set(new_value):
+		var old_zoom := zoom
+		zoom = new_value
+		if old_zoom < zoom:
+			svg_update()
+
 var update_pending := false
 
 func _ready() -> void:
@@ -22,7 +29,7 @@ func _process(_delta: float) -> void:
 func svg_update() -> void:
 	# Store the SVG string.
 	var img := Image.new()
-	img.load_svg_from_string(SVG.string, 128.0)
+	img.load_svg_from_string(SVG.string, zoom * 4.0)
 	# Update the display.
 	if not img.is_empty():
 		var image_texture := ImageTexture.create_from_image(img)

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -257,6 +257,7 @@ layout_mode = 2
 alignment = 1
 
 [node name="ZoomOut" type="Button" parent="Display/PanelContainer/MarginContainer/HBoxContainer/ZoomMenu"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "#zoom_out"
 mouse_default_cursor_shape = 2
@@ -274,6 +275,7 @@ shortcut = SubResource("Shortcut_le5f5")
 text = "100%"
 
 [node name="ZoomIn" type="Button" parent="Display/PanelContainer/MarginContainer/HBoxContainer/ZoomMenu"]
+unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "#zoom_in"
 mouse_default_cursor_shape = 2

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -7,17 +7,19 @@ const minimum_visible_proportion = 0.3
 @onready var display: TextureRect = $Checkerboard
 @onready var snap_lines: Control = $SnapLines
 @onready var main_node: VBoxContainer = %Display
+@onready var display_texture: TextureRect = $Checkerboard/DisplayTexture
 @onready var controls: TextureRect = $Checkerboard/Controls
 
 var zoom_level: float:
 	set(new_value):
 		zoom_level = clampf(new_value, min_zoom, max_zoom)
-		main_node.update_zoom_label(zoom_level)
+		main_node.update_zoom_widget(zoom_level)
 		size_2d_override = size / zoom_level
 		display.material.set_shader_parameter(&"uv_scale",
 				nearest_po2(int(zoom_level * 32)) / 32.0)
 		clamp_view()
 		controls.zoom = zoom_level
+		display_texture.zoom = zoom_level
 		snap_lines.queue_redraw()
 
 
@@ -44,7 +46,8 @@ func zoom_out() -> void:
 	center_frame()
 
 func zoom_reset() -> void:
-	zoom_level = float(nearest_po2(int(256 / maxf(SVG.data.width, SVG.data.height))))
+	zoom_level = float(
+			nearest_po2(int(8192 / maxf(SVG.data.width, SVG.data.height))) / 32.0)
 	center_frame()
 
 


### PR DESCRIPTION
This fixes some situations where large SVGs would cause massive lag. However, it causes zooming in to be a pain point now (which will need to be worked on further), but later with that - I have a few other performance bottlenecks to handle first.