### PR TITLE
Small improvements to file opening.

### DIFF
--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -2,6 +2,9 @@
 ## The SVG text, and the native [TagSVG] representation.
 extends Node
 
+const AlertDialog := preload("res://src/ui_parts/alert_dialog.tscn")
+const ImportWarningDialog = preload("res://src/ui_parts/import_warning_dialog.tscn")
+
 var text := ""
 var root_tag := TagSVG.new()
 
@@ -16,25 +19,23 @@ func _ready() -> void:
 	SVG.root_tag.child_attribute_changed.connect(update_text)
 	SVG.root_tag.tag_layout_changed.connect(update_text)
 	
-	var svg_file: FileAccess = null
 	var cmdline_args := OS.get_cmdline_args()
-	if cmdline_args.size() > 0:
-		var file_to_open := cmdline_args[0]
-		if file_to_open.get_extension() == "svg":
-			svg_file = FileAccess.open(file_to_open, FileAccess.READ)
-	
-	if svg_file != null:
-		var svg_text := svg_file.get_as_text()
-		text = svg_text
-		saved_text = svg_text
-		update_tags()
+	var load_cmdl: bool
+	if OS.is_debug_build() and not OS.has_feature("template"):
+		load_cmdl = false
+	elif cmdline_args.size() >= 1:
+		load_cmdl = true
+		
+	await get_tree().process_frame # Warning dialogs on cmdline file opening would not work otherwise.
+	if (apply_svg_from_path(cmdline_args[0]) if load_cmdl else -1) == OK:
+		pass
 	elif not GlobalSettings.save_data.svg_text.is_empty():
 		text = GlobalSettings.save_data.svg_text
 		saved_text = GlobalSettings.save_data.svg_text
 		update_tags()
 	else:
-		root_tag.attributes.width.set_value(16.0, Attribute.SyncMode.SILENT)
-		root_tag.attributes.height.set_value(16.0, Attribute.SyncMode.SILENT)
+		root_tag.attributes.width.set_value("16.0", Attribute.SyncMode.SILENT)
+		root_tag.attributes.height.set_value("16.0", Attribute.SyncMode.SILENT)
 		update_text(false)
 	UR.clear_history()
 
@@ -64,3 +65,34 @@ func _unhandled_input(event: InputEvent) -> void:
 	elif event.is_action_pressed(&"undo") and UR.has_undo():
 		UR.undo()
 		update_tags()
+
+func apply_svg_from_path(path: String) -> int:
+	var svg_file := FileAccess.open(path, FileAccess.READ)
+	var error := ""
+	var extension := path.get_extension()
+	
+	if extension.is_empty():
+		error = "#file_open_empty_extension"
+	elif extension == &"tscn":
+		return ERR_FILE_CANT_OPEN
+	elif not extension == &"svg":
+		error = tr(
+			"#file_open_unsupported_extension").format({"passed_extension": extension})
+	elif svg_file == null:
+		error = "#file_open_fail_message"
+	if not error.is_empty():
+		var alert_dialog := AlertDialog.instantiate()
+		get_tree().get_root().add_child(alert_dialog)
+		alert_dialog.setup(error, "#alert", 280.0)
+		return ERR_FILE_CANT_OPEN
+	
+	var svg_text := svg_file.get_as_text()
+	var warning_panel := ImportWarningDialog.instantiate()
+	warning_panel.imported.connect(func (svg: String) -> void:
+		text = svg
+		saved_text = svg
+		update_tags()
+		)
+	warning_panel.set_svg(svg_text)
+	get_tree().get_root().add_child(warning_panel)
+	return OK

--- a/src/ui_parts/Dialog.gd
+++ b/src/ui_parts/Dialog.gd
@@ -1,11 +1,15 @@
 ## Translucent black rectangle to be used for modals.
 class_name Dialog extends ColorRect
 
+static var is_open: bool
+
 func _enter_tree() -> void:
+	is_open = true
 	color = Color(0, 0, 0, 0.4)
 	anchors_preset = PRESET_FULL_RECT
 	process_mode = PROCESS_MODE_ALWAYS
 	get_tree().paused = true
 
 func _exit_tree() -> void:
+	is_open = false
 	get_tree().paused = false

--- a/src/ui_parts/alert_dialog.gd
+++ b/src/ui_parts/alert_dialog.gd
@@ -1,4 +1,4 @@
-extends ColorRect
+extends Dialog
 
 @onready var title: Label = %MainContainer/TextContainer/Title
 @onready var label: RichTextLabel = %MainContainer/TextContainer/Label

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -83,25 +83,19 @@ func _on_export_button_pressed() -> void:
 	get_tree().get_root().add_child(export_panel)
 
 func apply_svg_from_path(path: String) -> void:
-	if path.get_extension().is_empty():
-		var alert_dialog := AlertDialog.instantiate()
-		get_tree().get_root().add_child(alert_dialog)
-		alert_dialog.setup("#file_open_empty_extension", "#alert", 280.0)
-		return
-	elif not path.get_extension() == "svg":
-		var alert_dialog := AlertDialog.instantiate()
-		get_tree().get_root().add_child(alert_dialog)
-		alert_dialog.setup(
-			tr("#file_open_unsupported_extension").format(
-				{"passed_extension": path.get_extension()}
-			), 
-			"#alert", 280.0)
-		return
 	var svg_file := FileAccess.open(path, FileAccess.READ)
+	var error := ""
+	if path.get_extension().is_empty():
+		error = "#file_open_empty_extension"
+	elif not path.get_extension() == "svg":
+		error = tr(
+			"#file_open_unsupported_extension").format({"passed_extension": path.get_extension()})
 	if svg_file == null:
+		error = "#file_open_fail_message"
+	if not error.is_empty():
 		var alert_dialog := AlertDialog.instantiate()
 		get_tree().get_root().add_child(alert_dialog)
-		alert_dialog.setup("#file_open_fail_message", "#alert", 280.0)
+		alert_dialog.setup(error, "#alert", 280.0)
 		return
 	
 	var svg_text := svg_file.get_as_text()

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -83,10 +83,19 @@ func _on_export_button_pressed() -> void:
 	get_tree().get_root().add_child(export_panel)
 
 func apply_svg_from_path(path: String) -> void:
-	if not path.get_extension() == "svg":
+	if path.get_extension().is_empty():
 		var alert_dialog := AlertDialog.instantiate()
 		get_tree().get_root().add_child(alert_dialog)
-		alert_dialog.setup("#file_open_unsupported_extension", "#alert", 280.0)
+		alert_dialog.setup("#file_open_empty_extension", "#alert", 280.0)
+		return
+	elif not path.get_extension() == "svg":
+		var alert_dialog := AlertDialog.instantiate()
+		get_tree().get_root().add_child(alert_dialog)
+		alert_dialog.setup(
+			tr("#file_open_unsupported_extension").format(
+				{"passed_extension": path.get_extension()}
+			), 
+			"#alert", 280.0)
 		return
 	var svg_file := FileAccess.open(path, FileAccess.READ)
 	if svg_file == null:

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -1,8 +1,6 @@
 extends VBoxContainer
 
 const SVGFileDialog = preload("svg_file_dialog.tscn")
-const ImportWarningDialog = preload("import_warning_dialog.tscn")
-const AlertDialog = preload("alert_dialog.tscn")
 const ExportDialog = preload("export_dialog.tscn")
 
 @onready var code_edit: TextEdit = $ScriptEditor/SVGCodeEdit
@@ -59,7 +57,7 @@ func _on_copy_button_pressed() -> void:
 
 func native_file_import(has_selected: bool, files: PackedStringArray, _filter_idx: int):
 	if has_selected:
-		apply_svg_from_path(files[0])
+		SVG.apply_svg_from_path(files[0])
 		GlobalSettings.modify_save_data("last_used_dir", files[0].get_base_dir())
 
 func _on_import_button_pressed() -> void:
@@ -76,34 +74,11 @@ func _on_import_button_pressed() -> void:
 	else:
 		var svg_import_dialog := SVGFileDialog.instantiate()
 		get_tree().get_root().add_child(svg_import_dialog)
-		svg_import_dialog.file_selected.connect(apply_svg_from_path)
+		svg_import_dialog.file_selected.connect(SVG.apply_svg_from_path)
 
 func _on_export_button_pressed() -> void:
 	var export_panel := ExportDialog.instantiate()
 	get_tree().get_root().add_child(export_panel)
-
-func apply_svg_from_path(path: String) -> void:
-	var svg_file := FileAccess.open(path, FileAccess.READ)
-	var error := ""
-	var extension := path.get_extension()
-	if extension.is_empty():
-		error = &"#file_open_empty_extension"
-	elif not extension == "svg":
-		error = tr(
-			"#file_open_unsupported_extension").format({"passed_extension": extension})
-	elif svg_file == null:
-		error = &"#file_open_fail_message"
-	if not error.is_empty():
-		var alert_dialog := AlertDialog.instantiate()
-		get_tree().get_root().add_child(alert_dialog)
-		alert_dialog.setup(error, "#alert", 280.0)
-		return
-	
-	var svg_text := svg_file.get_as_text()
-	var warning_panel := ImportWarningDialog.instantiate()
-	warning_panel.imported.connect(set_new_text)
-	warning_panel.set_svg(svg_text)
-	get_tree().get_root().add_child(warning_panel)
 
 func set_new_text(svg_text: String) -> void:
 	code_edit.text = svg_text
@@ -130,4 +105,4 @@ func _on_svg_code_edit_focus_exited() -> void:
 		SVG.update_text(true)
 
 func _on_files_dropped(files: PackedStringArray):
-	apply_svg_from_path(files[0])
+	SVG.apply_svg_from_path(files[0])

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -83,6 +83,11 @@ func _on_export_button_pressed() -> void:
 	get_tree().get_root().add_child(export_panel)
 
 func apply_svg_from_path(path: String) -> void:
+	if not path.get_extension() == "svg":
+		var alert_dialog := AlertDialog.instantiate()
+		get_tree().get_root().add_child(alert_dialog)
+		alert_dialog.setup("#file_open_unsupported_extension", "#alert", 280.0)
+		return
 	var svg_file := FileAccess.open(path, FileAccess.READ)
 	if svg_file == null:
 		var alert_dialog := AlertDialog.instantiate()
@@ -120,5 +125,5 @@ func _on_svg_code_edit_focus_exited() -> void:
 	if SVG.saved_text != code_edit.text:
 		SVG.update_text(true)
 
-func _on_files_dropped(files: PackedStringArray): 
+func _on_files_dropped(files: PackedStringArray):
 	apply_svg_from_path(files[0])

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -105,4 +105,5 @@ func _on_svg_code_edit_focus_exited() -> void:
 		SVG.update_text(true)
 
 func _on_files_dropped(files: PackedStringArray):
-	SVG.apply_svg_from_path(files[0])
+	if not Dialog.is_open:
+		SVG.apply_svg_from_path(files[0])

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -19,6 +19,7 @@ func _ready() -> void:
 	SVG.root_tag.child_attribute_changed.connect(auto_update_text.unbind(1))
 	SVG.root_tag.tag_layout_changed.connect(auto_update_text)
 	SVG.root_tag.changed_unknown.connect(auto_update_text)
+	get_window().files_dropped.connect(_on_files_dropped)
 
 func auto_update_text() -> void:
 	if not code_edit.has_focus():
@@ -118,3 +119,6 @@ func _on_svg_code_edit_focus_exited() -> void:
 	code_edit.text = SVG.text
 	if SVG.saved_text != code_edit.text:
 		SVG.update_text(true)
+
+func _on_files_dropped(files: PackedStringArray): 
+	apply_svg_from_path(files[0])

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -85,13 +85,14 @@ func _on_export_button_pressed() -> void:
 func apply_svg_from_path(path: String) -> void:
 	var svg_file := FileAccess.open(path, FileAccess.READ)
 	var error := ""
-	if path.get_extension().is_empty():
-		error = "#file_open_empty_extension"
-	elif not path.get_extension() == "svg":
+	var extension := path.get_extension()
+	if extension.is_empty():
+		error = &"#file_open_empty_extension"
+	elif not extension == "svg":
 		error = tr(
-			"#file_open_unsupported_extension").format({"passed_extension": path.get_extension()})
-	if svg_file == null:
-		error = "#file_open_fail_message"
+			"#file_open_unsupported_extension").format({"passed_extension": extension})
+	elif svg_file == null:
+		error = &"#file_open_fail_message"
 	if not error.is_empty():
 		var alert_dialog := AlertDialog.instantiate()
 		get_tree().get_root().add_child(alert_dialog)

--- a/src/ui_parts/docs.gd
+++ b/src/ui_parts/docs.gd
@@ -1,4 +1,4 @@
-extends ColorRect
+extends Dialog
 
 @onready var desc: RichTextLabel = %Desc
 

--- a/src/ui_parts/svg_file_dialog.gd
+++ b/src/ui_parts/svg_file_dialog.gd
@@ -1,4 +1,4 @@
-extends ColorRect
+extends Dialog
 
 signal file_selected(path: String)
 

--- a/translations/translation_sheet.csv
+++ b/translations/translation_sheet.csv
@@ -73,4 +73,5 @@
 #cut,Cut,Изрежи,
 #alert,Alert!,Предупреждение!,
 #file_open_fail_message,"The file couldn't be opened.\nTry checking the file path, ensure that the file is not deleted, or choose a different file.","Файлът не може да бъде отворен.\nОпитайте да проверите пътя към файла, уверете се, че файла не е изтрит, или изберете различен файл.",
+#file_open_unsupported_extension,The file has an unsupported file extension and can't be opened.\nGodSVG can only open SVG files.,,
 #ok,OK,Добре,

--- a/translations/translation_sheet.csv
+++ b/translations/translation_sheet.csv
@@ -73,5 +73,6 @@
 #cut,Cut,Изрежи,
 #alert,Alert!,Предупреждение!,
 #file_open_fail_message,"The file couldn't be opened.\nTry checking the file path, ensure that the file is not deleted, or choose a different file.","Файлът не може да бъде отворен.\nОпитайте да проверите пътя към файла, уверете се, че файла не е изтрит, или изберете различен файл.",
-#file_open_unsupported_extension,The file has an unsupported file extension and can't be opened.\nGodSVG can only open SVG files.,,
+#file_open_unsupported_extension,"""{passed_extension}"" is a unsupported file extension. Only ""svg"" files are supported.",,
+#file_open_empty_extension,"The file extension is empty. Only ""svg"" files are supported.",,
 #ok,OK,Добре,


### PR DESCRIPTION
- Adds drag and drop for files and file extension checks.
- Applies file extension checks and error messages when opening from cmdline
- makes all menus and dialogs extend `Dialog` and adds a `is_open `static variable to make sure that dropped files dont get opened when there is a dialog open.
- Moves opening SVG files to the SVG script