### PR TITLE
Minor optimizations and code simplification

### DIFF
--- a/src/small_editors/path_command_editor.gd
+++ b/src/small_editors/path_command_editor.gd
@@ -316,7 +316,7 @@ var mouse_inside := false:
 				Interactions.remove_inner_hovered(tag_idx, cmd_idx)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseMotion:
+	if event is InputEventMouseMotion and event.button_mask == 0:
 		mouse_inside = get_global_rect().has_point(get_global_mouse_position()) and\
 		get_node(^"../../../../../../../../..").get_global_rect().\
 				has_point(get_global_mouse_position())

--- a/src/ui_parts/export_dialog.gd
+++ b/src/ui_parts/export_dialog.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 	dimensions.y = SVG.root_tag.attributes.height.get_value()
 	update_dimensions_label()
 	update_final_scale()
-	var scaling_factor := 256.0 / maxf(dimensions.x, dimensions.y)
+	var scaling_factor := 512.0 / maxf(dimensions.x, dimensions.y)
 	var img := Image.new()
 	img.load_svg_from_string(SVG.string, scaling_factor)
 	if not img.is_empty():

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -411,6 +411,7 @@ expand_mode = 1
 stretch_mode = 1
 
 [node name="DisplayTexture" type="TextureRect" parent="Display/ViewportContainer/Viewport/Checkerboard"]
+process_mode = 3
 clip_contents = true
 layout_mode = 1
 anchors_preset = 15
@@ -428,6 +429,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 1
 script = ExtResource("5_pltvx")
 
 [node name="SnapLines" type="Control" parent="Display/ViewportContainer/Viewport"]

--- a/src/ui_parts/snap_lines.gd
+++ b/src/ui_parts/snap_lines.gd
@@ -31,7 +31,7 @@ func _draw() -> void:
 	# The grid lines are always 1px wide, but the numbers need to be resized.
 	RenderingServer.canvas_item_clear(surface)
 	RenderingServer.canvas_item_set_transform(surface,
-		Transform2D(0, Vector2(1, 1) / viewport_scale, 0, Vector2.ZERO))
+			Transform2D(0, Vector2(1, 1) / viewport_scale, 0, Vector2.ZERO))
 	
 	var i := x_offset
 	while i <= size.x:

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -155,7 +155,7 @@ var mouse_inside := false:
 				Interactions.remove_hovered(tag_index)
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseMotion:
+	if event is InputEventMouseMotion and event.button_mask == 0:
 		mouse_inside = get_global_rect().has_point(get_global_mouse_position()) and\
 		get_node(^"../..").get_global_rect().has_point(get_global_mouse_position()) and\
 		Interactions.semi_hovered_tag != tag_index


### PR DESCRIPTION
Fixes minor bugs that caused expensive actions to trigger when they shouldn't. Also caches texture dimensions in the handles manager, causing it to not need to be re-fetched in `convert_in()`, `convert_out()`, and `get_viewbox_zoom()`. It's a small optimization, but these functions can run thousands of times for really big SVGs, so it might amount to something.