### PR TITLE
Improve inspector performance by preloading context popups

### DIFF
--- a/src/ui_elements/enum_field.gd
+++ b/src/ui_elements/enum_field.gd
@@ -1,9 +1,9 @@
 ## An editor to be tied to an AttributeEnum.
 extends AttributeEditor
 
+const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 const bold_font = preload("res://visual/fonts/FontBold.ttf")
 
-@onready var value_picker: Popup = $ContextPopup
 @onready var indicator: LineEdit = $LineEdit
 
 signal value_changed(new_value: String)
@@ -27,11 +27,13 @@ func _ready() -> void:
 	indicator.tooltip_text = attribute_name
 
 func _on_button_pressed() -> void:
+	var value_picker := ContextPopup.instantiate()
 	var buttons_arr: Array[Button] = []
 	for enum_constant in attribute.possible_values:
 		var btn := Button.new()
 		btn.text = str(enum_constant)
 		btn.pressed.connect(_on_option_pressed.bind(enum_constant))
+		btn.pressed.connect(value_picker.hide)
 		if enum_constant == get_value():
 			btn.disabled = true
 		else:
@@ -39,11 +41,12 @@ func _on_button_pressed() -> void:
 		if attribute != null and enum_constant == attribute.default:
 			btn.add_theme_font_override(&"font", bold_font)
 		buttons_arr.append(btn)
+	add_child(value_picker)
+	value_picker.popup_hide.connect(value_picker.queue_free)
 	value_picker.set_btn_array(buttons_arr)
 	Utils.popup_under_control(value_picker, indicator)
 
 func _on_option_pressed(option: String) -> void:
-	value_picker.hide()
 	set_value(option)
 
 func _on_value_changed(new_value: String) -> void:

--- a/src/ui_elements/enum_field.tscn
+++ b/src/ui_elements/enum_field.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://d2da0thyq5rq8"]
+[gd_scene load_steps=6 format=3 uid="uid://d2da0thyq5rq8"]
 
 [ext_resource type="Script" path="res://src/ui_elements/enum_field.gd" id="1_1jqoy"]
 [ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_4bajq"]
 [ext_resource type="Texture2D" uid="uid://coda6chhcatal" path="res://visual/icons/Arrow.svg" id="3_vhd8v"]
-[ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/ui_elements/context_popup.tscn" id="4_4cpb7"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y4kmw"]
 draw_center = false
@@ -53,8 +52,5 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"LeftConnectedButton"
 icon = ExtResource("3_vhd8v")
 expand_icon = true
-
-[node name="ContextPopup" parent="." instance=ExtResource("4_4cpb7")]
-visible = false
 
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/src/ui_elements/path_command_editor.tscn
+++ b/src/ui_elements/path_command_editor.tscn
@@ -1,9 +1,8 @@
-[gd_scene load_steps=9 format=3 uid="uid://dcdrc3r60bgg3"]
+[gd_scene load_steps=8 format=3 uid="uid://dcdrc3r60bgg3"]
 
 [ext_resource type="Script" path="res://src/ui_elements/path_command_editor.gd" id="1_om2fk"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="2_o5eem"]
 [ext_resource type="Texture2D" uid="uid://cmepkbqde0jh0" path="res://visual/icons/SmallMore.svg" id="3_a76tm"]
-[ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/ui_elements/context_popup.tscn" id="4_xqjqs"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_sewij"]
 
@@ -65,9 +64,6 @@ theme_override_styles/normal = SubResource("StyleBoxEmpty_dsai0")
 theme_override_styles/hover = SubResource("StyleBoxFlat_ky4q6")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_5jayv")
 icon = ExtResource("3_a76tm")
-
-[node name="ActionsPopup" parent="." instance=ExtResource("4_xqjqs")]
-visible = false
 
 [connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="pressed" from="HBox/RelativeButton" to="HBox" method="_on_relative_button_pressed"]

--- a/src/ui_elements/path_field.gd
+++ b/src/ui_elements/path_field.gd
@@ -59,7 +59,7 @@ func rebuild_commands() -> void:
 		var command_editor := CommandEditor.instantiate()
 		command_editor.path_command = attribute.get_command(command_idx)
 		# TODO Fix this mess, it's needed for individual path commands selection.
-		command_editor.tid = get_node(^"../../../../../../..").tid
+		command_editor.tid = get_node(^"../../../../../..").tid
 		command_editor.cmd_idx = command_idx
 		command_editor.update_type()
 		command_editor.cmd_update_value.connect(_update_command_value)

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -1,5 +1,7 @@
 extends TextureRect
 
+const strip_count = 8
+
 var rasterized := false:
 	set(new_value):
 		if new_value != rasterized:
@@ -16,7 +18,12 @@ var image_zoom := 0.0
 var update_pending := false
 var svg_change_pending := false
 
+# TODO a bug in ThorVG locks this. The TextureRect should be a Control.
+# I had to draw the SVG with the rendering server, I got some white textures otherwise.
+#var surface := RenderingServer.canvas_item_create()
+
 func _ready() -> void:
+	#RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
 	SVG.root_tag.attribute_changed.connect(queue_update)
 	SVG.root_tag.child_attribute_changed.connect(queue_update)
 	SVG.root_tag.tag_layout_changed.connect(queue_update)
@@ -34,16 +41,55 @@ func _process(_delta: float) -> void:
 		update_pending = false
 		svg_change_pending = false
 
+
+# Strips of the final image.
+
 func svg_update(svg_changed := true) -> void:
 	var bigger_side := maxf(SVG.root_tag.attributes.width.get_value(),
 			SVG.root_tag.attributes.height.get_value())
-	var img := Image.new()
+	
 	var new_image_zoom := 1.0 if rasterized else minf(zoom * 3.0, 16384 / bigger_side)
 	if not svg_changed and not rasterized and new_image_zoom <= image_zoom:
 		return  # Don't waste time resizing if the new image won't be bigger.
 	else:
 		image_zoom = new_image_zoom
 	
+	# TODO delete this when the ThorVG bug is fixed.
+	var img := Image.new()
 	img.load_svg_from_string(SVG.string, image_zoom)
-	if not img.is_empty():
-		texture = ImageTexture.create_from_image(img)
+	texture = ImageTexture.create_from_image(img)
+	
+	# TODO this is locked by a bug in ThorVG.
+	#var task_id := WorkerThreadPool.add_group_task(generate_strip, strip_count)
+	#WorkerThreadPool.wait_for_group_task_completion(task_id)
+	#queue_redraw()
+
+#var svg_strips: Array[Texture2D] = [null, null, null, null, null, null, null, null]
+
+# TODO this is locked by a bug in ThorVG.
+# 4 strips to be handled by WorkerThreadPool for faster image loading.
+#func generate_strip(index: int) -> void:
+	#var svg_tag := SVG.root_tag.create_duplicate()
+	#svg_tag.attributes.width.set_value(svg_tag.attributes.width.get_value() / strip_count)
+	#var viewbox_attrib_value: Rect2 = svg_tag.attributes.viewBox.get_value()
+	#var strip_width := viewbox_attrib_value.size.x / strip_count
+	#var offset := index * strip_width
+	#svg_tag.attributes.viewBox.set_value(Rect2(viewbox_attrib_value.position +\
+			#Vector2(offset, 0), Vector2(strip_width, viewbox_attrib_value.size.y)))
+	#var svg_strip_string := SVGParser.svg_to_text(svg_tag)
+	#var img := Image.new()
+	#img.load_svg_from_string(svg_strip_string, image_zoom)
+	#svg_strips[index] = ImageTexture.create_from_image(img)
+#
+#func _draw() -> void:
+	#RenderingServer.canvas_item_clear(surface)
+	#RenderingServer.canvas_item_set_default_texture_filter(surface,
+			#RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_NEAREST if rasterized else\
+			#RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_LINEAR)
+	#for strip_idx in svg_strips.size():
+		#var strip := svg_strips[strip_idx]
+		#if strip != null:
+			#var rect := get_rect()
+			#rect.size.x /= strip_count
+			#rect.position.x += strip_idx * rect.size.x
+			#strip.draw_rect(surface, rect, false)

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -16,7 +16,6 @@ func _ready() -> void:
 
 
 func full_rebuild() -> void:
-	svg_tag_editor.update_svg_attributes()
 	for node in tags_container.get_children():
 		node.queue_free()
 	svg_tag_editor.tag = SVG.root_tag

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -5,6 +5,7 @@ const shape_attributes = ["cx", "cy", "x", "y", "r", "rx", "ry", "width", "heigh
 
 const unknown_icon = preload("res://visual/icons/tag/unknown.svg")
 
+const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 const TagEditor = preload("tag_editor.tscn")
 const NumberField = preload("res://src/ui_elements/number_field.tscn")
 const NumberSlider = preload("res://src/ui_elements/number_field_with_slider.tscn")
@@ -30,8 +31,6 @@ func find_first_ancestor_scroll_container() -> ScrollContainer:
 @onready var title_button: Button = %TitleButton
 @onready var title_button_icon: TextureRect = %TitleButtonIcon
 @onready var title_button_label: Label = %TitleButtonLabel
-@onready var tag_context: Popup = $ContextPopup
-@onready var margin_container: MarginContainer = $MarginContainer
 @onready var child_tags_container: VBoxContainer = %ChildTags
 
 var tid: PackedInt32Array
@@ -102,7 +101,7 @@ func _ready() -> void:
 			child_tags_container.add_child(tag_editor)
 
 
-func tag_context_populate() -> void:
+func create_tag_context() -> Popup:
 	var parent_tid := Utils.get_parent_tid(tid)
 	var tag_count := SVG.root_tag.get_by_tid(parent_tid).get_child_count()
 	var buttons_arr: Array[Button] = []
@@ -140,27 +139,27 @@ func tag_context_populate() -> void:
 	delete_button.pressed.connect(_on_delete_button_pressed)
 	buttons_arr.append(delete_button)
 	
+	var tag_context := ContextPopup.instantiate()
+	add_child(tag_context)
 	tag_context.set_btn_array(buttons_arr)
+	tag_context.popup_hide.connect(tag_context.queue_free)
+	return tag_context
 
 func _on_title_button_pressed() -> void:
 	Indications.normal_select(tid)
-	tag_context_populate()
+	var tag_context := create_tag_context()
 	Utils.popup_under_control(tag_context, title_button)
 
 func _on_move_up_button_pressed() -> void:
-	tag_context.hide()
 	SVG.root_tag.move_tags_in_parent([tid], false)
 
 func _on_move_down_button_pressed() -> void:
-	tag_context.hide()
 	SVG.root_tag.move_tags_in_parent([tid], true)
 
 func _on_delete_button_pressed() -> void:
-	tag_context.hide()
 	SVG.root_tag.delete_tags([tid])
 
 func _on_duplicate_button_pressed() -> void:
-	tag_context.hide()
 	SVG.root_tag.duplicate_tags([tid])
 
 
@@ -175,7 +174,7 @@ func _on_gui_input(event: InputEvent) -> void:
 				Indications.normal_select(tid)
 		elif event.button_index == MOUSE_BUTTON_RIGHT:
 			Indications.normal_select(tid)
-			tag_context_populate()
+			var tag_context := create_tag_context()
 			tag_context.popup(Rect2(get_global_mouse_position() +\
 					Vector2(-tag_context.size.x / 2, 0), tag_context.size))
 
@@ -201,6 +200,7 @@ func determine_selection_highlight() -> void:
 	var stylebox := StyleBoxFlat.new()
 	stylebox.set_corner_radius_all(4)
 	stylebox.set_border_width_all(2)
+	stylebox.set_content_margin_all(5)
 	
 	var is_selected := tid in Indications.selected_tids
 	var is_hovered := Indications.hovered_tid == tid

--- a/src/ui_parts/tag_editor.tscn
+++ b/src/ui_parts/tag_editor.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://cksx526iftj5d"]
+[gd_scene load_steps=6 format=3 uid="uid://cksx526iftj5d"]
 
 [ext_resource type="Script" path="res://src/ui_parts/tag_editor.gd" id="1_7i0c4"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="2_0lxvf"]
-[ext_resource type="PackedScene" uid="uid://wp77eqhikp6k" path="res://src/ui_elements/context_popup.tscn" id="3_qx6wd"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xmwqw"]
 content_margin_left = 4.0
@@ -58,21 +57,14 @@ offset_right = 1024.0
 offset_bottom = 30.0
 script = ExtResource("1_7i0c4")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
-layout_mode = 2
-theme_override_constants/margin_left = 4
-theme_override_constants/margin_top = 3
-theme_override_constants/margin_right = 5
-theme_override_constants/margin_bottom = 3
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 theme_override_constants/margin_left = 0
@@ -80,7 +72,7 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 2
 theme_override_constants/margin_bottom = 4
 
-[node name="TitleButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer"]
+[node name="TitleButton" type="Button" parent="VBoxContainer/HBoxContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -92,7 +84,7 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_50r0v")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_dfilu")
 theme_override_styles/disabled = SubResource("StyleBoxFlat_xmwqw")
 
-[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/HBoxContainer/MarginContainer/TitleButton"]
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 40.0
@@ -102,12 +94,12 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 6
 theme_override_constants/margin_bottom = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer"]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 0
 
-[node name="TitleButtonIcon" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer"]
+[node name="TitleButtonIcon" type="TextureRect" parent="VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(18, 18)
 layout_mode = 2
@@ -115,7 +107,7 @@ size_flags_horizontal = 4
 size_flags_vertical = 0
 mouse_filter = 2
 
-[node name="TitleButtonLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer"]
+[node name="TitleButtonLabel" type="Label" parent="VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(24, 0)
 layout_mode = 2
@@ -124,37 +116,33 @@ theme_override_fonts/font = ExtResource("2_0lxvf")
 theme_override_font_sizes/font_size = 12
 horizontal_alignment = 1
 
-[node name="RightContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="RightContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 12
 
-[node name="AttributeContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/RightContainer"]
+[node name="AttributeContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/RightContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="UnknownAttributes" type="HFlowContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
+[node name="UnknownAttributes" type="HFlowContainer" parent="VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="PaintAttributes" type="HFlowContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
+[node name="PaintAttributes" type="HFlowContainer" parent="VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ShapeAttributes" type="HFlowContainer" parent="MarginContainer/VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
+[node name="ShapeAttributes" type="HFlowContainer" parent="VBoxContainer/HBoxContainer/RightContainer/AttributeContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ChildTags" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="ChildTags" type="VBoxContainer" parent="VBoxContainer"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
-
-[node name="ContextPopup" parent="." instance=ExtResource("3_qx6wd")]
-visible = false
 
 [connection signal="gui_input" from="." to="." method="_on_gui_input"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton" to="." method="_on_title_button_pressed"]
-[connection signal="draw" from="MarginContainer/VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer" to="." method="_on_title_button_container_draw"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/MarginContainer/TitleButton" to="." method="_on_title_button_pressed"]
+[connection signal="draw" from="VBoxContainer/HBoxContainer/MarginContainer/TitleButton/MarginContainer/VBoxContainer" to="." method="_on_title_button_container_draw"]

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -5,7 +5,7 @@ const buffer_view_space = 0.8
 @onready var display: TextureRect = %Checkerboard
 @onready var view: Camera2D = $ViewCamera
 @onready var controls: Control = %Checkerboard/Controls
-@onready var display_texture: TextureRect = %Checkerboard/DisplayTexture
+@onready var display_texture: Control = %Checkerboard/DisplayTexture
 @onready var zoom_menu: HBoxContainer = %ZoomMenu
 @onready var main_node: VBoxContainer = %Display
 


### PR DESCRIPTION
Hard to measure, but it seems to improve inspector building performance by about 10%.

The baseline for a future optimization is added, but for now it can't be used because of a bug in ThorVG.