### PR TITLE
Add back the code font for attribute tooltips

### DIFF
--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -1,10 +1,13 @@
 ## A LineEdit with a few tweaks to make it nicer to use.
 class_name BetterLineEdit extends LineEdit
 
+const code_font = preload("res://visual/fonts/FontMono.ttf")
+
 var hovered := false
 
 @export var hover_stylebox: StyleBox
 @export var focus_stylebox: StyleBox
+@export var code_font_tooltip := false
 
 func _ready() -> void:
 	focus_entered.connect(_on_focus_entered)
@@ -43,3 +46,13 @@ func _draw() -> void:
 			draw_style_box(focus_stylebox, Rect2(Vector2.ZERO, size))
 		elif hovered and hover_stylebox != null:
 			draw_style_box(hover_stylebox, Rect2(Vector2.ZERO, size))
+
+func _make_custom_tooltip(for_text: String) -> Object:
+	if code_font_tooltip:
+		var label := Label.new()
+		label.add_theme_font_override(&"font", code_font)
+		label.add_theme_font_size_override(&"font_size", 12)
+		label.text = for_text
+		return label
+	else:
+		return null

--- a/src/ui_elements/color_field.tscn
+++ b/src/ui_elements/color_field.tscn
@@ -1,10 +1,10 @@
 [gd_scene load_steps=8 format=3 uid="uid://carf2o1y7wvmc"]
 
-[ext_resource type="Script" path="res://src/ui_elements/color_field.gd" id="1_330tl"]
-[ext_resource type="Texture2D" uid="uid://y0l74x73w0co" path="res://visual/CheckerboardMini.svg" id="2_gsj5a"]
-[ext_resource type="Script" path="res://src/ui_elements/color_popup.gd" id="2_hgyyv"]
-[ext_resource type="PackedScene" uid="uid://cpvtf3kaa2ltr" path="res://src/ui_elements/color_swatch.tscn" id="3_38vpq"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="3_frxce"]
+[ext_resource type="Script" path="res://src/ui_elements/color_field.gd" id="1_2pe1j"]
+[ext_resource type="Texture2D" uid="uid://y0l74x73w0co" path="res://visual/CheckerboardMini.svg" id="2_t1t6b"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="3_u777p"]
+[ext_resource type="Script" path="res://src/ui_elements/color_popup.gd" id="4_4syqq"]
+[ext_resource type="PackedScene" uid="uid://cpvtf3kaa2ltr" path="res://src/ui_elements/color_swatch.tscn" id="5_g5jha"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q6tej"]
 draw_center = false
@@ -31,8 +31,8 @@ custom_minimum_size = Vector2(0, 22)
 offset_right = 50.0
 offset_bottom = 21.0
 theme_override_constants/separation = 0
-script = ExtResource("1_330tl")
-checkerboard = ExtResource("2_gsj5a")
+script = ExtResource("1_2pe1j")
+checkerboard = ExtResource("2_t1t6b")
 
 [node name="LineEdit" type="LineEdit" parent="."]
 custom_minimum_size = Vector2(54, 0)
@@ -43,9 +43,10 @@ max_length = 20
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("3_frxce")
+script = ExtResource("3_u777p")
 hover_stylebox = SubResource("StyleBoxFlat_q6tej")
 focus_stylebox = SubResource("StyleBoxFlat_edu3w")
+code_font_tooltip = true
 
 [node name="Button" type="Button" parent="."]
 custom_minimum_size = Vector2(13, 0)
@@ -57,7 +58,7 @@ theme_type_variation = &"LeftConnectedButtonTransparent"
 [node name="ColorPopup" type="Popup" parent="."]
 transparent_bg = true
 size = Vector2i(150, 220)
-script = ExtResource("2_hgyyv")
+script = ExtResource("4_4syqq")
 
 [node name="PanelContainer" type="PanelContainer" parent="ColorPopup"]
 offset_right = 150.0
@@ -89,32 +90,32 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/h_separation = 2
 
-[node name="White" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="White" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure white"
 color_hex = "ffffff"
 
-[node name="Black" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="Black" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure black"
 color_hex = "000000"
 
-[node name="Red" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="Red" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure red"
 color_hex = "ff0000"
 
-[node name="Green" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="Green" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure green"
 color_hex = "00ff00"
 
-[node name="Blue" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="Blue" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure blue"
 color_hex = "0000ff"
 
-[node name="Blue2" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("3_38vpq")]
+[node name="Blue2" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Pure/PureSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Pure blue"
 color_hex = "none"
@@ -134,52 +135,52 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/h_separation = 2
 
-[node name="Icon" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Icon" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Icon color"
 color_hex = "e0e0e0"
 
-[node name="IconDisabled" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="IconDisabled" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Icon disabled color"
 color_hex = "919191"
 
-[node name="Node2D" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Node2D" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Node2D color"
 color_hex = "8da5f3"
 
-[node name="Control" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Control" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Control color"
 color_hex = "8eef97"
 
-[node name="Node3D" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Node3D" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Node3D color"
 color_hex = "fc7f7f"
 
-[node name="Animation" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Animation" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Animation color"
 color_hex = "c38ef1"
 
-[node name="Mesh" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Mesh" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Mesh color"
 color_hex = "ffca5f"
 
-[node name="Shape" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Shape" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Shape color"
 color_hex = "2998ff"
 
-[node name="ShapeLight" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="ShapeLight" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Shape light color"
 color_hex = "a2d2ff"
 
-[node name="Input" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("3_38vpq")]
+[node name="Input" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Common/CommonSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Input color"
 color_hex = "69c4d4"
@@ -199,37 +200,37 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/h_separation = 2
 
-[node name="Red" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Red" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow red"
 color_hex = "ff4545"
 
-[node name="Yellow" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Yellow" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow yellow"
 color_hex = "ffe345"
 
-[node name="Green" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Green" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow green"
 color_hex = "80ff45"
 
-[node name="Aqua" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Aqua" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow aqua"
 color_hex = "45ffa2"
 
-[node name="Blue" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Blue" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow blue"
 color_hex = "45d7ff"
 
-[node name="Purple" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Purple" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow purple"
 color_hex = "8045ff"
 
-[node name="Pink" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("3_38vpq")]
+[node name="Pink" parent="ColorPopup/PanelContainer/MarginContainer/MainContainer/Rainbow/RainbowSwatches" instance=ExtResource("5_g5jha")]
 layout_mode = 2
 tooltip_text = "Rainbow pink"
 color_hex = "ff4596"

--- a/src/ui_elements/enum_field.tscn
+++ b/src/ui_elements/enum_field.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=7 format=3 uid="uid://d2da0thyq5rq8"]
 
-[ext_resource type="Script" path="res://src/ui_elements/enum_field.gd" id="1_vkd5r"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_hytgg"]
-[ext_resource type="Texture2D" uid="uid://coda6chhcatal" path="res://visual/icons/Arrow.svg" id="2_owe3f"]
-[ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/ui_elements/context_popup.tscn" id="3_qw0q5"]
+[ext_resource type="Script" path="res://src/ui_elements/enum_field.gd" id="1_1jqoy"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_4bajq"]
+[ext_resource type="Texture2D" uid="uid://coda6chhcatal" path="res://visual/icons/Arrow.svg" id="3_vhd8v"]
+[ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/ui_elements/context_popup.tscn" id="4_4cpb7"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y4kmw"]
 draw_center = false
@@ -30,7 +30,7 @@ custom_minimum_size = Vector2(0, 22)
 offset_right = 73.0
 offset_bottom = 22.0
 theme_override_constants/separation = 0
-script = ExtResource("1_vkd5r")
+script = ExtResource("1_1jqoy")
 
 [node name="LineEdit" type="LineEdit" parent="."]
 custom_minimum_size = Vector2(58, 0)
@@ -40,9 +40,10 @@ theme_type_variation = &"RightConnectedLineEdit"
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("2_hytgg")
+script = ExtResource("2_4bajq")
 hover_stylebox = SubResource("StyleBoxFlat_y4kmw")
 focus_stylebox = SubResource("StyleBoxFlat_qhmpn")
+code_font_tooltip = true
 
 [node name="Button" type="Button" parent="."]
 custom_minimum_size = Vector2(15, 0)
@@ -50,10 +51,10 @@ layout_mode = 2
 focus_mode = 0
 mouse_default_cursor_shape = 2
 theme_type_variation = &"LeftConnectedButton"
-icon = ExtResource("2_owe3f")
+icon = ExtResource("3_vhd8v")
 expand_icon = true
 
-[node name="ContextPopup" parent="." instance=ExtResource("3_qw0q5")]
+[node name="ContextPopup" parent="." instance=ExtResource("4_4cpb7")]
 visible = false
 
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/src/ui_elements/mini_number_field.tscn
+++ b/src/ui_elements/mini_number_field.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=3 uid="uid://cm3uphorskcix"]
 
-[ext_resource type="Script" path="res://src/ui_elements/mini_number_field.gd" id="1_uggel"]
+[ext_resource type="Script" path="res://src/ui_elements/mini_number_field.gd" id="1_ggi5v"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wk41m"]
 draw_center = false
@@ -20,6 +20,7 @@ theme_type_variation = &"MiniLineEdit"
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("1_uggel")
+script = ExtResource("1_ggi5v")
 hover_stylebox = SubResource("StyleBoxFlat_wk41m")
 focus_stylebox = SubResource("StyleBoxFlat_ul27o")
+code_font_tooltip = true

--- a/src/ui_elements/number_field.tscn
+++ b/src/ui_elements/number_field.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://c6vgjud6wrdu4"]
 
-[ext_resource type="Script" path="res://src/ui_elements/number_field.gd" id="1_vy4cm"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_gfns5"]
+[ext_resource type="Script" path="res://src/ui_elements/number_field.gd" id="1_lyqve"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_m6us2"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kgadk"]
 draw_center = false
@@ -33,7 +33,7 @@ layout_mode = 3
 anchors_preset = 0
 offset_right = 48.0
 offset_bottom = 22.0
-script = ExtResource("1_vy4cm")
+script = ExtResource("1_lyqve")
 
 [node name="LineEdit" type="LineEdit" parent="."]
 layout_mode = 1
@@ -48,9 +48,10 @@ focus_mode = 1
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("2_gfns5")
+script = ExtResource("2_m6us2")
 hover_stylebox = SubResource("StyleBoxFlat_kgadk")
 focus_stylebox = SubResource("StyleBoxFlat_m2p2n")
+code_font_tooltip = true
 
 [connection signal="focus_exited" from="LineEdit" to="." method="_on_focus_exited"]
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]

--- a/src/ui_elements/number_field_with_slider.tscn
+++ b/src/ui_elements/number_field_with_slider.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://bp2vpf7g8w8aj"]
 
-[ext_resource type="Script" path="res://src/ui_elements/number_field_with_slider.gd" id="1_q10gl"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_hvn86"]
+[ext_resource type="Script" path="res://src/ui_elements/number_field_with_slider.gd" id="1_ymm02"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_ytia1"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_e034s"]
 draw_center = false
@@ -43,7 +43,7 @@ custom_minimum_size = Vector2(0, 22)
 offset_right = 46.0
 offset_bottom = 22.0
 theme_override_constants/separation = 0
-script = ExtResource("1_q10gl")
+script = ExtResource("1_ymm02")
 
 [node name="LineEdit" type="LineEdit" parent="."]
 custom_minimum_size = Vector2(46, 0)
@@ -54,9 +54,10 @@ theme_type_variation = &"RightConnectedLineEdit"
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("2_hvn86")
+script = ExtResource("2_ytia1")
 hover_stylebox = SubResource("StyleBoxFlat_e034s")
 focus_stylebox = SubResource("StyleBoxFlat_0nb8u")
+code_font_tooltip = true
 
 [node name="Slider" type="Button" parent="."]
 clip_contents = true

--- a/src/ui_elements/path_field.tscn
+++ b/src/ui_elements/path_field.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=9 format=3 uid="uid://dqy5lv33sy5r7"]
 
-[ext_resource type="Script" path="res://src/ui_elements/path_field.gd" id="1_enb3p"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_iwuws"]
-[ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="3_cdafs"]
+[ext_resource type="Script" path="res://src/ui_elements/path_field.gd" id="1_22rk2"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_48xgh"]
+[ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="3_at2g1"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4rmxx"]
 draw_center = false
@@ -61,7 +61,7 @@ offset_right = 332.0
 offset_bottom = 26.0
 size_flags_horizontal = 3
 theme_override_constants/separation = 2
-script = ExtResource("1_enb3p")
+script = ExtResource("1_22rk2")
 
 [node name="MainLine" type="HBoxContainer" parent="."]
 custom_minimum_size = Vector2(0, 22)
@@ -76,9 +76,10 @@ focus_mode = 1
 context_menu_enabled = false
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("2_iwuws")
+script = ExtResource("2_48xgh")
 hover_stylebox = SubResource("StyleBoxFlat_4rmxx")
 focus_stylebox = SubResource("StyleBoxFlat_wqlhg")
+code_font_tooltip = true
 
 [node name="Commands" type="VBoxContainer" parent="."]
 custom_minimum_size = Vector2(336, 0)
@@ -96,7 +97,7 @@ mouse_default_cursor_shape = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_lcnxl")
 theme_override_styles/hover = SubResource("StyleBoxFlat_4yine")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_kmpxk")
-icon = ExtResource("3_cdafs")
+icon = ExtResource("3_at2g1")
 
 [connection signal="text_submitted" from="MainLine/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="pressed" from="AddMove" to="." method="_on_add_move_pressed"]

--- a/src/ui_elements/rect_field.tscn
+++ b/src/ui_elements/rect_field.tscn
@@ -1,23 +1,23 @@
 [gd_scene load_steps=3 format=3 uid="uid://dh0dj6qdbfrb0"]
 
-[ext_resource type="Script" path="res://src/ui_elements/rect_field.gd" id="1_euct7"]
-[ext_resource type="PackedScene" uid="uid://c6vgjud6wrdu4" path="res://src/ui_elements/number_field.tscn" id="2_dkxh3"]
+[ext_resource type="Script" path="res://src/ui_elements/rect_field.gd" id="1_fmk5c"]
+[ext_resource type="PackedScene" uid="uid://c6vgjud6wrdu4" path="res://src/ui_elements/number_field.tscn" id="2_hfi4f"]
 
 [node name="RectField" type="HBoxContainer"]
 offset_right = 64.0
 offset_bottom = 22.0
-script = ExtResource("1_euct7")
+script = ExtResource("1_fmk5c")
 
-[node name="XField" parent="." instance=ExtResource("2_dkxh3")]
+[node name="XField" parent="." instance=ExtResource("2_hfi4f")]
 layout_mode = 2
 
-[node name="YField" parent="." instance=ExtResource("2_dkxh3")]
+[node name="YField" parent="." instance=ExtResource("2_hfi4f")]
 layout_mode = 2
 
-[node name="WField" parent="." instance=ExtResource("2_dkxh3")]
+[node name="WField" parent="." instance=ExtResource("2_hfi4f")]
 layout_mode = 2
 
-[node name="HField" parent="." instance=ExtResource("2_dkxh3")]
+[node name="HField" parent="." instance=ExtResource("2_hfi4f")]
 layout_mode = 2
 
 [connection signal="value_changed" from="XField" to="." method="_on_x_field_value_changed"]

--- a/src/ui_elements/unknown_field.tscn
+++ b/src/ui_elements/unknown_field.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=6 format=3 uid="uid://mr2c1hti43k4"]
 
-[ext_resource type="Script" path="res://src/ui_elements/unknown_field.gd" id="1_5ooio"]
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="1_gtdpd"]
-[ext_resource type="Texture2D" uid="uid://bi38k4pq83omf" path="res://visual/icons/QuestionMark.svg" id="2_c8kyj"]
+[ext_resource type="Script" path="res://src/ui_elements/unknown_field.gd" id="1_decfb"]
+[ext_resource type="Texture2D" uid="uid://bi38k4pq83omf" path="res://visual/icons/QuestionMark.svg" id="2_hsdl6"]
+[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="3_poc0i"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ekjre"]
 draw_center = false
@@ -32,7 +32,7 @@ corner_radius_bottom_left = 5
 custom_minimum_size = Vector2(72, 22)
 layout_mode = 3
 anchors_preset = 0
-script = ExtResource("1_5ooio")
+script = ExtResource("1_decfb")
 
 [node name="LineEdit" type="LineEdit" parent="."]
 layout_mode = 1
@@ -43,11 +43,12 @@ grow_horizontal = 2
 grow_vertical = 2
 focus_mode = 1
 context_menu_enabled = false
-right_icon = ExtResource("2_c8kyj")
+right_icon = ExtResource("2_hsdl6")
 select_all_on_focus = true
 caret_blink = true
-script = ExtResource("1_gtdpd")
+script = ExtResource("3_poc0i")
 hover_stylebox = SubResource("StyleBoxFlat_ekjre")
 focus_stylebox = SubResource("StyleBoxFlat_0q8qv")
+code_font_tooltip = true
 
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -40,7 +40,7 @@ func svg_update(svg_changed := true) -> void:
 	var bigger_side := maxf(SVG.root_tag.attributes.width.get_value(),
 			SVG.root_tag.attributes.height.get_value())
 	var img := Image.new()
-	var new_image_zoom := 1.0 if rasterized else minf(zoom * 4.0, 16384 / bigger_side)
+	var new_image_zoom := 1.0 if rasterized else minf(zoom * 3.0, 16384 / bigger_side)
 	if not svg_changed and not rasterized and new_image_zoom <= image_zoom:
 		return  # Don't waste time resizing if the new image won't be bigger.
 	else:

--- a/src/ui_parts/svg_code_edit.gd
+++ b/src/ui_parts/svg_code_edit.gd
@@ -36,6 +36,8 @@ func redraw_caret() -> void:
 		var char_size := code_font.get_char_size(69,
 				get_theme_font_size(&"TextEdit", &"font_size"))
 		for caret in get_caret_count():
+			# FIXME There's a bug(?) causing the draw pos to sometimes not update
+			# when outside of the screen.
 			var caret_draw_pos := get_caret_draw_pos(caret)
 			if is_overtype_mode_enabled():
 				RenderingServer.canvas_item_add_line(surface, caret_draw_pos - Vector2(1, 0),

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -32,10 +32,10 @@ func _ready() -> void:
 	update_view_limits()
 
 func update_view_limits() -> void:
-	view.limit_left = -size_2d_override.x * buffer_view_space
-	view.limit_right = size_2d_override.x * buffer_view_space + display.size.x
-	view.limit_top = -size_2d_override.y * buffer_view_space
-	view.limit_bottom = size_2d_override.y * buffer_view_space + display.size.y
+	view.limit_left = int(-size_2d_override.x * buffer_view_space)
+	view.limit_right = int(size_2d_override.x * buffer_view_space + display.size.x)
+	view.limit_top = int(-size_2d_override.y * buffer_view_space)
+	view.limit_bottom = int(size_2d_override.y * buffer_view_space + display.size.y)
 	set_view(view.position)  # Ensure the view is still clamped.
 
 # Top left corner.
@@ -50,6 +50,7 @@ func zoom_in() -> void:
 func zoom_out() -> void:
 	zoom_level /= sqrt(2)
 
+# Choose an appropriate zoom level and center the camera.
 func zoom_reset() -> void:
 	var svg_attribs := SVG.root_tag.attributes
 	zoom_level = float(nearest_po2(int(8192 / maxf(svg_attribs.width.get_value(),

--- a/translations/translation_sheet.csv
+++ b/translations/translation_sheet.csv
@@ -1,6 +1,6 @@
-﻿,en,bg,de
+,en,bg,de
 #remember_svg_setting,Remember SVG,Запомни SVG,SVG merken
-#remember_svg_desc,"When this box is checked, the SVG will persist between session.","Когато тази кутийка е отметната, SVG-то ще бъде запомнено между сесиите.","Wenn diese Option aktiviert ist, wird das SVG zwischen Sitzungen wiederhergestellt."
+#remember_svg_desc,"When this box is checked, the SVG will persist between sessions.","Когато тази кутийка е отметната, SVG-то ще бъде запомнено между сесиите.","Wenn diese Option aktiviert ist, wird das SVG zwischen Sitzungen wiederhergestellt."
 #remember_window_mode_settings,Remember window mode,Запомни режима на прозореца,Fenstermodus wiederherstellen
 #remember_window_mode_desc,"When this box is checked, the window can remain restored between sessions.","Когато тази кутийка е отметната, прозорецът може да остане малък между сесиите.","Wenn diese Option aktiviert ist, wird das Fenster zwischen Sitzungen wiederhergestellt."
 #language,Language,Език,Sprache
@@ -33,7 +33,7 @@
 #insert_after,Insert After,Вмъкни отпред,Danach einsetzen
 #err_empty_svg,SVG is empty.,Текстът е празен.,SVG ist leer.
 #err_not_svg,Doesn’t describe a SVG.,Текстът не описва SVG.,Beschreibt kein SVG.
-#err_improper_nesting,Improper nesting.,Несъвместими тагове.,Ungültige formatierung.
+#err_improper_nesting,Improper nesting.,Несъвместими тагове.,Ungültige Formatierung.
 #err_improper_closing,Not all tags are closed.,Не всички тагове са затворени.,Es wurden nicht alle Elemente geschlossen.
 #shortcut_inspector_delete,Delete: Deletes the selected tags,Delete: Изтрива избраните тагове,Entf: Ausgewählte Elemente löschen
 #shortcut_inspector_ctrl_down,Ctrl+Down: Moves the selected tags down,Ctrl+Down: Премества избраните тагове надолу,Strg+Unten: Ausgewählte Elemente nach unten verschieben

--- a/visual/main_theme.tres
+++ b/visual/main_theme.tres
@@ -707,7 +707,6 @@ TextEdit/fonts/font = ExtResource("5_nfqug")
 TextEdit/styles/focus = SubResource("StyleBoxFlat_1gwcd")
 TextEdit/styles/normal = SubResource("StyleBoxFlat_ichfn")
 TooltipLabel/colors/font_color = Color(0.866667, 0.933333, 1, 1)
-TooltipLabel/font_sizes/font_size = 14
 TooltipLabel/fonts/font = ExtResource("11_ccloq")
 TooltipPanel/styles/panel = SubResource("StyleBoxFlat_ghiib")
 VScrollBar/styles/grabber = SubResource("StyleBoxFlat_dptuh")


### PR DESCRIPTION
Small fixes, among which, attribute editors once again use the code font for tooltips, and I reduced the zooming of SVGs (the viewport rework removed the jittering, so the new zoom of 3 is now arguably better than the old zoom of 4).

If I understand the bottlenecks correctly, this should improve performance by up to 40%. (#106 is starting to crack!!)