### PR TITLE
Rework ZoomMenu

### DIFF
--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -6,9 +6,6 @@ const docs = preload("docs.tscn")
 
 const NumberField = preload("res://src/ui_elements/number_field.tscn")
 
-@onready var zoom_reset_button: Button = %ZoomReset
-@onready var zoom_in_button: Button = %ZoomIn
-@onready var zoom_out_button: Button = %ZoomOut
 @onready var viewport: SubViewport = $ViewportContainer/Viewport
 @onready var controls: Control = %Checkerboard/Controls
 @onready var grid_visuals: Camera2D = $ViewportContainer/Viewport/ViewCamera
@@ -17,17 +14,6 @@ const NumberField = preload("res://src/ui_elements/number_field.tscn")
 @onready var more_button: Button = %LeftMenu/MoreOptions
 @onready var more_popup: Popup = %LeftMenu/MorePopup
 @onready var snapper: BetterLineEdit = %LeftMenu/Snapping/NumberEdit
-
-func update_zoom_widget(zoom_level: float) -> void:
-	await get_tree().process_frame
-	zoom_reset_button.text = String.num(zoom_level * 100,
-			2 if zoom_level < 0.1 else 1 if zoom_level < 10.0 else 0) + "%"
-	zoom_out_button.disabled = (zoom_level <= viewport.min_zoom)
-	zoom_out_button.mouse_default_cursor_shape = Control.CURSOR_ARROW\
-			if zoom_out_button.disabled else Control.CURSOR_POINTING_HAND
-	zoom_in_button.disabled = (zoom_level >= viewport.max_zoom)
-	zoom_in_button.mouse_default_cursor_shape = Control.CURSOR_ARROW\
-			if zoom_in_button.disabled else Control.CURSOR_POINTING_HAND
 
 
 func _on_settings_pressed() -> void:

--- a/src/ui_parts/display/menu/zoom_menu/zoom_menu.gd
+++ b/src/ui_parts/display/menu/zoom_menu/zoom_menu.gd
@@ -2,12 +2,14 @@ extends HBoxContainer
 
 
 const MIN_ZOOM = 0.125
-
 const MAX_ZOOM = 64.0
 
 signal zoom_changed(zoom_level: float)
+signal zoom_reset_pressed()
 
-signal zoom_reseted()
+@onready var zoom_out_button: Button = $ZoomOut
+@onready var zoom_in_button: Button = $ZoomIn
+@onready var zoom_reset_button: Button = $ZoomReset
 
 var zoom_level: float:
 	set(value):
@@ -24,6 +26,8 @@ func _ready() -> void:
 func zoom_out() -> void:
 	zoom_level /= sqrt(2)
 
+func zoom_in() -> void:
+	zoom_level *= sqrt(2)
 
 # Choose an appropriate zoom level and center the camera.
 func zoom_reset() -> void:
@@ -32,23 +36,19 @@ func zoom_reset() -> void:
 	zoom_level = float(nearest_po2(int(8192 / maxf(svg_attribs.width.get_value(),
 			svg_attribs.height.get_value()))) / 32.0)
 	
-	zoom_reseted.emit()
-
-
-func zoom_in() -> void:
-	zoom_level *= sqrt(2)
+	zoom_reset_pressed.emit()
 
 
 func _update_buttons_appearance() -> void:
-	%ZoomReset.text = String.num(zoom_level * 100,
+	zoom_reset_button.text = String.num(zoom_level * 100,
 			2 if zoom_level < 0.1 else 1 if zoom_level < 10.0 else 0) + "%"
 	
-	%ZoomIn.disabled = zoom_level >= MAX_ZOOM
-	%ZoomIn.mouse_default_cursor_shape = (
-		Control.CURSOR_ARROW if %ZoomIn.disabled else Control.CURSOR_POINTING_HAND
+	zoom_in_button.disabled = zoom_level >= MAX_ZOOM
+	zoom_in_button.mouse_default_cursor_shape = (
+		Control.CURSOR_ARROW if zoom_in_button.disabled else Control.CURSOR_POINTING_HAND
 	)
 	
-	%ZoomOut.disabled = zoom_level <= MIN_ZOOM
-	%ZoomOut.mouse_default_cursor_shape = (
-		Control.CURSOR_ARROW if %ZoomOut.disabled else Control.CURSOR_POINTING_HAND
+	zoom_out_button.disabled = zoom_level <= MIN_ZOOM
+	zoom_out_button.mouse_default_cursor_shape = (
+		Control.CURSOR_ARROW if zoom_out_button.disabled else Control.CURSOR_POINTING_HAND
 	)

--- a/src/ui_parts/display/menu/zoom_menu/zoom_menu.gd
+++ b/src/ui_parts/display/menu/zoom_menu/zoom_menu.gd
@@ -1,0 +1,54 @@
+extends HBoxContainer
+
+
+const MIN_ZOOM = 0.125
+
+const MAX_ZOOM = 64.0
+
+signal zoom_changed(zoom_level: float)
+
+signal zoom_reseted()
+
+var zoom_level: float:
+	set(value):
+		zoom_level = clampf(value, MIN_ZOOM, MAX_ZOOM)
+		zoom_changed.emit(zoom_level)
+	
+		_update_buttons_appearance()
+
+
+func _ready() -> void:
+	zoom_reset()
+
+
+func zoom_out() -> void:
+	zoom_level /= sqrt(2)
+
+
+# Choose an appropriate zoom level and center the camera.
+func zoom_reset() -> void:
+	var svg_attribs := SVG.root_tag.attributes
+	
+	zoom_level = float(nearest_po2(int(8192 / maxf(svg_attribs.width.get_value(),
+			svg_attribs.height.get_value()))) / 32.0)
+	
+	zoom_reseted.emit()
+
+
+func zoom_in() -> void:
+	zoom_level *= sqrt(2)
+
+
+func _update_buttons_appearance() -> void:
+	%ZoomReset.text = String.num(zoom_level * 100,
+			2 if zoom_level < 0.1 else 1 if zoom_level < 10.0 else 0) + "%"
+	
+	%ZoomIn.disabled = zoom_level >= MAX_ZOOM
+	%ZoomIn.mouse_default_cursor_shape = (
+		Control.CURSOR_ARROW if %ZoomIn.disabled else Control.CURSOR_POINTING_HAND
+	)
+	
+	%ZoomOut.disabled = zoom_level <= MIN_ZOOM
+	%ZoomOut.mouse_default_cursor_shape = (
+		Control.CURSOR_ARROW if %ZoomOut.disabled else Control.CURSOR_POINTING_HAND
+	)

--- a/src/ui_parts/display/menu/zoom_menu/zoom_menu.tscn
+++ b/src/ui_parts/display/menu/zoom_menu/zoom_menu.tscn
@@ -36,7 +36,6 @@ alignment = 1
 script = ExtResource("1_18ab8")
 
 [node name="ZoomOut" type="Button" parent="."]
-unique_name_in_owner = true
 custom_minimum_size = Vector2(28, 0)
 layout_mode = 2
 tooltip_text = "#zoom_out"
@@ -47,7 +46,6 @@ icon = ExtResource("1_8ggy2")
 icon_alignment = 1
 
 [node name="ZoomReset" type="Button" parent="."]
-unique_name_in_owner = true
 custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
 tooltip_text = "#zoom_reset"
@@ -58,7 +56,6 @@ shortcut = SubResource("Shortcut_4v7wx")
 text = "100%"
 
 [node name="ZoomIn" type="Button" parent="."]
-unique_name_in_owner = true
 custom_minimum_size = Vector2(28, 0)
 layout_mode = 2
 tooltip_text = "#zoom_in"

--- a/src/ui_parts/display/menu/zoom_menu/zoom_menu.tscn
+++ b/src/ui_parts/display/menu/zoom_menu/zoom_menu.tscn
@@ -1,0 +1,73 @@
+[gd_scene load_steps=10 format=3 uid="uid://oltvrf01xrxl"]
+
+[ext_resource type="Texture2D" uid="uid://c2h5snkvemm4p" path="res://visual/icons/Minus.svg" id="1_8ggy2"]
+[ext_resource type="Script" path="res://src/ui_parts/display/menu/zoom_menu/zoom_menu.gd" id="1_18ab8"]
+[ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="2_284x5"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_y2lqj"]
+device = -1
+ctrl_pressed = true
+keycode = 45
+unicode = 45
+
+[sub_resource type="Shortcut" id="Shortcut_ntgv0"]
+events = [SubResource("InputEventKey_y2lqj")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_q17wx"]
+device = -1
+ctrl_pressed = true
+keycode = 48
+unicode = 48
+
+[sub_resource type="Shortcut" id="Shortcut_4v7wx"]
+events = [SubResource("InputEventKey_q17wx")]
+
+[sub_resource type="InputEventKey" id="InputEventKey_gqh1f"]
+device = -1
+ctrl_pressed = true
+keycode = 61
+unicode = 61
+
+[sub_resource type="Shortcut" id="Shortcut_y6ouu"]
+events = [SubResource("InputEventKey_gqh1f")]
+
+[node name="ZoomMenu" type="HBoxContainer"]
+alignment = 1
+script = ExtResource("1_18ab8")
+
+[node name="ZoomOut" type="Button" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+tooltip_text = "#zoom_out"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+shortcut = SubResource("Shortcut_ntgv0")
+icon = ExtResource("1_8ggy2")
+icon_alignment = 1
+
+[node name="ZoomReset" type="Button" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(60, 0)
+layout_mode = 2
+tooltip_text = "#zoom_reset"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_override_font_sizes/font_size = 14
+shortcut = SubResource("Shortcut_4v7wx")
+text = "100%"
+
+[node name="ZoomIn" type="Button" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(28, 0)
+layout_mode = 2
+tooltip_text = "#zoom_in"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+shortcut = SubResource("Shortcut_y6ouu")
+icon = ExtResource("2_284x5")
+icon_alignment = 1
+
+[connection signal="pressed" from="ZoomOut" to="." method="zoom_out"]
+[connection signal="pressed" from="ZoomReset" to="." method="zoom_reset"]
+[connection signal="pressed" from="ZoomIn" to="." method="zoom_in"]

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -349,4 +349,4 @@ script = ExtResource("5_pltvx")
 [connection signal="toggled" from="Display/PanelContainer/HBoxContainer/LeftMenu/Snapping/SnapButton" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snap_button_toggled"]
 [connection signal="value_changed" from="Display/PanelContainer/HBoxContainer/LeftMenu/Snapping/NumberEdit" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snapper_value_changed"]
 [connection signal="zoom_changed" from="Display/PanelContainer/HBoxContainer/ZoomMenu" to="Display/ViewportContainer/Viewport" method="_on_zoom_changed"]
-[connection signal="zoom_reseted" from="Display/PanelContainer/HBoxContainer/ZoomMenu" to="Display/ViewportContainer/Viewport" method="center_frame"]
+[connection signal="zoom_reset_pressed" from="Display/PanelContainer/HBoxContainer/ZoomMenu" to="Display/ViewportContainer/Viewport" method="center_frame"]

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=37 format=3 uid="uid://ce6j54x27pom"]
+[gd_scene load_steps=30 format=3 uid="uid://ce6j54x27pom"]
 
 [ext_resource type="PackedScene" uid="uid://ccynisiuyn5qn" path="res://src/ui_parts/inspector.tscn" id="1_afxvd"]
 [ext_resource type="Texture2D" uid="uid://ccvjkdd0s7rb4" path="res://visual/icons/Copy.svg" id="1_fm0ux"]
 [ext_resource type="Script" path="res://src/ui_parts/code_editor.gd" id="1_ry6k8"]
-[ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="2_w635r"]
+[ext_resource type="FontFile" uid="uid://cfof4x3ewn6bl" path="res://visual/fonts/FontMono.ttf" id="2_w635r"]
 [ext_resource type="Script" path="res://src/ui_parts/display.gd" id="2_ylpv1"]
 [ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://visual/Checkerboard.svg" id="3_d58qh"]
 [ext_resource type="Texture2D" uid="uid://ckkkgof1hcbld" path="res://visual/icons/Gear.svg" id="4_3rshc"]
@@ -20,9 +20,8 @@
 [ext_resource type="Texture2D" uid="uid://buire51l0mifg" path="res://visual/icons/Snap.svg" id="11_u7ddj"]
 [ext_resource type="Shader" path="res://src/ui_parts/zoom_shader.gdshader" id="12_wewnk"]
 [ext_resource type="PackedScene" uid="uid://dad7fkhmsooc6" path="res://src/ui_elements/number_edit.tscn" id="13_oxv3i"]
-[ext_resource type="Texture2D" uid="uid://c2h5snkvemm4p" path="res://visual/icons/Minus.svg" id="13_uqus2"]
-[ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="14_t8hbh"]
 [ext_resource type="Script" path="res://src/ui_parts/view_camera.gd" id="15_v2yj8"]
+[ext_resource type="PackedScene" uid="uid://oltvrf01xrxl" path="res://src/ui_parts/display/menu/zoom_menu/zoom_menu.tscn" id="18_e3qve"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_082e3"]
 content_margin_left = 6.0
@@ -86,33 +85,6 @@ content_margin_bottom = 7.0
 bg_color = Color(0.02, 0.02, 0.08, 1)
 border_width_bottom = 2
 border_color = Color(0.4, 0.7, 1, 1)
-
-[sub_resource type="InputEventKey" id="InputEventKey_n13ij"]
-device = -1
-ctrl_pressed = true
-keycode = 45
-unicode = 45
-
-[sub_resource type="Shortcut" id="Shortcut_teo1i"]
-events = [SubResource("InputEventKey_n13ij")]
-
-[sub_resource type="InputEventKey" id="InputEventKey_g6r8v"]
-device = -1
-ctrl_pressed = true
-keycode = 48
-unicode = 48
-
-[sub_resource type="Shortcut" id="Shortcut_le5f5"]
-events = [SubResource("InputEventKey_g6r8v")]
-
-[sub_resource type="InputEventKey" id="InputEventKey_la6x6"]
-device = -1
-ctrl_pressed = true
-keycode = 61
-unicode = 61
-
-[sub_resource type="Shortcut" id="Shortcut_ihtjd"]
-events = [SubResource("InputEventKey_la6x6")]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_kqplg"]
 shader = ExtResource("12_wewnk")
@@ -307,49 +279,16 @@ visible = false
 [node name="MorePopup" parent="Display/PanelContainer/HBoxContainer/LeftMenu" instance=ExtResource("10_hraj8")]
 visible = false
 
-[node name="ZoomMenu" type="HBoxContainer" parent="Display/PanelContainer/HBoxContainer"]
-layout_mode = 2
-alignment = 1
-
-[node name="ZoomOut" type="Button" parent="Display/PanelContainer/HBoxContainer/ZoomMenu"]
+[node name="ZoomMenu" parent="Display/PanelContainer/HBoxContainer" instance=ExtResource("18_e3qve")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(28, 0)
 layout_mode = 2
-tooltip_text = "#zoom_out"
-focus_mode = 0
-mouse_default_cursor_shape = 2
-shortcut = SubResource("Shortcut_teo1i")
-icon = ExtResource("13_uqus2")
-icon_alignment = 1
-
-[node name="ZoomReset" type="Button" parent="Display/PanelContainer/HBoxContainer/ZoomMenu"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(60, 0)
-layout_mode = 2
-tooltip_text = "#zoom_reset"
-focus_mode = 0
-mouse_default_cursor_shape = 2
-theme_override_font_sizes/font_size = 14
-shortcut = SubResource("Shortcut_le5f5")
-text = "100%"
-
-[node name="ZoomIn" type="Button" parent="Display/PanelContainer/HBoxContainer/ZoomMenu"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(28, 0)
-layout_mode = 2
-tooltip_text = "#zoom_in"
-focus_mode = 0
-mouse_default_cursor_shape = 2
-shortcut = SubResource("Shortcut_ihtjd")
-icon = ExtResource("14_t8hbh")
-icon_alignment = 1
 
 [node name="ViewportContainer" type="SubViewportContainer" parent="Display"]
 process_mode = 3
 layout_mode = 2
 size_flags_horizontal = 10
 
-[node name="Viewport" type="SubViewport" parent="Display/ViewportContainer"]
+[node name="Viewport" type="SubViewport" parent="Display/ViewportContainer" node_paths=PackedStringArray("display", "view", "controls", "display_texture")]
 disable_3d = true
 handle_input_locally = false
 gui_snap_controls_to_pixels = false
@@ -357,6 +296,10 @@ size = Vector2i(600, 600)
 size_2d_override_stretch = true
 render_target_update_mode = 4
 script = ExtResource("6_7hypx")
+display = NodePath("Checkerboard")
+view = NodePath("ViewCamera")
+controls = NodePath("Checkerboard/Controls")
+display_texture = NodePath("Checkerboard/DisplayTexture")
 
 [node name="ViewCamera" type="Camera2D" parent="Display/ViewportContainer/Viewport"]
 anchor_mode = 0
@@ -405,6 +348,5 @@ script = ExtResource("5_pltvx")
 [connection signal="toggled" from="Display/PanelContainer/HBoxContainer/LeftMenu/Snapping/SnapButton" to="Display" method="_on_snap_button_toggled"]
 [connection signal="toggled" from="Display/PanelContainer/HBoxContainer/LeftMenu/Snapping/SnapButton" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snap_button_toggled"]
 [connection signal="value_changed" from="Display/PanelContainer/HBoxContainer/LeftMenu/Snapping/NumberEdit" to="Display/ViewportContainer/Viewport/Checkerboard/Controls" method="_on_snapper_value_changed"]
-[connection signal="pressed" from="Display/PanelContainer/HBoxContainer/ZoomMenu/ZoomOut" to="Display/ViewportContainer/Viewport" method="zoom_out"]
-[connection signal="pressed" from="Display/PanelContainer/HBoxContainer/ZoomMenu/ZoomReset" to="Display/ViewportContainer/Viewport" method="zoom_reset"]
-[connection signal="pressed" from="Display/PanelContainer/HBoxContainer/ZoomMenu/ZoomIn" to="Display/ViewportContainer/Viewport" method="zoom_in"]
+[connection signal="zoom_changed" from="Display/PanelContainer/HBoxContainer/ZoomMenu" to="Display/ViewportContainer/Viewport" method="_on_zoom_changed"]
+[connection signal="zoom_reseted" from="Display/PanelContainer/HBoxContainer/ZoomMenu" to="Display/ViewportContainer/Viewport" method="center_frame"]

--- a/src/ui_parts/view_camera.gd
+++ b/src/ui_parts/view_camera.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 
 # Don't ask me to explain this.
 func _draw() -> void:
-	var size: Vector2 = get_parent().size / get_parent().zoom_level
+	var size: Vector2 = get_parent().size / %ZoomMenu.zoom_level
 	draw_line(Vector2(-position.x, 0), Vector2(-position.x, size.y), main_line_color)
 	draw_line(Vector2(0, -position.y), Vector2(size.x, -position.y), main_line_color)
 	
@@ -23,7 +23,7 @@ func _draw() -> void:
 	var x_offset := fmod(-position.x, 1.0)
 	var y_offset := fmod(-position.y, 1.0)
 	var tick_distance := float(ticks_interval)
-	var viewport_scale: float = get_parent().zoom_level
+	var viewport_scale: float = %ZoomMenu.zoom_level
 	var draw_pixel_lines := viewport_scale >= 3.0
 	var rate := nearest_po2(roundi(maxf(64.0 / (ticks_interval * viewport_scale), 1.0)))
 	

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -7,6 +7,7 @@ const buffer_view_space = 0.8
 @export var controls: Control
 @export var display_texture: TextureRect
 
+@onready var zoom_menu: HBoxContainer = %ZoomMenu
 @onready var main_node: VBoxContainer = %Display
 
 
@@ -48,23 +49,23 @@ func _unhandled_input(event: InputEvent) -> void:
 	
 	if event is InputEventPanGesture:
 		if event.ctrl_pressed:
-			%ZoomMenu.zoom_level *= 1 + event.delta.y / 2
+			zoom_menu.zoom_level *= 1 + event.delta.y / 2
 		else:
 			set_view(view.position + event.delta * 32)
 	
 	if event is InputEventMagnifyGesture:
-		%ZoomMenu.zoom_level *= event.factor
+		zoom_menu.zoom_level *= event.factor
 	
 	if event is InputEventMouseButton and event.is_pressed():
 		match event.button_index:
 			MOUSE_BUTTON_WHEEL_UP when GlobalSettings.invert_zoom:
-				%ZoomMenu.zoom_out()
+				zoom_menu.zoom_out()
 			MOUSE_BUTTON_WHEEL_UP:
-				%ZoomMenu.zoom_in()
+				zoom_menu.zoom_in()
 			MOUSE_BUTTON_WHEEL_DOWN when GlobalSettings.invert_zoom:
-				%ZoomMenu.zoom_in()
+				zoom_menu.zoom_in()
 			MOUSE_BUTTON_WHEEL_DOWN:
-				%ZoomMenu.zoom_out()
+				zoom_menu.zoom_out()
 	
 	if event is InputEventMouseButton:
 		if event.ctrl_pressed:

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -1,32 +1,16 @@
 extends SubViewport
 
-const min_zoom = 0.125
-const max_zoom = 64.0
 const buffer_view_space = 0.8
 
-@onready var view: Camera2D = $ViewCamera
-@onready var display: TextureRect = $Checkerboard
-@onready var main_node: VBoxContainer = %Display
-@onready var display_texture: TextureRect = $Checkerboard/DisplayTexture
-@onready var controls: Control = $Checkerboard/Controls
+@export var display: TextureRect
+@export var view: Camera2D
+@export var controls: Control
+@export var display_texture: TextureRect
 
-var zoom_level: float:
-	set(new_value):
-		zoom_level = clampf(new_value, min_zoom, max_zoom)
-		main_node.update_zoom_widget(zoom_level)
-		var old_size_2d_override := size_2d_override
-		size_2d_override = size / zoom_level
-		set_view(view.position + (old_size_2d_override - size_2d_override) / 2.0)
-		display.material.set_shader_parameter(&"uv_scale",
-				nearest_po2(int(zoom_level * 32)) / 32.0)
-		update_view_limits()
-		controls.zoom = zoom_level
-		display_texture.zoom = zoom_level
-		view.queue_redraw()
+@onready var main_node: VBoxContainer = %Display
 
 
 func _ready() -> void:
-	zoom_reset()  # Do this first so zoom_level is not 0.
 	SVG.root_tag.attribute_changed.connect(resize)
 	SVG.root_tag.changed_unknown.connect(resize)
 	resize()
@@ -45,20 +29,6 @@ func set_view(new_position: Vector2) -> void:
 			Vector2(view.limit_right, view.limit_bottom) - size_2d_override * 1.0)
 
 
-func zoom_in() -> void:
-	zoom_level *= sqrt(2)
-
-func zoom_out() -> void:
-	zoom_level /= sqrt(2)
-
-# Choose an appropriate zoom level and center the camera.
-func zoom_reset() -> void:
-	var svg_attribs := SVG.root_tag.attributes
-	zoom_level = float(nearest_po2(int(8192 / maxf(svg_attribs.width.get_value(),
-			svg_attribs.height.get_value()))) / 32.0)
-	center_frame()
-
-
 func resize() -> void:
 	var svg_attribs := SVG.root_tag.attributes
 	display.size = Vector2(svg_attribs.width.get_value(), svg_attribs.height.get_value())
@@ -71,32 +41,43 @@ func center_frame() -> void:
 func _unhandled_input(event: InputEvent) -> void:
 	if not event is InputEventMouseMotion or event.button_mask != 0:
 		view.queue_redraw()
+	
 	if event is InputEventMouseMotion and\
 	event.button_mask in [MOUSE_BUTTON_MASK_LEFT, MOUSE_BUTTON_MASK_MIDDLE]:
 		set_view(view.position - event.relative)
 	
 	if event is InputEventPanGesture:
 		if event.ctrl_pressed:
-			zoom_level *= 1 + event.delta.y / 2
+			%ZoomMenu.zoom_level *= 1 + event.delta.y / 2
 		else:
 			set_view(view.position + event.delta * 32)
 	
 	if event is InputEventMagnifyGesture:
-		zoom_level *= event.factor
+		%ZoomMenu.zoom_level *= event.factor
 	
 	if event is InputEventMouseButton and event.is_pressed():
 		match event.button_index:
+			MOUSE_BUTTON_WHEEL_UP when GlobalSettings.invert_zoom:
+				%ZoomMenu.zoom_out()
 			MOUSE_BUTTON_WHEEL_UP:
-				if GlobalSettings.invert_zoom:
-					zoom_out()
-				else:
-					zoom_in()
+				%ZoomMenu.zoom_in()
+			MOUSE_BUTTON_WHEEL_DOWN when GlobalSettings.invert_zoom:
+				%ZoomMenu.zoom_in()
 			MOUSE_BUTTON_WHEEL_DOWN:
-				if GlobalSettings.invert_zoom:
-					zoom_in()
-				else:
-					zoom_out()
+				%ZoomMenu.zoom_out()
 	
 	if event is InputEventMouseButton:
 		if event.ctrl_pressed:
 			pass
+
+
+func _on_zoom_changed(zoom_level: float) -> void:
+	var old_size_2d_override := size_2d_override
+	size_2d_override = size / zoom_level
+	set_view(view.position + (old_size_2d_override - size_2d_override) / 2.0)
+	display.material.set_shader_parameter(&"uv_scale",
+			nearest_po2(int(zoom_level * 32)) / 32.0)
+	update_view_limits()
+	controls.zoom = zoom_level
+	display_texture.zoom = zoom_level
+	view.queue_redraw()


### PR DESCRIPTION
This would rework `ZoomMenu` to be a scene with it own logic, removing a little of logic from `Viewport` and `Display`.  

Changes:
- `ZoomMenu` would get full control over `zoom_level` and buttons to control it.
- `ZoomMenu` will notify others about zoom change with signals.
- Change `display`, `view`, `controls`, `display_texture` to use `@export`.
  - Using `@onready` creates a need to use `await get_tree().process_frame` (to wait variables be setted). As they exists from the start, there is no reason to not use `@export` and point at them.
- Refactor match condition in `Viewport` to use `when`.
  - This could cause problems because is quite new.

**Note**: I'm just proposing, it's okay if doesn't fit this repository style.

**Note 2**: For some reason I always have problem when opening GodSVG project the first time right after cloning. But opening a second time seems to correct :thinking: 
