### PR TITLE
Fix SVG tag editing

### DIFF
--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -47,7 +47,10 @@ func get_viewbox() -> Rect2:
 	if attributes.viewBox.get_value() != null:
 		return attributes.viewBox.rect
 	else:
-		return Rect2(0, 0, attributes.width.get_value(), attributes.height.get_value())
+		if is_nan(attributes.width.get_value()) or is_nan(attributes.height.get_value()):
+			return Rect2(0, 0, 0, 0)
+		else:
+			return Rect2(0, 0, attributes.width.get_value(), attributes.height.get_value())
 
 
 func get_all_tids() -> Array[PackedInt32Array]:

--- a/src/ui_parts/root_tag_editor.gd
+++ b/src/ui_parts/root_tag_editor.gd
@@ -62,8 +62,8 @@ func _on_couple_button_toggled(toggled_on: bool) -> void:
 
 func update_coupling_config() -> void:
 	update_editable()
-	if SVG.root_tag.attributes.width.get_value() == NAN or\
-	SVG.root_tag.attributes.height.get_value() == NAN or\
+	if is_nan(SVG.root_tag.attributes.width.get_value()) or\
+	is_nan(SVG.root_tag.attributes.height.get_value()) or\
 	SVG.root_tag.attributes.viewBox.get_value() == null:
 		couple_button.disabled = true
 		couple_button.mouse_default_cursor_shape = Control.CURSOR_ARROW
@@ -158,16 +158,16 @@ func _on_viewbox_edit_h_value_changed(new_value: float) -> void:
 			SVG.root_tag.attributes.viewBox.set_rect_h(new_value)
 
 func _on_width_button_toggled(toggled_on: bool) -> void:
-	update_coupling_config()
 	SVG.root_tag.attributes.width.set_value(true_width if toggled_on else NAN)
+	update_coupling_config()
 
 func _on_height_button_toggled(toggled_on: bool) -> void:
-	update_coupling_config()
 	SVG.root_tag.attributes.height.set_value(true_height if toggled_on else NAN)
+	update_coupling_config()
 
 func _on_viewbox_button_toggled(toggled_on: bool) -> void:
-	update_coupling_config()
 	if toggled_on:
 		SVG.root_tag.attributes.viewBox.set_rect(true_viewbox)
 	else:
 		SVG.root_tag.attributes.viewBox.set_value(null)
+	update_coupling_config()


### PR DESCRIPTION
Hell will still break loose when the SVG is ill-defined, but I don't plan to fix that. I'm considering implementing warnings for errors that don't make the XML malformed, but still give it issues, like path parsing bugs and such.