### PR TITLE
Split off Number Fields With Sliders

### DIFF
--- a/src/BetterLineEdit.gd
+++ b/src/BetterLineEdit.gd
@@ -1,0 +1,42 @@
+class_name BetterLineEdit extends LineEdit
+
+var hovered := false
+
+@export var hover_stylebox: StyleBox
+@export var focus_stylebox: StyleBox
+
+func _ready() -> void:
+	focus_entered.connect(_on_focus_entered)
+	focus_exited.connect(_on_focus_exited)
+	mouse_entered.connect(_on_mouse_entered)
+	mouse_exited.connect(_on_mouse_exited)
+	text_submitted.connect(_on_text_submitted)
+
+func _input(event: InputEvent) -> void:
+	if has_focus() and event is InputEventMouseButton and\
+	not get_global_rect().has_point(event.position):
+		release_focus()
+
+func _on_focus_entered() -> void:
+	get_tree().paused = true
+
+func _on_focus_exited() -> void:
+	get_tree().paused = false
+
+func _on_mouse_entered() -> void:
+	hovered = true
+	queue_redraw()
+
+func _on_mouse_exited() -> void:
+	hovered = false
+	queue_redraw()
+
+func _on_text_submitted(_new_text: String) -> void:
+	release_focus()
+
+func _draw() -> void:
+	if editable:
+		if has_focus() and focus_stylebox != null:
+			draw_style_box(focus_stylebox, Rect2(Vector2.ZERO, size))
+		elif hovered and hover_stylebox != null:
+			draw_style_box(hover_stylebox, Rect2(Vector2.ZERO, size))

--- a/src/small_editors/color_field.gd
+++ b/src/small_editors/color_field.gd
@@ -207,21 +207,12 @@ func _draw() -> void:
 	draw_style_box(stylebox, Rect2(Vector2.ZERO, button_size - Vector2(1, 2)))
 
 
-# Hacks to make LineEdit bearable.
-
-func _on_focus_entered() -> void:
-	get_tree().paused = true
-
 func _on_focus_exited() -> void:
 	set_value(color_edit.text)
-	get_tree().paused = false
 
 func _on_text_submitted(new_text: String) -> void:
 	set_value(new_text)
-	color_edit.release_focus()
 
-func _input(event: InputEvent) -> void:
-	Utils.defocus_control_on_outside_click(color_edit, event)
 
 func _on_color_picked(new_color: String) -> void:
 	set_value(new_color)

--- a/src/small_editors/color_field.tscn
+++ b/src/small_editors/color_field.tscn
@@ -1,9 +1,30 @@
-[gd_scene load_steps=5 format=3 uid="uid://carf2o1y7wvmc"]
+[gd_scene load_steps=8 format=3 uid="uid://carf2o1y7wvmc"]
 
 [ext_resource type="Script" path="res://src/small_editors/color_field.gd" id="1_330tl"]
 [ext_resource type="Texture2D" uid="uid://y0l74x73w0co" path="res://visual/CheckerboardMini.svg" id="2_gsj5a"]
 [ext_resource type="Script" path="res://src/small_editors/color_popup.gd" id="2_hgyyv"]
 [ext_resource type="PackedScene" uid="uid://cpvtf3kaa2ltr" path="res://src/small_editors/color_swatch.tscn" id="3_38vpq"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="3_lamtl"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q6tej"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(1, 1, 1, 0.0666667)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_edu3w"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(0.501961, 0.752941, 1, 0.133333)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
 
 [node name="ColorField" type="HBoxContainer"]
 custom_minimum_size = Vector2(0, 22)
@@ -22,6 +43,9 @@ max_length = 20
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
+script = ExtResource("3_lamtl")
+hover_stylebox = SubResource("StyleBoxFlat_q6tej")
+focus_stylebox = SubResource("StyleBoxFlat_edu3w")
 
 [node name="Button" type="Button" parent="."]
 custom_minimum_size = Vector2(13, 0)
@@ -210,7 +234,6 @@ layout_mode = 2
 tooltip_text = "Rainbow pink"
 color_hex = "ff4596"
 
-[connection signal="focus_entered" from="LineEdit" to="." method="_on_focus_entered"]
 [connection signal="focus_exited" from="LineEdit" to="." method="_on_focus_exited"]
 [connection signal="text_changed" from="LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]

--- a/src/small_editors/enum_field.gd
+++ b/src/small_editors/enum_field.gd
@@ -46,11 +46,7 @@ func _on_value_changed(new_value: String) -> void:
 		set_text_tint()
 
 
-func _input(event: InputEvent) -> void:
-	Utils.defocus_control_on_outside_click(indicator, event)
-
-
-func _on_line_edit_text_submitted(new_text: String) -> void:
+func _on_text_submitted(new_text: String) -> void:
 	indicator.release_focus()
 	if new_text in attribute.possible_values:
 		set_value(new_text)
@@ -59,7 +55,7 @@ func _on_line_edit_text_submitted(new_text: String) -> void:
 	else:
 		indicator.text = get_value()
 
-func _on_line_edit_text_changed(new_text: String) -> void:
+func _on_text_changed(new_text: String) -> void:
 	if new_text in attribute.possible_values:
 		indicator.add_theme_color_override(&"font_color", Color(0.6, 1.0, 0.6))
 	else:

--- a/src/small_editors/enum_field.tscn
+++ b/src/small_editors/enum_field.tscn
@@ -1,8 +1,29 @@
-[gd_scene load_steps=4 format=3 uid="uid://d2da0thyq5rq8"]
+[gd_scene load_steps=7 format=3 uid="uid://d2da0thyq5rq8"]
 
 [ext_resource type="Script" path="res://src/small_editors/enum_field.gd" id="1_vkd5r"]
 [ext_resource type="Texture2D" uid="uid://coda6chhcatal" path="res://visual/icons/Arrow.svg" id="2_owe3f"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="2_sry6s"]
 [ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/small_editors/context_popup.tscn" id="3_qw0q5"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y4kmw"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(1, 1, 1, 0.0666667)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qhmpn"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(0.501961, 0.752941, 1, 0.133333)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
 
 [node name="EnumField" type="VBoxContainer"]
 offset_bottom = 22.0
@@ -21,6 +42,9 @@ theme_type_variation = &"RightConnectedLineEdit"
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
+script = ExtResource("2_sry6s")
+hover_stylebox = SubResource("StyleBoxFlat_y4kmw")
+focus_stylebox = SubResource("StyleBoxFlat_qhmpn")
 
 [node name="Button" type="Button" parent="MainLine"]
 custom_minimum_size = Vector2(15, 0)
@@ -33,6 +57,6 @@ icon = ExtResource("2_owe3f")
 [node name="ContextPopup" parent="." instance=ExtResource("3_qw0q5")]
 visible = false
 
-[connection signal="text_changed" from="MainLine/LineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="text_submitted" from="MainLine/LineEdit" to="." method="_on_line_edit_text_submitted"]
+[connection signal="text_changed" from="MainLine/LineEdit" to="." method="_on_text_changed"]
+[connection signal="text_submitted" from="MainLine/LineEdit" to="." method="_on_text_submitted"]
 [connection signal="pressed" from="MainLine/Button" to="." method="_on_button_pressed"]

--- a/src/small_editors/number_field.tscn
+++ b/src/small_editors/number_field.tscn
@@ -1,52 +1,51 @@
-[gd_scene load_steps=3 format=3 uid="uid://bp2vpf7g8w8aj"]
+[gd_scene load_steps=5 format=3 uid="uid://c6vgjud6wrdu4"]
 
 [ext_resource type="Script" path="res://src/small_editors/number_field.gd" id="1_vy4cm"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="2_c3tak"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_smesa"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kgadk"]
 draw_center = false
-border_width_left = 1
+border_width_left = 2
 border_width_top = 2
 border_width_right = 2
 border_width_bottom = 2
-border_color = Color(0.203922, 0.254902, 0.4, 1)
+border_color = Color(1, 1, 1, 0.0666667)
+corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
-corner_detail = 16
+corner_radius_bottom_left = 5
 
-[node name="NumberField" type="HBoxContainer"]
-custom_minimum_size = Vector2(0, 22)
-offset_right = 50.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_m2p2n"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.501961, 0.752941, 1, 0.133333)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="NumberField" type="Control"]
+custom_minimum_size = Vector2(54, 22)
+layout_mode = 3
+anchors_preset = 0
+offset_right = 48.0
 offset_bottom = 22.0
-theme_override_constants/separation = 0
 script = ExtResource("1_vy4cm")
 
 [node name="LineEdit" type="LineEdit" parent="."]
-custom_minimum_size = Vector2(46, 0)
-layout_mode = 2
-size_flags_horizontal = 3
-focus_mode = 1
-context_menu_enabled = false
-select_all_on_focus = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
 caret_blink = true
-
-[node name="Slider" type="Button" parent="."]
-visible = false
-clip_contents = true
-custom_minimum_size = Vector2(12, 0)
-layout_mode = 2
-focus_mode = 0
-mouse_default_cursor_shape = 2
-theme_type_variation = &"LeftConnectedButtonTransparent"
-theme_override_styles/pressed = SubResource("StyleBoxFlat_smesa")
-
-[connection signal="focus_entered" from="LineEdit" to="." method="_on_focus_entered"]
-[connection signal="focus_exited" from="LineEdit" to="." method="_on_focus_exited"]
-[connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
-[connection signal="gui_input" from="Slider" to="." method="_on_slider_gui_input"]
-[connection signal="mouse_entered" from="Slider" to="." method="_on_slider_mouse_entered"]
-[connection signal="mouse_exited" from="Slider" to="." method="_on_slider_mouse_exited"]
-[connection signal="resized" from="Slider" to="." method="_on_slider_resized"]
+caret_blink_interval = 0.5
+script = ExtResource("2_c3tak")
+hover_stylebox = SubResource("StyleBoxFlat_kgadk")
+focus_stylebox = SubResource("StyleBoxFlat_m2p2n")

--- a/src/small_editors/number_field_with_slider.tscn
+++ b/src/small_editors/number_field_with_slider.tscn
@@ -1,0 +1,75 @@
+[gd_scene load_steps=6 format=3 uid="uid://bp2vpf7g8w8aj"]
+
+[ext_resource type="Script" path="res://src/small_editors/number_field_with_slider.gd" id="1_q10gl"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="2_sbc18"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e034s"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(1, 1, 1, 0.0666667)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_0nb8u"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(0.501961, 0.752941, 1, 0.133333)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_smesa"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+draw_center = false
+border_width_left = 1
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.203922, 0.254902, 0.4, 1)
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_detail = 16
+
+[node name="NumberFieldWithSlider" type="HBoxContainer"]
+custom_minimum_size = Vector2(0, 22)
+offset_right = 46.0
+offset_bottom = 22.0
+theme_override_constants/separation = 0
+script = ExtResource("1_q10gl")
+
+[node name="LineEdit" type="LineEdit" parent="."]
+custom_minimum_size = Vector2(46, 0)
+layout_mode = 2
+size_flags_horizontal = 3
+focus_mode = 1
+theme_type_variation = &"RightConnectedLineEdit"
+context_menu_enabled = false
+select_all_on_focus = true
+caret_blink = true
+script = ExtResource("2_sbc18")
+hover_stylebox = SubResource("StyleBoxFlat_e034s")
+focus_stylebox = SubResource("StyleBoxFlat_0nb8u")
+
+[node name="Slider" type="Button" parent="."]
+clip_contents = true
+custom_minimum_size = Vector2(12, 0)
+layout_mode = 2
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_type_variation = &"LeftConnectedButtonTransparent"
+theme_override_styles/pressed = SubResource("StyleBoxFlat_smesa")
+
+[connection signal="focus_exited" from="LineEdit" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
+[connection signal="gui_input" from="Slider" to="." method="_on_slider_gui_input"]
+[connection signal="mouse_entered" from="Slider" to="." method="_on_slider_mouse_entered"]
+[connection signal="mouse_exited" from="Slider" to="." method="_on_slider_mouse_exited"]
+[connection signal="resized" from="Slider" to="." method="_on_slider_resized"]

--- a/src/small_editors/path_field.gd
+++ b/src/small_editors/path_field.gd
@@ -127,9 +127,5 @@ func toggle_relative(idx: int) -> void:
 	attribute.toggle_relative_command(idx)
 
 
-func _input(event: InputEvent) -> void:
-	Utils.defocus_control_on_outside_click(line_edit, event)
-
 func _on_line_edit_text_submitted(new_text: String) -> void:
 	set_value(new_text)
-	line_edit.release_focus()

--- a/src/small_editors/path_field.tscn
+++ b/src/small_editors/path_field.tscn
@@ -1,9 +1,30 @@
-[gd_scene load_steps=8 format=3 uid="uid://dqy5lv33sy5r7"]
+[gd_scene load_steps=11 format=3 uid="uid://dqy5lv33sy5r7"]
 
 [ext_resource type="Script" path="res://src/small_editors/path_field.gd" id="1_enb3p"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="2_2o08v"]
 [ext_resource type="Texture2D" uid="uid://coda6chhcatal" path="res://visual/icons/Arrow.svg" id="2_fbpdu"]
 [ext_resource type="Script" path="res://src/small_editors/path_popup.gd" id="3_ocxcs"]
 [ext_resource type="Script" path="res://src/small_editors/path_command_button.gd" id="4_ej4hf"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4rmxx"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(1, 1, 1, 0.0666667)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wqlhg"]
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 1
+border_width_bottom = 2
+border_color = Color(0.501961, 0.752941, 1, 0.133333)
+corner_radius_top_left = 5
+corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jqdng"]
 content_margin_left = 8.0
@@ -61,7 +82,7 @@ layout_mode = 2
 theme_override_constants/separation = 0
 
 [node name="LineEdit" type="LineEdit" parent="MainLine"]
-custom_minimum_size = Vector2(260, 0)
+custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 tooltip_text = "d"
 focus_mode = 1
@@ -69,6 +90,9 @@ theme_type_variation = &"RightConnectedLineEdit"
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
+script = ExtResource("2_2o08v")
+hover_stylebox = SubResource("StyleBoxFlat_4rmxx")
+focus_stylebox = SubResource("StyleBoxFlat_wqlhg")
 
 [node name="Button" type="Button" parent="MainLine"]
 custom_minimum_size = Vector2(15, 0)

--- a/src/small_editors/rect_field.gd
+++ b/src/small_editors/rect_field.gd
@@ -1,9 +1,9 @@
 extends AttributeEditor
 
-@onready var x_field: HBoxContainer = $XField
-@onready var y_field: HBoxContainer = $YField
-@onready var w_field: HBoxContainer = $WField
-@onready var h_field: HBoxContainer = $HField
+@onready var x_field: Control = $XField
+@onready var y_field: Control = $YField
+@onready var w_field: Control = $WField
+@onready var h_field: Control = $HField
 
 signal value_changed(new_value: Rect2)
 var _value: Rect2  # Must not be updated directly.

--- a/src/small_editors/rect_field.tscn
+++ b/src/small_editors/rect_field.tscn
@@ -1,30 +1,21 @@
 [gd_scene load_steps=3 format=3 uid="uid://dh0dj6qdbfrb0"]
 
 [ext_resource type="Script" path="res://src/small_editors/rect_field.gd" id="1_euct7"]
-[ext_resource type="PackedScene" uid="uid://bp2vpf7g8w8aj" path="res://src/small_editors/number_field.tscn" id="2_5lh3m"]
+[ext_resource type="PackedScene" uid="uid://c6vgjud6wrdu4" path="res://src/small_editors/number_field.tscn" id="2_dkxh3"]
 
 [node name="RectField" type="HBoxContainer"]
 offset_right = 64.0
 offset_bottom = 22.0
 script = ExtResource("1_euct7")
 
-[node name="XField" parent="." instance=ExtResource("2_5lh3m")]
+[node name="XField" parent="." instance=ExtResource("2_dkxh3")]
 layout_mode = 2
-tooltip_text = "x"
 
-[node name="YField" parent="." instance=ExtResource("2_5lh3m")]
+[node name="YField" parent="." instance=ExtResource("2_dkxh3")]
 layout_mode = 2
-tooltip_text = "y"
 
-[node name="WField" parent="." instance=ExtResource("2_5lh3m")]
+[node name="WField" parent="." instance=ExtResource("2_dkxh3")]
 layout_mode = 2
-tooltip_text = "w"
 
-[node name="HField" parent="." instance=ExtResource("2_5lh3m")]
+[node name="HField" parent="." instance=ExtResource("2_dkxh3")]
 layout_mode = 2
-tooltip_text = "h"
-
-[connection signal="value_changed" from="XField" to="." method="_on_x_field_value_changed"]
-[connection signal="value_changed" from="YField" to="." method="_on_y_field_value_changed"]
-[connection signal="value_changed" from="WField" to="." method="_on_w_field_value_changed"]
-[connection signal="value_changed" from="HField" to="." method="_on_h_field_value_changed"]

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -18,6 +18,7 @@
 [ext_resource type="Script" path="res://src/small_editors/number_field.gd" id="11_sa433"]
 [ext_resource type="Texture2D" uid="uid://buire51l0mifg" path="res://visual/icons/Snap.svg" id="11_u7ddj"]
 [ext_resource type="Shader" path="res://src/ui_parts/zoom_shader.gdshader" id="12_wewnk"]
+[ext_resource type="Script" path="res://src/BetterLineEdit.gd" id="13_agirq"]
 [ext_resource type="Texture2D" uid="uid://c2h5snkvemm4p" path="res://visual/icons/Minus.svg" id="13_uqus2"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="14_t8hbh"]
 [ext_resource type="Script" path="res://src/ui_parts/snap_lines.gd" id="15_v2yj8"]
@@ -85,21 +86,6 @@ corner_detail = 16
 bg_color = Color(0.02, 0.02, 0.08, 1)
 border_width_bottom = 2
 border_color = Color(0.4, 0.7, 1, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_smesa"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-draw_center = false
-border_width_left = 1
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.203922, 0.254902, 0.4, 1)
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_detail = 16
 
 [sub_resource type="InputEventKey" id="InputEventKey_n13ij"]
 device = -1
@@ -321,15 +307,7 @@ editable = false
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-
-[node name="Slider" type="Button" parent="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper"]
-visible = false
-clip_contents = true
-custom_minimum_size = Vector2(12, 0)
-layout_mode = 2
-mouse_default_cursor_shape = 2
-theme_type_variation = &"LeftConnectedButtonTransparent"
-theme_override_styles/pressed = SubResource("StyleBoxFlat_smesa")
+script = ExtResource("13_agirq")
 
 [node name="VisualsPopup" parent="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu" instance=ExtResource("10_hraj8")]
 visible = false
@@ -443,13 +421,8 @@ script = ExtResource("15_v2yj8")
 [connection signal="toggled" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/SnapButton" to="Display" method="_on_snap_button_toggled"]
 [connection signal="toggled" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/SnapButton" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snap_button_toggled"]
 [connection signal="value_changed" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snapper_value_changed"]
-[connection signal="focus_entered" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/LineEdit" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_focus_entered" flags=18]
-[connection signal="focus_exited" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/LineEdit" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_focus_exited" flags=18]
-[connection signal="text_submitted" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/LineEdit" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_text_submitted" flags=18]
-[connection signal="gui_input" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/Slider" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_slider_gui_input" flags=18]
-[connection signal="mouse_entered" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/Slider" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_slider_mouse_entered" flags=18]
-[connection signal="mouse_exited" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/Slider" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_slider_mouse_exited" flags=18]
-[connection signal="resized" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/Slider" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_slider_resized" flags=18]
+[connection signal="focus_exited" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/LineEdit" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_focus_exited"]
+[connection signal="text_submitted" from="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper/LineEdit" to="Display/PanelContainer/MarginContainer/HBoxContainer/LeftMenu/Snapping/Snapper" method="_on_text_submitted"]
 [connection signal="pressed" from="Display/PanelContainer/MarginContainer/HBoxContainer/ZoomMenu/ZoomOut" to="Display/ViewportContainer/Viewport" method="zoom_out"]
 [connection signal="pressed" from="Display/PanelContainer/MarginContainer/HBoxContainer/ZoomMenu/ZoomReset" to="Display/ViewportContainer/Viewport" method="zoom_reset"]
 [connection signal="pressed" from="Display/PanelContainer/MarginContainer/HBoxContainer/ZoomMenu/ZoomIn" to="Display/ViewportContainer/Viewport" method="zoom_in"]

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -4,6 +4,7 @@ const shape_attributes = ["cx", "cy", "x", "y", "r", "rx", "ry", "width", "heigh
 		"x1", "y1", "x2", "y2"]
 
 const NumberField = preload("res://src/small_editors/number_field.tscn")
+const NumberSlider = preload("res://src/small_editors/number_field_with_slider.tscn")
 const ColorField = preload("res://src/small_editors/color_field.tscn")
 const PathField = preload("res://src/small_editors/path_field.tscn")
 const EnumField = preload("res://src/small_editors/enum_field.tscn")
@@ -35,10 +36,9 @@ func _ready() -> void:
 				input_field = NumberField.instantiate()
 				input_field.allow_lower = false
 			Attribute.Type.NFLOAT:
-				input_field = NumberField.instantiate()
+				input_field = NumberSlider.instantiate()
 				input_field.allow_lower = false
 				input_field.allow_higher = false
-				input_field.show_slider = true
 				input_field.slider_step = 0.01
 			Attribute.Type.COLOR:
 				input_field = ColorField.instantiate()

--- a/translations/.~lock.translation_sheet.csv#
+++ b/translations/.~lock.translation_sheet.csv#
@@ -1,1 +1,0 @@
-,volter,volter,18.10.2023 23:23,file:///home/volter/.config/libreoffice/4;


### PR DESCRIPTION
Improve the LineEdit with a BetterLineEdit class that allows some extra theming and fixes a few janky situations in the standard LineEdit.

Removes the slider of number fields by default, now there's a separate class with that. This simplifies the logic and reduces the overhead.

Fixes bugs.