### PR TITLE
Revert code editor wrapping mode change

### DIFF
--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -251,7 +251,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 wrap_mode = 1
-autowrap_mode = 1
 scroll_smooth = true
 scroll_v_scroll_speed = 30.0
 caret_blink = true


### PR DESCRIPTION
Word (Smart) is better, even if it has the annoying padding.

Reintroduces #114 