### PR TITLE
Add a SVG highlighter

### DIFF
--- a/SVGDB.gd
+++ b/SVGDB.gd
@@ -1,0 +1,20 @@
+class_name SVGDB extends RefCounted
+
+const known_tags = ["svg", "circle", "ellipse", "rect", "path", "line"]
+
+const known_tag_attributes = {  # Dictionary{}
+	"svg": TagSVG.known_attributes,
+	"circle": TagCircle.known_attributes,
+	"ellipse": TagEllipse.known_attributes,
+	"rect": TagRect.known_attributes,
+	"path": TagPath.known_attributes,
+	"line": TagLine.known_attributes,
+}
+
+static func is_tag_known(tag_name: String) -> bool:
+	return tag_name in known_tags
+
+static func is_attribute_known(tag_name: String, attribute_name: String) -> bool:
+	if not known_tag_attributes.has(tag_name):
+		return false
+	return attribute_name in known_tag_attributes[tag_name]

--- a/src/data_classes/SVGHighlighter.gd
+++ b/src/data_classes/SVGHighlighter.gd
@@ -1,0 +1,109 @@
+## A syntax highlighter for SVGs, allows for more flexibility than CodeHighlighter.
+class_name SVGHighlighter extends SyntaxHighlighter
+
+@export var symbol_color := Color("abc9ff")
+@export var known_tag_color := Color("ff8ccc")
+@export var unknown_tag_color := Color("ff8ccc").darkened(0.3)
+@export var known_attribute_color := Color("bce0ff")
+@export var unknown_attribute_color := Color("bce0ff").darkened(0.3)
+@export var string_color := Color("a1ffe0")
+@export var comment_color := Color("cdcfd280")
+
+func is_attribute_symbol(c: String) -> bool:
+	return (c >= "a" and c <= "z") or (c >= "A" and c <= "Z") or c == "-"
+
+func _get_line_syntax_highlighting(line: int) -> Dictionary:
+	var color_map := {}  # Dictionary{int: Dictionary{String: Color}}
+	var parser := XMLParser.new()
+	var svg_text := get_text_edit().get_line(line)
+	parser.open_buffer(svg_text.to_ascii_buffer())
+	while parser.read() == OK:
+		match parser.get_node_type():
+			XMLParser.NODE_COMMENT, XMLParser.NODE_CDATA, XMLParser.NODE_TEXT:
+				var offset := parser.get_node_offset()
+				color_map[offset] = {"color": comment_color}
+			XMLParser.NODE_ELEMENT_END:
+				var offset := parser.get_node_offset()
+				var tag_name := parser.get_node_name()
+				color_map[offset] = {"color": symbol_color}
+				offset += 2
+				color_map[offset] = {"color":
+						known_tag_color if SVGDB.is_tag_known(tag_name) else unknown_tag_color}
+				offset += tag_name.length()
+				color_map[offset] = {"color": symbol_color}
+			XMLParser.NODE_ELEMENT:
+				var offset := parser.get_node_offset()
+				var tag_name := parser.get_node_name()
+				color_map[offset] = {"color": symbol_color}
+				offset += 1
+				color_map[offset] = {"color":
+						known_tag_color if SVGDB.is_tag_known(tag_name) else unknown_tag_color}
+				offset += tag_name.length()
+				color_map[offset] = {"color": symbol_color}
+				
+				# Parsing stuff inside an element.
+				offset += 1
+				var attributes_parsed := 0
+				while offset < svg_text.length() and\
+				attributes_parsed < parser.get_attribute_count():
+					# Parse attribute name.
+					var attribute_start_offset := offset
+					while not is_attribute_symbol(svg_text[offset]):
+						if offset == svg_text.length():
+							break
+						offset += 1
+					var attribute_name := ""
+					while is_attribute_symbol(svg_text[offset]):
+						if offset == svg_text.length():
+							break
+						attribute_name += svg_text[offset]
+						offset += 1
+					
+					color_map[attribute_start_offset] = {"color": known_attribute_color\
+							if SVGDB.is_attribute_known(tag_name, attribute_name)\
+							else unknown_attribute_color}
+					
+					# Parse equal sign.
+					var next_equal_pos := svg_text.find("=", offset)
+					var next_end_a := svg_text.find("/>", offset)
+					var next_end_b := svg_text.find(">", offset)
+					var next_end: int
+					if next_end_a == -1 and next_end_b != -1:
+						next_end = next_end_b
+					elif next_end_b == -1 and next_end_a != -1:
+						next_end = next_end_a
+					elif next_end_b != -1 and next_end_a != -1:
+						next_end = mini(next_end_a, next_end_b)
+					else:
+						next_end = -1
+					
+					if next_end == -1:
+						return color_map
+					if next_equal_pos == -1 or next_equal_pos > next_end:
+						offset = next_end
+						break
+					else:
+						offset = next_equal_pos
+						color_map[offset] = {"color": symbol_color}
+					
+					# Parse attribute value.
+					var next_quote_pos := svg_text.find('"', offset)
+					if next_quote_pos == -1 or next_quote_pos >\
+					minf(svg_text.find("/", offset), svg_text.find(">", offset)):
+						offset = mini(svg_text.find("/", offset), svg_text.find(">", offset))
+						break
+					else:
+						offset = next_quote_pos
+						color_map[offset] = {"color": string_color}
+						next_quote_pos = svg_text.find('"', offset + 1)
+						if next_quote_pos == -1:
+							return color_map
+						else:
+							offset = next_quote_pos + 1
+							attributes_parsed += 1
+				
+				# Finish parsing.
+				color_map[offset] = {"color": symbol_color}
+	
+	return color_map
+

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -1,5 +1,8 @@
-## A <circle> tag.
+## A <circle/> tag.
 class_name TagCircle extends Tag
+
+const known_attributes = ["cx", "cy", "r",
+		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 
 func _init() -> void:
 	title = "circle"

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -1,5 +1,8 @@
-## A <ellipse> tag.
+## An <ellipse/> tag.
 class_name TagEllipse extends Tag
+
+const known_attributes = ["cx", "cy", "rx", "ry",
+		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 
 func _init() -> void:
 	title = "ellipse"

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -1,5 +1,8 @@
-## A <line> tag.
+## A <line/> tag.
 class_name TagLine extends Tag
+
+const known_attributes = ["x1", "y1", "x2", "y2",
+		"opacity", "stroke", "stroke-opacity", "stroke-width", "stroke-linecap"]
 
 func _init() -> void:
 	title = "line"

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -1,4 +1,9 @@
+## A <path/> tag.
 class_name TagPath extends Tag
+
+const known_attributes = ["d",
+		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width",
+		"stroke-linecap", "stroke-linejoin"]
 
 func _init() -> void:
 	title = "path"

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -1,5 +1,9 @@
-## A <rect> tag.
+## A <rect/> tag.
 class_name TagRect extends Tag
+
+const known_attributes = ["x", "y", "width", "height", "rx", "ry",
+		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width",
+		"stroke-linejoin"]
 
 func _init() -> void:
 	title = "rect"

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -1,5 +1,7 @@
-## A <svg> tag.
+## A <svg></svg> tag.
 class_name TagSVG extends TagB
+
+const known_attributes = ["width", "height", "viewBox", "xmlns"]
 
 func _init() -> void:
 	title = "svg"

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -28,29 +28,33 @@ func auto_update_text() -> void:
 
 func update_error(err_id: StringName) -> void:
 	if err_id == &"":
-		error_bar.hide()
-		code_edit.remove_theme_stylebox_override(&"normal")
-		code_edit.remove_theme_stylebox_override(&"focus")
-		code_edit.custom_minimum_size.y = 96
-		code_edit.size.y = 0
+		if error_bar.visible:
+			error_bar.hide()
+			code_edit.remove_theme_stylebox_override(&"normal")
+			code_edit.remove_theme_stylebox_override(&"focus")
+			var error_bar_real_height := error_bar.size.y - 2
+			code_edit.custom_minimum_size.y += error_bar_real_height
+			code_edit.size.y += error_bar_real_height
 	else:
 		# When the error is shown, the code editor's theme is changed to match up.
-		error_bar.show()
-		error_label.text = tr(err_id)
-		var stylebox := ThemeDB.get_project_theme().\
-				get_stylebox(&"normal", &"TextEdit").duplicate()
-		stylebox.corner_radius_bottom_right = 0
-		stylebox.corner_radius_bottom_left = 0
-		stylebox.border_width_bottom = 1
-		code_edit.add_theme_stylebox_override(&"normal", stylebox)
-		var stylebox2 := ThemeDB.get_project_theme().\
-				get_stylebox(&"focus", &"CodeEdit").duplicate()
-		stylebox2.corner_radius_bottom_right = 0
-		stylebox2.corner_radius_bottom_left = 0
-		stylebox2.border_width_bottom = 1
-		code_edit.add_theme_stylebox_override(&"focus", stylebox2)
-		code_edit.custom_minimum_size.y = 75
-		code_edit.size.y = 0
+		if not error_bar.visible:
+			error_bar.show()
+			error_label.text = tr(err_id)
+			var stylebox := ThemeDB.get_project_theme().\
+					get_stylebox(&"normal", &"TextEdit").duplicate()
+			stylebox.corner_radius_bottom_right = 0
+			stylebox.corner_radius_bottom_left = 0
+			stylebox.border_width_bottom = 1
+			code_edit.add_theme_stylebox_override(&"normal", stylebox)
+			var stylebox2 := ThemeDB.get_project_theme().\
+					get_stylebox(&"focus", &"CodeEdit").duplicate()
+			stylebox2.corner_radius_bottom_right = 0
+			stylebox2.corner_radius_bottom_left = 0
+			stylebox2.border_width_bottom = 1
+			code_edit.add_theme_stylebox_override(&"focus", stylebox2)
+			var error_bar_real_height := error_bar.size.y - 2
+			code_edit.custom_minimum_size.y -= error_bar_real_height
+			code_edit.size.y -= error_bar_real_height
 
 
 func _on_copy_button_pressed() -> void:

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=35 format=3 uid="uid://ce6j54x27pom"]
+[gd_scene load_steps=36 format=3 uid="uid://ce6j54x27pom"]
 
 [ext_resource type="PackedScene" uid="uid://ccynisiuyn5qn" path="res://src/ui_parts/inspector.tscn" id="1_afxvd"]
 [ext_resource type="Texture2D" uid="uid://ccvjkdd0s7rb4" path="res://visual/icons/Copy.svg" id="1_fm0ux"]
@@ -10,6 +10,7 @@
 [ext_resource type="Texture2D" uid="uid://6ymbl3jqersp" path="res://visual/icons/Import.svg" id="4_ehrkr"]
 [ext_resource type="Script" path="res://src/ui_parts/handles_manager.gd" id="5_pltvx"]
 [ext_resource type="Texture2D" uid="uid://d0uvwj0t44n6v" path="res://visual/icons/Export.svg" id="5_qe6jq"]
+[ext_resource type="Script" path="res://src/data_classes/SVGHighlighter.gd" id="6_0jtpx"]
 [ext_resource type="Script" path="res://src/ui_parts/viewport.gd" id="6_7hypx"]
 [ext_resource type="Texture2D" uid="uid://ccbta5q43jobk" path="res://visual/icons/More.svg" id="7_7iuuq"]
 [ext_resource type="Script" path="res://src/ui_parts/display_texture.gd" id="7_cxx0h"]
@@ -53,47 +54,15 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="CodeHighlighter" id="CodeHighlighter_jg7xq"]
-number_color = Color(0.631373, 1, 0.878431, 1)
+[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_fhint"]
+script = ExtResource("6_0jtpx")
 symbol_color = Color(0.670588, 0.788235, 1, 1)
-function_color = Color(0.341176, 0.701961, 1, 1)
-keyword_colors = {
-"circle": Color(1, 0.54902, 0.8, 1),
-"cx": Color(0.737255, 0.878431, 1, 1),
-"cy": Color(0.737255, 0.878431, 1, 1),
-"d": Color(0.737255, 0.878431, 1, 1),
-"ellipse": Color(1, 0.54902, 0.8, 1),
-"fill": Color(0.737255, 0.878431, 1, 1),
-"g": Color(1, 0.54902, 0.8, 1),
-"height": Color(0.737255, 0.878431, 1, 1),
-"line": Color(1, 0.54902, 0.8, 1),
-"linearGradient": Color(1, 0.54902, 0.8, 1),
-"opacity": Color(0.737255, 0.878431, 1, 1),
-"path": Color(1, 0.54902, 0.8, 1),
-"r": Color(0.737255, 0.878431, 1, 1),
-"radialGradient": Color(1, 0.54902, 0.8, 1),
-"rect": Color(1, 0.54902, 0.8, 1),
-"rx": Color(0.737255, 0.878431, 1, 1),
-"ry": Color(0.737255, 0.878431, 1, 1),
-"stop": Color(1, 0.54902, 0.8, 1),
-"stroke": Color(0.737255, 0.878431, 1, 1),
-"stroke-linecap": Color(0.737255, 0.878431, 1, 1),
-"stroke-linejoin": Color(0.737255, 0.878431, 1, 1),
-"stroke-width": Color(0.737255, 0.878431, 1, 1),
-"svg": Color(1, 0.54902, 0.8, 1),
-"viewBox": Color(0.737255, 0.878431, 1, 1),
-"width": Color(0.737255, 0.878431, 1, 1),
-"x": Color(0.737255, 0.878431, 1, 1),
-"x1": Color(0.737255, 0.878431, 1, 1),
-"x2": Color(0.737255, 0.878431, 1, 1),
-"xmlns": Color(0.737255, 0.878431, 1, 1),
-"y": Color(0.737255, 0.878431, 1, 1),
-"y1": Color(0.737255, 0.878431, 1, 1),
-"y2": Color(0.737255, 0.878431, 1, 1)
-}
-color_regions = {
-"\" \"": Color(0.631373, 1, 0.878431, 1)
-}
+known_tag_color = Color(1, 0.54902, 0.8, 1)
+unknown_tag_color = null
+known_attribute_color = Color(0.737255, 0.878431, 1, 1)
+unknown_attribute_color = null
+string_color = Color(0.631373, 1, 0.878431, 1)
+comment_color = Color(0.803922, 0.811765, 0.823529, 0.501961)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k0een"]
 content_margin_left = 2.0
@@ -234,7 +203,7 @@ scroll_smooth = true
 scroll_v_scroll_speed = 30.0
 caret_blink = true
 caret_multiple = false
-syntax_highlighter = SubResource("CodeHighlighter_jg7xq")
+syntax_highlighter = SubResource("SyntaxHighlighter_fhint")
 highlight_all_occurrences = true
 auto_brace_completion_highlight_matching = true
 auto_brace_completion_pairs = {
@@ -253,6 +222,7 @@ theme_override_constants/margin_left = 8
 theme_override_constants/margin_right = 8
 
 [node name="Label" type="RichTextLabel" parent="PanelContainer/MainContainer/CodeEditor/ScriptEditor/ErrorBar/Padding"]
+custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 theme_override_colors/default_color = Color(1, 0.4, 0.4, 1)
 theme_override_fonts/normal_font = ExtResource("2_w635r")


### PR DESCRIPTION
Fixes #148

![image](https://github.com/MewPurPur/GodSVG/assets/85438892/8663d505-af9b-4e5f-a7dc-b2662f749e09)

Unrecognized tags and attributes are darkened.

This will need more work going forward, but it's already better than the previous highlighter.