### PR TITLE
Fix context menu positioning

### DIFF
--- a/src/Utils.gd
+++ b/src/Utils.gd
@@ -192,7 +192,7 @@ static func popup_under_control_centered(popup: Popup, control: Control) -> void
 	popup.popup(Rect2(popup_pos, popup.size))
 
 static func popup_under_mouse(popup: Popup, mouse_pos: Vector2) -> void:
-	popup.popup(Rect2(mouse_pos + Vector2(-popup.size.x / 2, 0), popup.size))
+	popup.popup(Rect2(mouse_pos, popup.size))
 
 
 static func get_cubic_bezier_points(cp1: Vector2, cp2: Vector2,

--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -100,4 +100,4 @@ func _on_gui_input(event: InputEvent) -> void:
 			add_child(context_popup)
 			context_popup.set_min_width(72.0)
 			context_popup.set_btn_array(btn_arr)
-			Utils.popup_under_mouse(context_popup, event.global_position)
+			Utils.popup_under_mouse(context_popup, get_global_mouse_position())

--- a/src/ui_elements/BetterTextEdit.gd
+++ b/src/ui_elements/BetterTextEdit.gd
@@ -93,7 +93,7 @@ func _on_gui_input(event: InputEvent) -> void:
 			add_child(context_popup)
 			context_popup.set_min_width(72.0)
 			context_popup.set_btn_array(btn_arr)
-			Utils.popup_under_mouse(context_popup, event.global_position)
+			Utils.popup_under_mouse(context_popup, get_global_mouse_position())
 	else:
 		# Set these inputs as handled, so the default UndoRedo doesn't eat them.
 		if event.is_action_pressed(&"redo"):


### PR DESCRIPTION
- Always get mouse position with `get_global_mouse_position()` because it takes fractional scaling into consideration.
- Make menu appear to **the right of the mouse** like in other programs. (it would center on x axis before, the change is in Utils.gd)