### PR TITLE
Tag conversion and auxiliary handles

### DIFF
--- a/src/data_classes/AttributeNumeric.gd
+++ b/src/data_classes/AttributeNumeric.gd
@@ -27,6 +27,10 @@ func get_num() -> float:
 static func num_to_text(number: float) -> String:
 	return String.num(number, 4)
 
+static func text_to_num(text: String) -> float:
+	return text.to_float()
+
+
 # This function evaluates expressions even if "," or ";" is used as a decimal separator.
 static func evaluate_numeric_expression(text: String) -> float:
 	var expr := Expression.new()

--- a/src/data_classes/PathCommand.gd
+++ b/src/data_classes/PathCommand.gd
@@ -36,8 +36,9 @@ func toggle_relative() -> void:
 class MoveCommand extends PathCommand:
 	var x: float
 	var y: float
-	func _init(new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "M"
+	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "m" if p_rel else "M"
 		arg_count = 2
 		x = new_x
 		y = new_y
@@ -45,23 +46,26 @@ class MoveCommand extends PathCommand:
 class LineCommand extends PathCommand:
 	var x: float
 	var y: float
-	func _init(new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "L"
+	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "l" if p_rel else "L"
 		arg_count = 2
 		x = new_x
 		y = new_y
 
 class HorizontalLineCommand extends PathCommand:
 	var x: float
-	func _init(new_x := 0.0) -> void:
-		command_char = "H"
+	func _init(new_x := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "h" if p_rel else "H"
 		arg_count = 1
 		x = new_x
 
 class VerticalLineCommand extends PathCommand:
 	var y: float
-	func _init(new_y := 0.0) -> void:
-		command_char = "V"
+	func _init(new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "v" if p_rel else "V"
 		arg_count = 1
 		y = new_y
 
@@ -73,9 +77,10 @@ class EllipticalArcCommand extends PathCommand:
 	var sweep_flag: int
 	var x: float
 	var y: float
-	func _init(new_rx := 1.0, new_ry := 1.0, new_rot := 0.0, new_large_arc_flag := 0,
-	new_sweep_flag := 0, new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "A"
+	func _init(new_rx := 0.0, new_ry := 0.0, new_rot := 0.0, new_large_arc_flag := 0,
+	new_sweep_flag := 0, new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "a" if p_rel else "A"
 		arg_count = 7
 		rx = new_rx
 		ry = new_ry
@@ -90,8 +95,10 @@ class QuadraticBezierCommand extends PathCommand:
 	var y1: float
 	var x: float
 	var y: float
-	func _init(new_x1 := 0.0, new_y1 := 0.0, new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "Q"
+	func _init(new_x1 := 0.0, new_y1 := 0.0, new_x := 0.0, new_y := 0.0,
+	p_rel := false) -> void:
+		relative = p_rel
+		command_char = "q" if p_rel else "Q"
 		arg_count = 4
 		x1 = new_x1
 		y1 = new_y1
@@ -101,8 +108,9 @@ class QuadraticBezierCommand extends PathCommand:
 class ShorthandQuadraticBezierCommand extends PathCommand:
 	var x: float
 	var y: float
-	func _init(new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "T"
+	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "t" if p_rel else "T"
 		arg_count = 2
 		x = new_x
 		y = new_y
@@ -115,8 +123,9 @@ class CubicBezierCommand extends PathCommand:
 	var x: float
 	var y: float
 	func _init(new_x1 := 0.0, new_y1 := 0.0, new_x2 := 0.0, new_y2 := 0.0,
-	new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "C"
+	new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
+		relative = p_rel
+		command_char = "c" if p_rel else "C"
 		arg_count = 6
 		x1 = new_x1
 		y1 = new_y1
@@ -130,8 +139,10 @@ class ShorthandCubicBezierCommand extends PathCommand:
 	var y2: float
 	var x: float
 	var y: float
-	func _init(new_x2 := 0.0, new_y2 := 0.0, new_x := 0.0, new_y := 0.0) -> void:
-		command_char = "S"
+	func _init(new_x2 := 0.0, new_y2 := 0.0, new_x := 0.0, new_y := 0.0,
+	p_rel := false) -> void:
+		relative = p_rel
+		command_char = "s" if p_rel else "S"
 		arg_count = 4
 		x2 = new_x2
 		y2 = new_y2
@@ -139,5 +150,6 @@ class ShorthandCubicBezierCommand extends PathCommand:
 		y = new_y
 
 class CloseCommand extends PathCommand:
-	func _init() -> void:
-		command_char = "Z"
+	func _init(p_rel := false) -> void:
+		relative = p_rel
+		command_char = "z" if p_rel else "Z"

--- a/src/data_classes/PathDataParser.gd
+++ b/src/data_classes/PathDataParser.gd
@@ -122,24 +122,23 @@ static func path_data_to_arrays(path_string: String) -> Array[Array]:
 
 static func path_commands_from_parsed_data(data: Array[Array]) -> Array[PathCommand]:
 	var cmds: Array[PathCommand] = []
-	for arr in data:
+	for a in data:
 		var new_cmd: PathCommand
-		var cmd_type = translation_dict[arr[0].to_upper()]
-		match arr.size():
-			1: new_cmd = cmd_type.new()
-			2: new_cmd = cmd_type.new(arr[1])
-			3: new_cmd = cmd_type.new(arr[1], arr[2])
-			5: new_cmd = cmd_type.new(arr[1], arr[2], arr[3], arr[4])
-			7: new_cmd = cmd_type.new(arr[1], arr[2], arr[3], arr[4], arr[5], arr[6])
-			8: new_cmd = cmd_type.new(arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7])
-		if Utils.is_string_lower(arr[0]):
-			new_cmd.relative = true
-			new_cmd.command_char = arr[0]
+		# The idx 0 element is the command char, the rest are the arguments.
+		var cmd_type = translation_dict[a[0].to_upper()]
+		var relative := Utils.is_string_lower(a[0])
+		match a.size():
+			1: new_cmd = cmd_type.new(relative)
+			2: new_cmd = cmd_type.new(a[1], relative)
+			3: new_cmd = cmd_type.new(a[1], a[2], relative)
+			5: new_cmd = cmd_type.new(a[1], a[2], a[3], a[4], relative)
+			7: new_cmd = cmd_type.new(a[1], a[2], a[3], a[4], a[5], a[6], relative)
+			8: new_cmd = cmd_type.new(a[1], a[2], a[3], a[4], a[5], a[6], a[7], relative)
 		cmds.append(new_cmd)
 	return cmds
 
 
-static func path_commands_to_value(commands_arr: Array[PathCommand]) -> String:
+static func path_commands_to_text(commands_arr: Array[PathCommand]) -> String:
 	var generated_value := ""
 	for command in commands_arr:
 		var cmd_char := command.command_char.to_upper()

--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -5,7 +5,6 @@ var child_tags: Array[Tag]
 
 signal attribute_changed(undo_redo: bool)
 
-var name: String
 var attributes: Dictionary  # Dictionary{String: Attribute}
 
 # Attributes that aren't recognized (usually because GodSVG doesn't support them).
@@ -35,7 +34,7 @@ func create_duplicate() -> Tag:
 	var type: GDScript = get_script()
 	var new_tag: Variant
 	if type == TagUnknown:
-		new_tag = type.new(name)
+		new_tag = type.new(type.name)
 	else:
 		new_tag = type.new()
 	for attribute in new_tag.attributes:
@@ -47,3 +46,10 @@ func create_duplicate() -> Tag:
 		new_child_tags.append(tag.create_duplicate())
 	new_tag.child_tags = new_child_tags
 	return new_tag
+
+# To be overridden in extending classes.
+func can_replace(_new_tag: String) -> bool:
+	return false
+
+func get_replacement(_new_tag: String) -> Tag:
+	return null

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -1,11 +1,12 @@
 ## A <circle/> tag.
 class_name TagCircle extends Tag
 
+const name = "circle"
+const possible_conversions = ["ellipse", "rect", "path"]
 const known_attributes = ["cx", "cy", "r",
 		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 
 func _init() -> void:
-	name = "circle"
 	attributes = {
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"cy": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -18,3 +19,52 @@ func _init() -> void:
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 	}
 	super()
+
+
+func can_replace(new_tag: String) -> bool:
+	return new_tag in ["ellipse", "rect", "path"]
+
+func get_replacement(new_tag: String) -> Tag:
+	if not can_replace(new_tag):
+		return null
+	
+	var tag: Tag
+	var retained_attributes: Array[String] = []
+	match new_tag:
+		"ellipse":
+			tag = TagEllipse.new()
+			retained_attributes = ["cx", "cy", "opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			tag.attributes.rx.set_num(attributes.r.get_num(), Attribute.SyncMode.SILENT)
+			tag.attributes.ry.set_num(attributes.r.get_num(), Attribute.SyncMode.SILENT)
+		"rect":
+			tag = TagRect.new()
+			retained_attributes = ["opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			tag.attributes.x.set_num(attributes.cx.get_num() - attributes.r.get_num(),
+					Attribute.SyncMode.SILENT)
+			tag.attributes.y.set_num(attributes.cy.get_num() - attributes.r.get_num(),
+					Attribute.SyncMode.SILENT)
+			tag.attributes.width.set_num(attributes.r.get_num() * 2,
+					Attribute.SyncMode.SILENT)
+			tag.attributes.height.set_num(attributes.r.get_num() * 2,
+					Attribute.SyncMode.SILENT)
+			tag.attributes.rx.set_num(attributes.r.get_num(), Attribute.SyncMode.SILENT)
+			tag.attributes.ry.set_num(attributes.r.get_num(), Attribute.SyncMode.SILENT)
+		"path":
+			tag = TagPath.new()
+			retained_attributes = ["opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			var commands: Array[PathCommand] = []
+			commands.append(PathCommand.MoveCommand.new(attributes.cx.get_num(),
+					attributes.cy.get_num() - attributes.r.get_num(), true))
+			commands.append(PathCommand.EllipticalArcCommand.new(attributes.r.get_num(),
+					attributes.r.get_num(), 0, 0, 0, 0, attributes.r.get_num() * 2, true))
+			commands.append(PathCommand.EllipticalArcCommand.new(attributes.r.get_num(),
+					attributes.r.get_num(), 0, 0, 0, 0, -attributes.r.get_num() * 2, true))
+			commands.append(PathCommand.CloseCommand.new(true))
+			tag.attributes.d.set_commands(commands, Attribute.SyncMode.SILENT)
+	for k in retained_attributes:
+		tag.attributes[k].set_value(attributes[k].get_value(), Attribute.SyncMode.SILENT)
+	
+	return tag

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -1,11 +1,12 @@
 ## An <ellipse/> tag.
 class_name TagEllipse extends Tag
 
+const name = "ellipse"
+const possible_conversions = ["circle", "rect", "path"]
 const known_attributes = ["cx", "cy", "rx", "ry",
 		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 
 func _init() -> void:
-	name = "ellipse"
 	attributes = {
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"cy": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -19,3 +20,52 @@ func _init() -> void:
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 	}
 	super()
+
+
+func can_replace(new_tag: String) -> bool:
+	if new_tag == "circle":
+		return attributes.rx.get_num() == attributes.ry.get_num()
+	else:
+		return new_tag in ["rect", "path"]
+
+func get_replacement(new_tag: String) -> Tag:
+	if not can_replace(new_tag):
+		return null
+	
+	var tag: Tag
+	var retained_attributes: Array[String] = []
+	match new_tag:
+		"circle":
+			tag = TagCircle.new()
+			retained_attributes = ["cx", "cy", "opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			tag.attributes.r.set_num(attributes.rx.get_num(), Attribute.SyncMode.SILENT)
+		"rect":
+			tag = TagRect.new()
+			retained_attributes = ["rx", "ry", "opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			tag.attributes.x.set_num(attributes.cx.get_num() - attributes.rx.get_num(),
+					Attribute.SyncMode.SILENT)
+			tag.attributes.y.set_num(attributes.cy.get_num() - attributes.ry.get_num(),
+					Attribute.SyncMode.SILENT)
+			tag.attributes.width.set_num(attributes.rx.get_num() * 2,
+					Attribute.SyncMode.SILENT)
+			tag.attributes.height.set_num(attributes.ry.get_num() * 2,
+					Attribute.SyncMode.SILENT)
+		"path":
+			tag = TagPath.new()
+			retained_attributes = ["opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width"]
+			var commands: Array[PathCommand] = []
+			commands.append(PathCommand.MoveCommand.new(attributes.cx.get_num(),
+					attributes.cy.get_num() - attributes.ry.get_num(), true))
+			commands.append(PathCommand.EllipticalArcCommand.new(attributes.rx.get_num(),
+					attributes.ry.get_num(), 0, 0, 0, 0, attributes.ry.get_num() * 2, true))
+			commands.append(PathCommand.EllipticalArcCommand.new(attributes.rx.get_num(),
+					attributes.ry.get_num(), 0, 0, 0, 0, -attributes.ry.get_num() * 2, true))
+			commands.append(PathCommand.CloseCommand.new(true))
+			tag.attributes.d.set_commands(commands, Attribute.SyncMode.SILENT)
+	for k in retained_attributes:
+		tag.attributes[k].set_value(attributes[k].get_value(), Attribute.SyncMode.SILENT)
+	
+	return tag

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -1,11 +1,12 @@
 ## A <line/> tag.
 class_name TagLine extends Tag
 
+const name = "line"
+const possible_conversions = ["path"]
 const known_attributes = ["x1", "y1", "x2", "y2",
 		"opacity", "stroke", "stroke-opacity", "stroke-width", "stroke-linecap"]
 
 func _init() -> void:
-	name = "line"
 	attributes = {
 		"x1": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"y1": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -18,3 +19,30 @@ func _init() -> void:
 		"stroke-linecap": AttributeEnum.new(["butt", "round", "square"], 0),
 	}
 	super()
+
+
+func can_replace(new_tag: String) -> bool:
+	return new_tag == "path"
+
+func get_replacement(new_tag: String) -> Tag:
+	if not can_replace(new_tag):
+		return null
+	
+	var tag: Tag
+	var retained_attributes: Array[String] = []
+	match new_tag:
+		"path":
+			tag = TagPath.new()
+			retained_attributes = ["opacity", "stroke", "stroke-opacity",
+					"stroke-width", "stroke-linecap"]
+			var commands: Array[PathCommand] = []
+			commands.append(PathCommand.MoveCommand.new(attributes.x1.get_num(),
+					attributes.y1.get_num(), true))
+			commands.append(PathCommand.LineCommand.new(
+					attributes.x2.get_num() - attributes.x1.get_num(),
+					attributes.y2.get_num() - attributes.y1.get_num(), true))
+			tag.attributes.d.set_commands(commands, Attribute.SyncMode.SILENT)
+	for k in retained_attributes:
+		tag.attributes[k].set_value(attributes[k].get_value(), Attribute.SyncMode.SILENT)
+	
+	return tag

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -1,12 +1,12 @@
 ## A <path/> tag.
 class_name TagPath extends Tag
 
-const known_attributes = ["d",
-		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width",
-		"stroke-linecap", "stroke-linejoin"]
+const name = "path"
+const possible_conversions = []
+const known_attributes = ["d", "opacity", "fill", "fill-opacity", "stroke",
+		"stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin"]
 
 func _init() -> void:
-	name = "path"
 	attributes = {
 		"d": AttributePath.new(),
 		"opacity": AttributeNumeric.new(AttributeNumeric.Mode.NFLOAT, "1"),
@@ -19,3 +19,12 @@ func _init() -> void:
 		"stroke-linejoin": AttributeEnum.new(["miter", "round", "bevel"], 0),
 	}
 	super()
+
+func can_replace(_new_tag: String) -> bool:
+	return false
+
+func get_replacement(new_tag: String) -> Tag:
+	if not can_replace(new_tag):
+		return null
+	
+	return null

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -1,12 +1,12 @@
 ## A <rect/> tag.
 class_name TagRect extends Tag
 
-const known_attributes = ["x", "y", "width", "height", "rx", "ry",
-		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width",
-		"stroke-linejoin"]
+const name = "rect"
+const possible_conversions = ["circle", "ellipse", "path"]
+const known_attributes = ["x", "y", "width", "height", "rx", "ry", "opacity", "fill",
+		"fill-opacity", "stroke", "stroke-opacity", "stroke-width", "stroke-linejoin"]
 
 func _init() -> void:
-	name = "rect"
 	attributes = {
 		"x": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"y": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -23,3 +23,88 @@ func _init() -> void:
 		"stroke-linejoin": AttributeEnum.new(["miter", "round", "bevel"], 0),
 	}
 	super()
+
+
+func can_replace(new_tag: String) -> bool:
+	if new_tag == "ellipse":
+		return attributes.rx.get_num() >= attributes.width.get_num() / 2 and\
+				attributes.ry.get_num() >= attributes.height.get_num() / 2
+	elif new_tag == "circle":
+		var side: float = attributes.width.get_num()
+		return attributes.height.get_num() == side and\
+				attributes.rx.get_num() >= side / 2 and attributes.ry.get_num() >= side / 2
+	else:
+		return new_tag == "path"
+
+func get_replacement(new_tag: String) -> Tag:
+	if not can_replace(new_tag):
+		return null
+	
+	var tag: Tag
+	var retained_attributes: Array[String] = []
+	match new_tag:
+		"ellipse":
+			tag = TagEllipse.new()
+			retained_attributes = ["rx", "ry", "opacity", "fill",
+					"fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
+			tag.attributes.cx.set_num(attributes.x.get_num() +\
+					attributes.width.get_num() / 2, Attribute.SyncMode.SILENT)
+			tag.attributes.cy.set_num(attributes.y.get_num() +\
+					attributes.height.get_num() / 2, Attribute.SyncMode.SILENT)
+		"circle":
+			tag = TagCircle.new()
+			retained_attributes = ["opacity", "fill", "fill-opacity",
+					"stroke", "stroke-opacity", "stroke-width"]
+			tag.attributes.r.set_num(attributes.rx.get_num(), Attribute.SyncMode.SILENT)
+			tag.attributes.cx.set_num(attributes.x.get_num() +\
+					attributes.width.get_num() / 2, Attribute.SyncMode.SILENT)
+			tag.attributes.cy.set_num(attributes.y.get_num() +\
+					attributes.height.get_num() / 2, Attribute.SyncMode.SILENT)
+		"path":
+			tag = TagPath.new()
+			retained_attributes = ["opacity", "fill", "fill-opacity", "stroke",
+					"stroke-opacity", "stroke-width", "stroke-linejoin"]
+			var rx := minf(attributes.rx.get_num(), attributes.width.get_num() / 2)
+			var ry := minf(attributes.ry.get_num(), attributes.height.get_num() / 2)
+			var commands: Array[PathCommand] = []
+			if rx == 0 and ry == 0:
+				commands.append(PathCommand.MoveCommand.new(attributes.x.get_num(),
+						attributes.y.get_num(), true))
+				commands.append(PathCommand.HorizontalLineCommand.new(
+						attributes.width.get_num(), true))
+				commands.append(PathCommand.VerticalLineCommand.new(
+						attributes.height.get_num(), true))
+				commands.append(PathCommand.HorizontalLineCommand.new(
+						-attributes.width.get_num(), true))
+				commands.append(PathCommand.CloseCommand.new(true))
+			else:
+				if rx == 0:
+					rx = ry
+				elif ry == 0:
+					ry = rx
+				var w: float = attributes.width.get_num() - rx * 2
+				var h: float = attributes.height.get_num() - ry * 2
+				
+				commands.append(PathCommand.MoveCommand.new(attributes.x.get_num(),
+						attributes.y.get_num() + ry, true))
+				commands.append(PathCommand.EllipticalArcCommand.new(
+						rx, ry, 0, 0, 1, rx, -ry, true))
+				if w > 0.0:
+					commands.append(PathCommand.HorizontalLineCommand.new(w, true))
+				commands.append(PathCommand.EllipticalArcCommand.new(
+						rx, ry, 0, 0, 1, rx, ry, true))
+				if h > 0.0:
+					commands.append(PathCommand.VerticalLineCommand.new(h, true))
+				commands.append(PathCommand.EllipticalArcCommand.new(
+						rx, ry, 0, 0, 1, -rx, ry, true))
+				if w > 0.0:
+					commands.append(PathCommand.HorizontalLineCommand.new(-w, true))
+				commands.append(PathCommand.EllipticalArcCommand.new(
+						rx, ry, 0, 0, 1, -rx, -ry, true))
+				commands.append(PathCommand.CloseCommand.new(true))
+			tag.attributes.d.set_commands(commands, Attribute.SyncMode.SILENT)
+			
+	for k in retained_attributes:
+		tag.attributes[k].set_value(attributes[k].get_value(), Attribute.SyncMode.SILENT)
+	
+	return tag

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -12,13 +12,14 @@ signal tags_added(tids: Array[PackedInt32Array])
 signal tags_deleted(tids: Array[PackedInt32Array])
 signal tags_moved_in_parent(parent_tid: PackedInt32Array, old_indices: Array[int])
 signal tags_moved_to(tid: PackedInt32Array, old_tids: Array[PackedInt32Array])
-signal tag_layout_changed  # Emitted together with any of the above 4.
+signal tag_changed(tid: PackedInt32Array)
+signal tag_layout_changed  # Emitted together with any of the above 5.
 
 # This list is currently only used by the highlighter, so xmlns is here.
 const known_attributes = ["width", "height", "viewBox", "xmlns"]
+const name = "svg"
 
 func _init() -> void:
-	name = "svg"
 	attributes = {
 		"height": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, ""),
 		"width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, ""),
@@ -249,6 +250,9 @@ func replace_tag(tid: PackedInt32Array, new_tag: Tag) -> void:
 	if tid.is_empty():
 		replace_self(new_tag)
 	get_by_tid(Utils.get_parent_tid(tid)).child_tags[tid[-1]] = new_tag
+	new_tag.attribute_changed.connect(emit_child_attribute_changed)
+	tag_changed.emit(tid)
+	tag_layout_changed.emit()
 
 func emit_child_attribute_changed(undo_redo: bool) -> void:
 	child_attribute_changed.emit(undo_redo)

--- a/src/data_classes/TagUnknown.gd
+++ b/src/data_classes/TagUnknown.gd
@@ -1,5 +1,9 @@
 ## A tag not recognized by GodSVG.
 class_name TagUnknown extends Tag
 
+var name: String
+const known_attributes = []
+const possible_conversions = []
+
 func _init(new_name: String) -> void:
 	name = new_name

--- a/src/ui_elements/number_field_with_slider.gd
+++ b/src/ui_elements/number_field_with_slider.gd
@@ -60,9 +60,9 @@ func sync(new_value: String) -> void:
 	if num_edit != null:
 		num_edit.text = new_value
 		if new_value == attribute.default:
-			add_theme_color_override(&"font_color", Color(0.64, 0.64, 0.64))
+			num_edit.add_theme_color_override(&"font_color", Color(0.64, 0.64, 0.64))
 		else:
-			remove_theme_color_override(&"font_color")
+			num_edit.remove_theme_color_override(&"font_color")
 	queue_redraw()
 
 

--- a/src/ui_parts/DeltaHandle.gd
+++ b/src/ui_parts/DeltaHandle.gd
@@ -1,0 +1,39 @@
+## A handle that binds to a numeric attribute, relative to two other numeric attributes.
+class_name DeltaHandle extends Handle
+
+# Required.
+var x_attribute: AttributeNumeric
+var y_attribute: AttributeNumeric
+
+var horizontal: bool
+var d_attribute: AttributeNumeric
+
+func _init(id: PackedInt32Array, xref: AttributeNumeric, yref: AttributeNumeric,\
+dref: AttributeNumeric, p_horizontal: bool) -> void:
+	tid = id
+	x_attribute = xref
+	y_attribute = yref
+	d_attribute = dref
+	horizontal = p_horizontal
+	display_mode = Display.SMALL
+	sync()
+
+func set_pos(new_pos: Vector2, undo_redo := false) -> void:
+	if initial_pos != new_pos and undo_redo:
+		d_attribute.set_num(absf(new_pos.x - x_attribute.get_num() if horizontal else\
+				new_pos.y - y_attribute.get_num()), Attribute.SyncMode.FINAL)
+	else:
+		d_attribute.set_num(absf(new_pos.x - x_attribute.get_num() if horizontal else\
+				new_pos.y - y_attribute.get_num()), Attribute.SyncMode.FINAL if undo_redo\
+				else Attribute.SyncMode.INTERMEDIATE)
+	pos = Vector2(x_attribute.get_num(), y_attribute.get_num())
+	if horizontal:
+		pos.x += d_attribute.get_num()
+	else:
+		pos.y += d_attribute.get_num()
+
+func sync() -> void:
+	if horizontal:
+		pos = Vector2(x_attribute.get_num() + d_attribute.get_num(), y_attribute.get_num())
+	else:
+		pos = Vector2(x_attribute.get_num(), y_attribute.get_num() + d_attribute.get_num())

--- a/src/ui_parts/Handle.gd
+++ b/src/ui_parts/Handle.gd
@@ -7,7 +7,6 @@ var display_mode := Display.BIG
 var tag: Tag
 var tid := PackedInt32Array()
 var pos: Vector2
-
 var initial_pos: Vector2  # The position of a handle when it started being dragged.
 
 func _init() -> void:

--- a/src/ui_parts/PathHandle.gd
+++ b/src/ui_parts/PathHandle.gd
@@ -26,7 +26,7 @@ func set_pos(new_pos: Vector2, undo_redo := false) -> void:
 					Attribute.SyncMode.FINAL)
 	else:
 		if x_param in command:
-			# Don't emit command_changed for the X change if there'll be a Y change too.
+			# Don't emit commands_changed for the X change if there'll be a Y change too.
 			path_attribute.set_command_property(command_index, x_param, new_coords.x,
 					Attribute.SyncMode.NO_PROPAGATION if (y_param in command and\
 					command.get(y_param) != new_coords.y) else Attribute.SyncMode.INTERMEDIATE)

--- a/src/ui_parts/XYHandle.gd
+++ b/src/ui_parts/XYHandle.gd
@@ -1,15 +1,13 @@
-## A handle that binds to one or two numeric attributes.
+## A handle that binds to two numeric attributes.
 class_name XYHandle extends Handle
 
 var x_attribute: AttributeNumeric
 var y_attribute: AttributeNumeric
-var delta_x_attribute: AttributeNumeric
-var delta_y_attribute: AttributeNumeric
 
-func _init(id: PackedInt32Array, x_ref: Attribute, y_ref: Attribute) -> void:
+func _init(id: PackedInt32Array, xref: AttributeNumeric, yref: AttributeNumeric) -> void:
 	tid = id
-	x_attribute = x_ref
-	y_attribute = y_ref
+	x_attribute = xref
+	y_attribute = yref
 	sync()
 
 func set_pos(new_pos: Vector2, undo_redo := false) -> void:
@@ -26,5 +24,4 @@ func set_pos(new_pos: Vector2, undo_redo := false) -> void:
 	pos = new_pos
 
 func sync() -> void:
-	pos = Vector2(x_attribute.get_num() if x_attribute != null else 0.0,
-			y_attribute.get_num() if y_attribute != null else 0.0)
+	pos = Vector2(x_attribute.get_num(), y_attribute.get_num())

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -49,7 +49,6 @@ func _on_add_button_pressed() -> void:
 		add_btn.text = tag_name
 		add_btn.add_theme_font_override(&"font", load("res://visual/fonts/FontMono.ttf"))
 		add_btn.icon = load("res://visual/icons/tag/" + tag_name + ".svg")
-		add_btn.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		add_btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
 		add_btn.pressed.connect(add_tag.bind(tag_name))
 		btn_array.append(add_btn)


### PR DESCRIPTION
Implements the ability to convert between tag types (resolves #291)
Implements DeltaHandle to more easily edit circles, ellipses, and rects (resolves #295). NOT READY

Smaller technical things:
- Tweaks how AttributePath works to be more similar to other attributes. This was pretty much needed to convert basic shapes into paths simply.
- Tweaks PathCommands to allow specifying on initialization if they are relative. Should be a small parsing optimization, hopefully nothing breaks from it. If there are negative effects, this can be re-evaluated. This was also pretty much needed for basic shapes.
- Tag names are now initialized independently in each tag. 
- Does some small renames, fixes some small bugs.