### PR TITLE
Add resized signal

### DIFF
--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -10,7 +10,7 @@ var UR := UndoRedo.new()
 signal parsing_finished(error_id: StringName) 
 
 func _ready() -> void:
-	SVG.root_tag.changed_unknown.connect(update_text)
+	SVG.root_tag.changed_unknown.connect(update_text.bind(false))
 	SVG.root_tag.attribute_changed.connect(update_text)
 	SVG.root_tag.child_attribute_changed.connect(update_text)
 	SVG.root_tag.tag_layout_changed.connect(update_text)
@@ -18,10 +18,11 @@ func _ready() -> void:
 	if GlobalSettings.save_data.svg_text.is_empty():
 		root_tag.attributes.width.set_value(16.0)
 		root_tag.attributes.height.set_value(16.0)
-		update_text()
+		update_text(false)
 	else:
 		text = GlobalSettings.save_data.svg_text
 		sync_data()
+	UR.clear_history()
 
 
 func sync_data() -> void:
@@ -30,8 +31,8 @@ func sync_data() -> void:
 	if err_id == &"":
 		update_tags()
 
-func update_text() -> void:
-	text = SVGParser.svg_to_text(root_tag)
-
 func update_tags() -> void:
 	root_tag.replace_self(SVGParser.text_to_svg(text))
+
+func update_text(undo_redo := true) -> void:
+	text = SVGParser.svg_to_text(root_tag)

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -1,6 +1,10 @@
 ## A <svg></svg> tag.
 class_name TagSVG extends Tag
 
+# The difference between attribute_changed() and resized() is that
+# resized will emit even after unknown changes.
+signal resized
+
 signal child_attribute_changed
 signal changed_unknown
 
@@ -98,7 +102,7 @@ func replace_self(new_tag: Tag) -> void:
 	
 	changed_unknown.emit()
 	if old_size != get_size():
-		emit_attribute_changed()  # Needed for things listening to this for resizing.
+		resized.emit()
 
 func delete_tags(tids: Array[PackedInt32Array]) -> void:
 	if tids.is_empty():
@@ -237,3 +241,7 @@ func duplicate_tags(tids: Array[PackedInt32Array]) -> void:
 
 func emit_child_attribute_changed() -> void:
 	child_attribute_changed.emit()
+
+func emit_attribute_changed() -> void:
+	super()
+	resized.emit()

--- a/src/ui_elements/path_field.tscn
+++ b/src/ui_elements/path_field.tscn
@@ -77,6 +77,17 @@ hover_stylebox = SubResource("StyleBoxFlat_4rmxx")
 focus_stylebox = SubResource("StyleBoxFlat_wqlhg")
 code_font_tooltip = true
 
+[node name="AddMove" type="Button" parent="."]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_override_styles/normal = SubResource("StyleBoxEmpty_lcnxl")
+theme_override_styles/hover = SubResource("StyleBoxFlat_4yine")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_kmpxk")
+icon = ExtResource("3_at2g1")
+
 [node name="HBox" type="HBoxContainer" parent="."]
 layout_mode = 2
 
@@ -90,17 +101,6 @@ layout_mode = 2
 size_flags_horizontal = 0
 mouse_filter = 0
 theme_override_constants/separation = 0
-
-[node name="AddMove" type="Button" parent="."]
-layout_mode = 2
-size_flags_horizontal = 0
-size_flags_vertical = 0
-focus_mode = 0
-mouse_default_cursor_shape = 2
-theme_override_styles/normal = SubResource("StyleBoxEmpty_lcnxl")
-theme_override_styles/hover = SubResource("StyleBoxFlat_4yine")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_kmpxk")
-icon = ExtResource("3_at2g1")
 
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="pressed" from="AddMove" to="." method="_on_add_move_pressed"]

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -24,10 +24,10 @@ var svg_change_pending := false
 
 func _ready() -> void:
 	#RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
-	SVG.root_tag.attribute_changed.connect(queue_update)
 	SVG.root_tag.child_attribute_changed.connect(queue_update)
 	SVG.root_tag.tag_layout_changed.connect(queue_update)
 	SVG.root_tag.changed_unknown.connect(queue_update)
+	SVG.root_tag.attribute_changed.connect(queue_update)
 	queue_update()
 
 func queue_update(svg_changed := true) -> void:

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -52,7 +52,7 @@ var surface := RenderingServer.canvas_item_create()
 
 func _ready() -> void:
 	RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
-	SVG.root_tag.attribute_changed.connect(update_dimensions)
+	SVG.root_tag.resized.connect(update_dimensions)
 	SVG.root_tag.child_attribute_changed.connect(queue_redraw)
 	SVG.root_tag.child_attribute_changed.connect(sync_handles)
 	SVG.root_tag.tag_layout_changed.connect(queue_update)

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -17,10 +17,10 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [node name="Inspector" type="VBoxContainer"]
-custom_minimum_size = Vector2(400, 0)
+custom_minimum_size = Vector2(392, 0)
 anchors_preset = 9
 anchor_bottom = 1.0
-offset_right = 368.0
+offset_right = 392.0
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/src/ui_parts/root_tag_editor.gd
+++ b/src/ui_parts/root_tag_editor.gd
@@ -28,12 +28,12 @@ var true_viewbox: Rect2
 
 
 func _ready() -> void:
-	SVG.root_tag.attribute_changed.connect(_on_attribute_changed)
+	SVG.root_tag.resized.connect(_on_resized)
 	SVG.root_tag.changed_unknown.connect(_on_unknown_changed)
 	update_attributes(true)
 
 
-func _on_attribute_changed() -> void:
+func _on_resized() -> void:
 	update_attributes()
 
 func update_attributes(configure_coupling := false) -> void:

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -20,8 +20,8 @@ const UnknownField = preload("res://src/ui_elements/unknown_field.tscn")
 @onready var unknown_container: HFlowContainer = %AttributeContainer/UnknownAttributes
 @onready var title_bar: PanelContainer = $Title
 @onready var content: PanelContainer = $Content
-@onready var title_icon: TextureRect = $Title/TitleBox/HBoxContainer/TitleIcon
-@onready var title_label: Label = $Title/TitleBox/HBoxContainer/TitleLabel
+@onready var title_icon: TextureRect = $Title/TitleBox/TitleIcon
+@onready var title_label: Label = $Title/TitleBox/TitleLabel
 @onready var title_button: Button = $Title/TitleBox/TitleButton
 
 var tid: PackedInt32Array

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -209,12 +209,12 @@ func determine_selection_highlight() -> void:
 		title_sb.border_color = Color.from_hsv(0.6, 0.75, 0.75)
 	elif is_hovered:
 		content_sb.bg_color = Color.from_hsv(0.625, 0.57, 0.19)
-		title_sb.bg_color = Color.from_hsv(0.625, 0.3, 0.2)
+		title_sb.bg_color = Color.from_hsv(0.625, 0.4, 0.2)
 		content_sb.border_color = Color.from_hsv(0.6, 0.55, 0.45)
 		title_sb.border_color = Color.from_hsv(0.6, 0.55, 0.45)
 	else:
 		content_sb.bg_color = Color.from_hsv(0.625, 0.6, 0.16)
-		title_sb.bg_color = Color.from_hsv(0.625, 0.35, 0.17)
+		title_sb.bg_color = Color.from_hsv(0.625, 0.45, 0.17)
 		content_sb.border_color = Color.from_hsv(0.6, 0.5, 0.35)
 		title_sb.border_color = Color.from_hsv(0.6, 0.5, 0.35)
 	

--- a/src/ui_parts/tag_editor.tscn
+++ b/src/ui_parts/tag_editor.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://cmepkbqde0jh0" path="res://visual/icons/SmallMore.svg" id="2_2n846"]
 
 [node name="TagEditor" type="VBoxContainer"]
-offset_right = 72.0
+offset_right = 49.0
 offset_bottom = 30.0
 theme_override_constants/separation = 0
 script = ExtResource("1_7i0c4")
@@ -18,19 +18,14 @@ layout_mode = 2
 theme_override_constants/separation = 6
 alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Title/TitleBox"]
-layout_mode = 2
-theme_override_constants/separation = 2
-
-[node name="TitleIcon" type="TextureRect" parent="Title/TitleBox/HBoxContainer"]
+[node name="TitleIcon" type="TextureRect" parent="Title/TitleBox"]
 custom_minimum_size = Vector2(18, 18)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 mouse_filter = 2
 
-[node name="TitleLabel" type="Label" parent="Title/TitleBox/HBoxContainer"]
-custom_minimum_size = Vector2(24, 0)
+[node name="TitleLabel" type="Label" parent="Title/TitleBox"]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_fonts/font = ExtResource("2_0lxvf")

--- a/src/ui_parts/view_camera.gd
+++ b/src/ui_parts/view_camera.gd
@@ -10,7 +10,7 @@ var surface := RenderingServer.canvas_item_create()  # Used for drawing the numb
 
 func _ready() -> void:
 	RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
-	SVG.root_tag.attribute_changed.connect(queue_redraw)
+	SVG.root_tag.resized.connect(queue_redraw)
 
 # Don't ask me to explain this.
 func _draw() -> void:

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -14,7 +14,7 @@ var zoom := 1.0
 
 
 func _ready() -> void:
-	SVG.root_tag.attribute_changed.connect(resize)
+	SVG.root_tag.resized.connect(resize)
 	resize()
 	await get_tree().process_frame
 	zoom_menu.zoom_reset()


### PR DESCRIPTION
Removes the need for duplicate parsing, helping performance a tiny bit. Also, something of a prerequisite for an UndoRedo implementation.