### PR TITLE
Add UndoRedo

### DIFF
--- a/src/Indications.gd
+++ b/src/Indications.gd
@@ -42,7 +42,7 @@ func _ready() -> void:
 	SVG.root_tag.tags_moved_in_parent.connect(_on_tags_moved_in_parent)
 	#SVG.root_tag.tags_moved_to.connect(_on_tags_moved_to)  # TODO
 	SVG.root_tag.changed_unknown.connect(clear_selection)
-	SVG.root_tag.child_attribute_changed.connect(clear_inner_selection)
+	SVG.root_tag.child_attribute_changed.connect(clear_inner_selection.unbind(1))
 
 
 ## Override the selected tags with a single new selected tag.

--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -5,12 +5,13 @@ extends Node
 var text := ""
 var root_tag := TagSVG.new()
 
+var saved_text := ""
 var UR := UndoRedo.new()
 
 signal parsing_finished(error_id: StringName) 
 
 func _ready() -> void:
-	SVG.root_tag.changed_unknown.connect(update_text)
+	SVG.root_tag.changed_unknown.connect(update_text.bind(false))
 	SVG.root_tag.attribute_changed.connect(update_text)
 	SVG.root_tag.child_attribute_changed.connect(update_text)
 	SVG.root_tag.tag_layout_changed.connect(update_text)
@@ -18,9 +19,10 @@ func _ready() -> void:
 	if GlobalSettings.save_data.svg_text.is_empty():
 		root_tag.attributes.width.set_value(16.0, Attribute.SyncMode.SILENT)
 		root_tag.attributes.height.set_value(16.0, Attribute.SyncMode.SILENT)
-		update_text()
+		update_text(false)
 	else:
 		text = GlobalSettings.save_data.svg_text
+		saved_text = GlobalSettings.save_data.svg_text
 		update_tags()
 	UR.clear_history()
 
@@ -31,8 +33,15 @@ func update_tags() -> void:
 	if err_id == &"":
 		root_tag.replace_self(SVGParser.text_to_svg(text))
 
-func update_text() -> void:
-	text = SVGParser.svg_to_text(root_tag)
+func update_text(undo_redo := true) -> void:
+	if undo_redo:
+		UR.create_action("")
+		UR.add_do_property(self, &"text", SVGParser.svg_to_text(root_tag))
+		UR.add_undo_property(self, &"text", saved_text)
+		UR.commit_action()
+		saved_text = text
+	else:
+		text = SVGParser.svg_to_text(root_tag)
 
 
 func _unhandled_input(event: InputEvent) -> void:
@@ -40,7 +49,6 @@ func _unhandled_input(event: InputEvent) -> void:
 		if UR.has_redo():
 			UR.redo()
 			update_tags()
-	elif event.is_action_pressed(&"undo"):
-		if UR.has_undo():
-			UR.undo()
-			update_tags()
+	elif event.is_action_pressed(&"undo") and UR.has_undo():
+		UR.undo()
+		update_tags()

--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -3,7 +3,7 @@ class_name Tag extends RefCounted
 
 var child_tags: Array[Tag]
 
-signal attribute_changed
+signal attribute_changed(undo_redo: bool)
 
 var name: String
 var attributes: Dictionary  # Dictionary{String: Attribute}
@@ -23,8 +23,8 @@ func set_unknown_attributes(attribs: Array[AttributeUnknown]) -> void:
 	for attribute in unknown_attributes:
 		attribute.propagate_value_changed.connect(emit_attribute_changed)
 
-func emit_attribute_changed():
-	attribute_changed.emit()
+func emit_attribute_changed(undo_redo: bool):
+	attribute_changed.emit(undo_redo)
 
 func get_child_count() -> int:
 	return child_tags.size()

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -5,7 +5,7 @@ class_name TagSVG extends Tag
 # resized will emit even after unknown changes.
 signal resized
 
-signal child_attribute_changed
+signal child_attribute_changed(undo_redo: bool)
 signal changed_unknown
 
 signal tags_added(tids: Array[PackedInt32Array])
@@ -239,9 +239,9 @@ func duplicate_tags(tids: Array[PackedInt32Array]) -> void:
 	tag_layout_changed.emit()
 
 
-func emit_child_attribute_changed() -> void:
-	child_attribute_changed.emit()
+func emit_child_attribute_changed(undo_redo: bool) -> void:
+	child_attribute_changed.emit(undo_redo)
 
-func emit_attribute_changed() -> void:
-	super()
+func emit_attribute_changed(undo_redo: bool) -> void:
+	super(undo_redo)
 	resized.emit()

--- a/src/ui_elements/AttributeEditor.gd
+++ b/src/ui_elements/AttributeEditor.gd
@@ -6,3 +6,10 @@ class_name AttributeEditor extends Control
 
 var attribute: Attribute
 var attribute_name: String
+
+# Values to be used for set_value().
+# REGULAR means that value_changed will emit if the new value is different.
+# NO_SIGNAL means value_changed won't emit.
+# INTERMEDIATE and FINAL cause the attribute update to have the corresponding sync mode.
+# Note that FINAL causes the equivalence check to be skipped.
+enum UpdateType {REGULAR, NO_SIGNAL, INTERMEDIATE, FINAL}

--- a/src/ui_elements/BetterTextEdit.gd
+++ b/src/ui_elements/BetterTextEdit.gd
@@ -110,6 +110,7 @@ func _on_gui_input(event: InputEvent) -> void:
 			if has_redo():
 				redo()
 			accept_event()
-		elif event.is_action_pressed(&"undo") and has_undo():
-			undo()
+		elif event.is_action_pressed(&"undo"):
+			if has_undo():
+				undo()
 			accept_event()

--- a/src/ui_elements/color_popup.gd
+++ b/src/ui_elements/color_popup.gd
@@ -84,4 +84,5 @@ func _switch_mode() -> void:
 
 
 func _on_popup_hide() -> void:
+	color_picked.emit(current_value, true)
 	queue_free()

--- a/src/ui_elements/enum_field.gd
+++ b/src/ui_elements/enum_field.gd
@@ -6,14 +6,14 @@ const bold_font = preload("res://visual/fonts/FontBold.ttf")
 
 @onready var indicator: LineEdit = $LineEdit
 
-signal value_changed(new_value: String)
+signal value_changed(new_value: String, update_type: UpdateType)
 var _value: String  # Must not be updated directly.
 
-func set_value(new_value: String, emit_value_changed := true):
-	if _value != new_value:
+func set_value(new_value: String, update_type := UpdateType.REGULAR):
+	if _value != new_value or update_type == UpdateType.FINAL:
 		_value = new_value
-		if emit_value_changed:
-			value_changed.emit(new_value)
+		if update_type != UpdateType.NO_SIGNAL:
+			value_changed.emit(new_value, update_type)
 
 func get_value() -> String:
 	return _value
@@ -48,10 +48,16 @@ func _on_button_pressed() -> void:
 func _on_option_pressed(option: String) -> void:
 	set_value(option)
 
-func _on_value_changed(new_value: String) -> void:
+func _on_value_changed(new_value: String, update_type: UpdateType) -> void:
 	indicator.text = new_value
 	if attribute != null:
-		attribute.set_value(new_value)
+		match update_type:
+			UpdateType.INTERMEDIATE:
+				attribute.set_value(new_value, Attribute.SyncMode.INTERMEDIATE)
+			UpdateType.FINAL:
+				attribute.set_value(new_value, Attribute.SyncMode.FINAL)
+			_:
+				attribute.set_value(new_value)
 		set_text_tint()
 
 

--- a/src/ui_parts/Handle.gd
+++ b/src/ui_parts/Handle.gd
@@ -1,8 +1,6 @@
 ## Base class for handles.
 class_name Handle extends RefCounted
 
-signal moved(new_value: Vector2)
-
 enum DisplayMode {BIG, SMALL}
 var display_mode := DisplayMode.BIG
 
@@ -10,11 +8,13 @@ var tag: Tag
 var tid := PackedInt32Array()
 var pos: Vector2
 
+var initial_pos: Vector2  # The position of a handle when it started being dragged.
+
 func _init() -> void:
 	pass
 
-func set_pos(new_pos: Vector2) -> void:
-	moved.emit(new_pos)
-
 func sync() -> void:
+	pass
+
+func set_pos(_new_pos: Vector2, _undo_redo := false) -> void:
 	pass

--- a/src/ui_parts/XYHandle.gd
+++ b/src/ui_parts/XYHandle.gd
@@ -10,14 +10,18 @@ func _init(id: PackedInt32Array, x_ref: Attribute, y_ref: Attribute) -> void:
 	y_attribute = y_ref
 	sync()
 
-func set_pos(new_pos: Vector2) -> void:
-	if new_pos.x != pos.x:
-		x_attribute.set_value(new_pos.x, Attribute.SyncMode.LOUD if\
-				new_pos.y == pos.y else Attribute.SyncMode.NO_PROPAGATION)
-	if new_pos.y != pos.y:
-		y_attribute.set_value(new_pos.y)
+func set_pos(new_pos: Vector2, undo_redo := false) -> void:
+	if undo_redo:
+		if initial_pos != new_pos:
+			x_attribute.set_value(new_pos.x, Attribute.SyncMode.NO_PROPAGATION)
+			y_attribute.set_value(new_pos.y, Attribute.SyncMode.FINAL)
+	else:
+		if new_pos.x != pos.x:
+			x_attribute.set_value(new_pos.x, Attribute.SyncMode.INTERMEDIATE if\
+					new_pos.y == pos.y else Attribute.SyncMode.NO_PROPAGATION)
+		if new_pos.y != pos.y:
+			y_attribute.set_value(new_pos.y, Attribute.SyncMode.INTERMEDIATE)
 	pos = new_pos
-	super(new_pos)
 
 func sync() -> void:
 	pos = Vector2(x_attribute.get_value() if x_attribute != null else 0.0,

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -15,15 +15,16 @@ func _ready() -> void:
 	auto_update_text()
 	update_size_label()
 	code_edit.clear_undo_history()
-	SVG.root_tag.attribute_changed.connect(auto_update_text)
-	SVG.root_tag.child_attribute_changed.connect(auto_update_text)
+	SVG.root_tag.attribute_changed.connect(auto_update_text.unbind(1))
+	SVG.root_tag.child_attribute_changed.connect(auto_update_text.unbind(1))
 	SVG.root_tag.tag_layout_changed.connect(auto_update_text)
 	SVG.root_tag.changed_unknown.connect(auto_update_text)
 
 func auto_update_text() -> void:
 	if not code_edit.has_focus():
 		code_edit.text = SVG.text
-		update_size_label()
+		code_edit.clear_undo_history()
+	update_size_label()
 
 func update_error(err_id: StringName) -> void:
 	if err_id == &"":
@@ -95,7 +96,6 @@ func set_new_text(svg_text: String) -> void:
 func _on_code_edit_text_changed() -> void:
 	SVG.text = code_edit.text
 	SVG.update_tags()
-	update_size_label()
 
 
 func _input(event: InputEvent) -> void:
@@ -109,3 +109,5 @@ func update_size_label() -> void:
 
 func _on_svg_code_edit_focus_exited() -> void:
 	code_edit.text = SVG.text
+	if SVG.saved_text != code_edit.text:
+		SVG.update_text(true)

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -24,10 +24,10 @@ var svg_change_pending := false
 
 func _ready() -> void:
 	#RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
-	SVG.root_tag.child_attribute_changed.connect(queue_update)
 	SVG.root_tag.tag_layout_changed.connect(queue_update)
 	SVG.root_tag.changed_unknown.connect(queue_update)
-	SVG.root_tag.attribute_changed.connect(queue_update)
+	SVG.root_tag.attribute_changed.connect(queue_update.unbind(1))
+	SVG.root_tag.child_attribute_changed.connect(queue_update.unbind(1))
 	queue_update()
 
 func queue_update(svg_changed := true) -> void:

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -53,8 +53,8 @@ var surface := RenderingServer.canvas_item_create()
 func _ready() -> void:
 	RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
 	SVG.root_tag.resized.connect(update_dimensions)
-	SVG.root_tag.child_attribute_changed.connect(queue_redraw)
-	SVG.root_tag.child_attribute_changed.connect(sync_handles)
+	SVG.root_tag.child_attribute_changed.connect(queue_redraw.unbind(1))
+	SVG.root_tag.child_attribute_changed.connect(sync_handles.unbind(1))
 	SVG.root_tag.tag_layout_changed.connect(queue_update)
 	SVG.root_tag.changed_unknown.connect(queue_update)
 	SVG.root_tag.changed_unknown.connect(update_dimensions)
@@ -691,6 +691,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		# React to LMB actions.
 		if hovered_handle != null and event.is_pressed():
 			dragged_handle = hovered_handle
+			dragged_handle.initial_pos = dragged_handle.pos
 			var inner_idx = -1
 			if hovered_handle is PathHandle:
 				inner_idx = hovered_handle.command_index
@@ -707,7 +708,7 @@ func _unhandled_input(event: InputEvent) -> void:
 				var new_pos := convert_out(event_pos)
 				if snap_enabled:
 					new_pos = new_pos.snapped(snap_vector)
-				dragged_handle.set_pos(new_pos)
+				dragged_handle.set_pos(new_pos, true)
 				was_handle_moved = false
 			dragged_handle = null
 		elif hovered_handle == null and event.is_pressed():

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -31,7 +31,7 @@ func _ready() -> void:
 	title_label.text = tag.name
 	title_icon.texture = unknown_icon if tag is TagUnknown\
 			else load("res://visual/icons/tag/" + tag.name + ".svg")
-	tag.attribute_changed.connect(select_conditionally)
+	tag.attribute_changed.connect(select_conditionally.unbind(1))
 	Indications.selection_changed.connect(determine_selection_highlight)
 	Indications.hover_changed.connect(determine_selection_highlight)
 	determine_selection_highlight()


### PR DESCRIPTION
This is the one! Resolves #55.

The simplest implementation I could think of.

- Changes the text directly, without needing a lot of custom logic for every type of operation. This leads to a quite low maintenance cost for the feature.
- There are two new types of attribute updates:
  - "Intermediate" for attribute changes that should be detected by everything, but not registered in the UndoRedo, like a handle while it's being dragged.
  - "Final" for attribute changes that should be detected by everything, and registered in the UndoRedo even if the new value is the same as the current one, like a handle that finished being dragged.
- Attribute editors also have a system of update types now, to cement this logic.

Still, from now on, UndoRedo will often have to be considered when making various things.