### PR TITLE
Fix the behavior of deleting multiple tags

### DIFF
--- a/AppInfo.gd
+++ b/AppInfo.gd
@@ -1,3 +1,4 @@
+## Stores basic information about GodSVG.
 class_name AppInfo extends RefCounted
 
 const version := "1.0.dev"
@@ -10,5 +11,5 @@ const authors: Array[String] = [
 	"Kiisu-Master",
 	"MewPurPur",
 	"Serem Titus (SeremTitus)",
-	"Swarkin"
+	"Swarkin",
 ]

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -1,3 +1,4 @@
+## This singleton handles save data and settings.
 extends Node
 
 const save_path = "user://save.tres"

--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -1,3 +1,5 @@
+## This singleton handles the two representations of the SVG:
+## The SVG text, and the native [TagSVG] representation.
 extends Node
 
 var string := ""
@@ -10,7 +12,7 @@ func _ready() -> void:
 	SVG.root_tag.attribute_changed.connect(update_string)
 	SVG.root_tag.child_tag_attribute_changed.connect(update_string)
 	SVG.root_tag.tag_added.connect(update_string)
-	SVG.root_tag.tag_deleted.connect(update_string.unbind(1))
+	SVG.root_tag.tags_deleted.connect(update_string.unbind(1))
 	SVG.root_tag.tag_moved.connect(update_string.unbind(2))
 	
 	if GlobalSettings.save_svg:

--- a/src/data_classes/Attribute.gd
+++ b/src/data_classes/Attribute.gd
@@ -1,3 +1,4 @@
+## An attribute inside a [Tag], i.e. <tag attribute="value"/>
 class_name Attribute extends RefCounted
 
 signal value_changed(new_value: Variant)

--- a/src/data_classes/AttributeEnum.gd
+++ b/src/data_classes/AttributeEnum.gd
@@ -1,3 +1,4 @@
+## An attribute with only a set of meaningful values.
 class_name AttributeEnum extends Attribute
 
 var possible_values: Array[String]

--- a/src/data_classes/AttributePath.gd
+++ b/src/data_classes/AttributePath.gd
@@ -1,3 +1,4 @@
+## The "d" attribute of [TagPath].
 class_name AttributePath extends Attribute
 
 signal command_changed

--- a/src/data_classes/AttributeRect.gd
+++ b/src/data_classes/AttributeRect.gd
@@ -1,3 +1,4 @@
+## An attribute representing a rectangle.
 class_name AttributeRect extends Attribute
 
 func _init(new_default: Variant = null, new_init: Variant = null) -> void:

--- a/src/data_classes/AttributeUnknown.gd
+++ b/src/data_classes/AttributeUnknown.gd
@@ -1,3 +1,4 @@
+## An attribute not recognized by GodSVG.
 class_name AttributeUnknown extends Attribute
 
 var name := ""

--- a/src/data_classes/PathCommand.gd
+++ b/src/data_classes/PathCommand.gd
@@ -1,3 +1,4 @@
+## A native class that represents a path command and its parameters.
 class_name PathCommand extends RefCounted
 
 const translation_dict := {

--- a/src/data_classes/SaveData.gd
+++ b/src/data_classes/SaveData.gd
@@ -1,3 +1,4 @@
+## Stores data that needs to be retained between sessions.
 class_name SaveData extends Resource
 
 @export var window_mode := DisplayServer.WINDOW_MODE_MAXIMIZED

--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -1,3 +1,4 @@
+## A tag that isn't holding other tags within it, i.e. [code]<tag/>[/code]
 class_name Tag extends RefCounted
 
 signal attribute_changed

--- a/src/data_classes/TagB.gd
+++ b/src/data_classes/TagB.gd
@@ -1,8 +1,9 @@
-class_name TagB extends Tag  # B as in branch.
+## A tag that may hold other tags within it, i.e. [code]<tag></tag>[/code]
+class_name TagB extends Tag
 
 signal child_tag_attribute_changed
 signal tag_added
-signal tag_deleted(tag_idx: int)
+signal tags_deleted(tag_indices: Array[int])
 signal tag_moved(old_idx: int, new_idx: int)
 signal changed_unknown
 
@@ -24,10 +25,13 @@ func replace_self(new_tag: TagB) -> void:
 	changed_unknown.emit()
 
 
-func delete_tag(idx: int) -> void:
-	if idx >= 0:
-		child_tags.remove_at(idx)
-		tag_deleted.emit(idx)
+func delete_tags(idx_arr: Array[int]) -> void:
+	idx_arr.sort()
+	for idx_idx in range(idx_arr.size() - 1, -1, -1):
+		var idx = idx_arr[idx_idx]
+		if idx >= 0:
+			child_tags.remove_at(idx)
+	tags_deleted.emit(idx_arr)
 
 func move_tag(old_idx: int, new_idx: int) -> void:
 	var tag: Tag = child_tags.pop_at(old_idx)  # Should be inferrable, GDScript bug.

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -1,3 +1,4 @@
+## A <circle> tag.
 class_name TagCircle extends Tag
 
 func _init() -> void:

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -1,3 +1,4 @@
+## A <ellipse> tag.
 class_name TagEllipse extends Tag
 
 func _init() -> void:

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -1,3 +1,4 @@
+## A <line> tag.
 class_name TagLine extends Tag
 
 func _init() -> void:

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -1,3 +1,4 @@
+## A <rect> tag.
 class_name TagRect extends Tag
 
 func _init() -> void:

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -1,3 +1,4 @@
+## A <svg> tag.
 class_name TagSVG extends TagB
 
 func _init() -> void:

--- a/src/data_classes/TagUnknown.gd
+++ b/src/data_classes/TagUnknown.gd
@@ -1,3 +1,4 @@
+## A tag not recognized by GodSVG.
 class_name TagUnknown extends Tag
 
 func _init(new_title: String) -> void:

--- a/src/small_editors/AttributeEditor.gd
+++ b/src/small_editors/AttributeEditor.gd
@@ -1,4 +1,8 @@
+## Base class for controls that bind to an [Attribute].
 class_name AttributeEditor extends Control
+
+# TODO Godot doesn't quite allow for this right now,
+# but ideally, there would be more unified aspects here.
 
 var attribute: Attribute
 var attribute_name: String

--- a/src/small_editors/BetterLineEdit.gd
+++ b/src/small_editors/BetterLineEdit.gd
@@ -1,3 +1,4 @@
+## A LineEdit with a few tweaks to make it nicer to use.
 class_name BetterLineEdit extends LineEdit
 
 var hovered := false

--- a/src/small_editors/color_field.gd
+++ b/src/small_editors/color_field.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to a color attribute.
 extends AttributeEditor
 
 const named_colors := {  # Dictionary{String: Color}

--- a/src/small_editors/color_popup.gd
+++ b/src/small_editors/color_popup.gd
@@ -1,3 +1,4 @@
+## A popup for picking a color.
 extends Popup
 
 signal color_picked(new_color: String)

--- a/src/small_editors/context_popup.gd
+++ b/src/small_editors/context_popup.gd
@@ -1,3 +1,4 @@
+## The standard context menu popup.
 extends Popup
 
 @onready var main_container: VBoxContainer = $PanelContainer/MainContainer

--- a/src/small_editors/dropdown.gd
+++ b/src/small_editors/dropdown.gd
@@ -1,3 +1,4 @@
+## A dropdown with multiple options, not tied to any attribute.
 extends HBoxContainer
 
 signal value_changed(new_value: String)

--- a/src/small_editors/enum_field.gd
+++ b/src/small_editors/enum_field.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to an AttributeEnum.
 extends AttributeEditor
 
 @onready var value_picker: Popup = $ContextPopup

--- a/src/small_editors/flag_field.gd
+++ b/src/small_editors/flag_field.gd
@@ -1,3 +1,4 @@
+## An editor for flags with the value of 0 or 1, not tied to any attribute.
 extends Button
 
 var hovered := false

--- a/src/small_editors/mini_number_field.gd
+++ b/src/small_editors/mini_number_field.gd
@@ -1,3 +1,5 @@
+## A minimalistic editor for numbers, not tied to any attribute.
+## Used for path command parameters.
 extends BetterLineEdit
 
 enum Mode {DEFAULT, ONLY_POSITIVE, ANGLE}

--- a/src/small_editors/number_edit.gd
+++ b/src/small_editors/number_edit.gd
@@ -1,3 +1,4 @@
+## A number editor, not tied to any attribute.
 extends BetterLineEdit
 
 @export var initial_value: float

--- a/src/small_editors/number_field.gd
+++ b/src/small_editors/number_field.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to a numeric attribute.
 extends AttributeEditor
 
 @onready var num_edit: LineEdit = $LineEdit

--- a/src/small_editors/number_field_with_slider.gd
+++ b/src/small_editors/number_field_with_slider.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to a numeric attribute, plus a slider widget.
 extends AttributeEditor
 
 @onready var num_edit: LineEdit = $LineEdit

--- a/src/small_editors/path_command_button.gd
+++ b/src/small_editors/path_command_button.gd
@@ -1,3 +1,4 @@
+## A button for a path command picker.
 extends Button
 
 @onready var rtl: RichTextLabel = $RichTextLabel

--- a/src/small_editors/path_command_editor.gd
+++ b/src/small_editors/path_command_editor.gd
@@ -1,3 +1,4 @@
+## An editor for a single path command.
 extends PanelContainer
 
 signal cmd_update_value(idx: int, new_value: float, property: StringName)

--- a/src/small_editors/path_field.gd
+++ b/src/small_editors/path_field.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to an AttributePath.
 extends AttributeEditor
 
 const CommandEditor = preload("path_command_editor.tscn")

--- a/src/small_editors/path_popup.gd
+++ b/src/small_editors/path_popup.gd
@@ -1,3 +1,4 @@
+## A popup for picking a path command.
 extends Popup
 
 signal path_command_picked(new_command: String)

--- a/src/small_editors/rect_field.gd
+++ b/src/small_editors/rect_field.gd
@@ -1,3 +1,4 @@
+## An editor to be tied to an AttributeRect.
 extends AttributeEditor
 
 @onready var x_field: Control = $XField

--- a/src/small_editors/unknown_field.gd
+++ b/src/small_editors/unknown_field.gd
@@ -1,3 +1,5 @@
+## An editor to be tied to an AttributeUnknown.
+## Allows attributes to be edited even if they aren't recognized by GodSVG.
 extends AttributeEditor
 
 @onready var line_edit: BetterLineEdit = $LineEdit

--- a/src/ui_parts/Dialog.gd
+++ b/src/ui_parts/Dialog.gd
@@ -1,3 +1,4 @@
+## Translucent black rectangle to be used for modals.
 class_name Dialog extends ColorRect
 
 func _enter_tree() -> void:

--- a/src/ui_parts/Handle.gd
+++ b/src/ui_parts/Handle.gd
@@ -1,3 +1,4 @@
+## Base class for handles.
 class_name Handle extends RefCounted
 
 signal moved(new_value: Vector2)

--- a/src/ui_parts/PathHandle.gd
+++ b/src/ui_parts/PathHandle.gd
@@ -1,3 +1,4 @@
+## A handle that binds to one or two path parameters.
 class_name PathHandle extends Handle
 
 var path_attribute: AttributePath

--- a/src/ui_parts/XYHandle.gd
+++ b/src/ui_parts/XYHandle.gd
@@ -1,3 +1,4 @@
+## A handle that binds to one or two numeric attributes.
 class_name XYHandle extends Handle
 
 var x_attribute: Attribute

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 	SVG.root_tag.attribute_changed.connect(auto_update_text)
 	SVG.root_tag.child_tag_attribute_changed.connect(auto_update_text)
 	SVG.root_tag.tag_added.connect(auto_update_text)
-	SVG.root_tag.tag_deleted.connect(auto_update_text.unbind(1))
+	SVG.root_tag.tags_deleted.connect(auto_update_text.unbind(1))
 	SVG.root_tag.tag_moved.connect(auto_update_text.unbind(2))
 	SVG.root_tag.changed_unknown.connect(auto_update_text)
 

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 	SVG.root_tag.attribute_changed.connect(queue_update)
 	SVG.root_tag.child_tag_attribute_changed.connect(queue_update)
 	SVG.root_tag.tag_added.connect(queue_update)
-	SVG.root_tag.tag_deleted.connect(queue_update.unbind(1))
+	SVG.root_tag.tags_deleted.connect(queue_update.unbind(1))
 	SVG.root_tag.tag_moved.connect(queue_update.unbind(2))
 	SVG.root_tag.changed_unknown.connect(queue_update)
 	queue_update()

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -57,7 +57,7 @@ func _ready() -> void:
 	SVG.root_tag.child_tag_attribute_changed.connect(queue_redraw)
 	SVG.root_tag.child_tag_attribute_changed.connect(sync_handles)
 	SVG.root_tag.tag_added.connect(queue_update)
-	SVG.root_tag.tag_deleted.connect(queue_update.unbind(1))
+	SVG.root_tag.tags_deleted.connect(queue_update.unbind(1))
 	SVG.root_tag.tag_moved.connect(queue_update.unbind(2))
 	SVG.root_tag.changed_unknown.connect(queue_update)
 	Interactions.selection_changed.connect(queue_redraw)

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	SVG.root_tag.attribute_changed.connect(svg_tag_editor.update_svg_attributes)
 	SVG.root_tag.tag_added.connect(full_rebuild)
 	SVG.root_tag.tag_moved.connect(full_rebuild.unbind(2))
-	SVG.root_tag.tag_deleted.connect(full_rebuild.unbind(1))
+	SVG.root_tag.tags_deleted.connect(full_rebuild.unbind(1))
 	SVG.root_tag.changed_unknown.connect(full_rebuild)
 	full_rebuild()
 


### PR DESCRIPTION
Adds some documentation comments and fixes the behavior of deleting multiple tags. `tag_deleted(int)` changed to `tags_deleted(Array[int])` to improve performance.