### PR TITLE
Allow to zoom far into SVGs without an extreme performance penalty

### DIFF
--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -1,27 +1,28 @@
 extends TextureRect
 
-const strip_count = 8
-
-var rasterized := false:
-	set(new_value):
-		if new_value != rasterized:
-			rasterized = new_value
-			queue_update()
-
 var zoom := 1.0:
 	set(new_value):
 		zoom = new_value
 		queue_update()
 
+var view_rect := Rect2():
+	set(new_value):
+		view_rect = new_value
+		queue_update()
+
+var rasterized := false:
+	set(new_value):
+		if new_value != rasterized:
+			rasterized = new_value
+			if zoom != 1.0:
+				queue_update()
+
+
 var image_zoom := 0.0
 var update_pending := false
 
-# TODO a bug in ThorVG locks this. The TextureRect should be a Control.
-# I had to draw the SVG with the rendering server, I got some white textures otherwise.
-#var surface := RenderingServer.canvas_item_create()
 
 func _ready() -> void:
-	#RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
 	SVG.root_tag.tag_layout_changed.connect(queue_update)
 	SVG.root_tag.changed_unknown.connect(queue_update)
 	SVG.root_tag.attribute_changed.connect(queue_update.unbind(1))
@@ -38,50 +39,17 @@ func _process(_delta: float) -> void:
 
 
 func svg_update() -> void:
-	var bigger_side := maxf(SVG.root_tag.get_width(), SVG.root_tag.get_height())
-	# TODO Change 4096 to 16384 when performance concerns are addressed.
-	# It might actually not be needed in the future, if only the visible part is drawn.
-	image_zoom = 1.0 if rasterized else minf(zoom, 4096 / bigger_side)
+	# TODO optimize this?
+	var svg_tag := SVG.root_tag.create_duplicate()
+	svg_tag.attributes.viewBox.set_rect(view_rect)
+	svg_tag.attributes.width.set_num(view_rect.size.x)
+	svg_tag.attributes.height.set_num(view_rect.size.y)
 	
-	# TODO delete this in favor of the multithreaded solution. See godot issue 85465.
-	# The multithreaded solution uses RenderingServer.
-	# If there are bugs with it, an HBoxContainer with 8 TextureRect strips will also do.
+	image_zoom = 1.0 if rasterized else minf(zoom,
+			16384 / maxf(svg_tag.get_width(), svg_tag.get_height()))
+	
 	var img := Image.new()
-	img.load_svg_from_string(SVG.text, image_zoom)
-	img.fix_alpha_edges()  # See godot issue 82579.
+	img.load_svg_from_string(SVGParser.svg_to_text(svg_tag), image_zoom)
 	texture = ImageTexture.create_from_image(img)
-	
-	#var task_id := WorkerThreadPool.add_group_task(generate_strip, strip_count)
-	#WorkerThreadPool.wait_for_group_task_completion(task_id)
-	#queue_redraw()
-
-# Strips of the final image.
-#var svg_strips: Array[Texture2D] = [null, null, null, null, null, null, null, null]
-
-# TODO this is locked by a bug in ThorVG.
-# 4 strips to be handled by WorkerThreadPool for faster image loading.
-#func generate_strip(index: int) -> void:
-	#var svg_tag := SVG.root_tag.create_duplicate()
-	#svg_tag.attributes.width.set_value(svg_tag.get_width() / strip_count)
-	#var viewbox_attrib_value: Rect2 = svg_tag.get_viewbox()
-	#var strip_width := viewbox_attrib_value.size.x / strip_count
-	#var offset := index * strip_width
-	#svg_tag.attributes.viewBox.set_value(Rect2(viewbox_attrib_value.position +\
-			#Vector2(offset, 0), Vector2(strip_width, viewbox_attrib_value.size.y)))
-	#var svg_strip_string := SVGParser.svg_to_text(svg_tag)
-	#var img := Image.new()
-	#img.load_svg_from_string(svg_strip_string, image_zoom)
-	#svg_strips[index] = ImageTexture.create_from_image(img)
-#
-#func _draw() -> void:
-	#RenderingServer.canvas_item_clear(surface)
-	#RenderingServer.canvas_item_set_default_texture_filter(surface,
-			#RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_NEAREST if rasterized else\
-			#RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_LINEAR)
-	#for strip_idx in svg_strips.size():
-		#var strip := svg_strips[strip_idx]
-		#if strip != null:
-			#var rect := get_rect()
-			#rect.size.x /= strip_count
-			#rect.position.x += strip_idx * rect.size.x
-			#strip.draw_rect(surface, rect, false)
+	position = view_rect.position
+	size = view_rect.size

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -324,7 +324,12 @@ func _draw() -> void:
 			
 			"path":
 				var pathdata: AttributePath = attribs.d
+				if pathdata.get_command_count() == 0 or\
+				pathdata.get_command(0).command_char.to_upper() != "M":
+					continue  # Nothing to draw.
+				
 				var current_mode := InteractionType.NONE
+				
 				for cmd_idx in pathdata.get_command_count():
 					# Drawing logic.
 					var points := PackedVector2Array()

--- a/src/ui_parts/zoom_menu.gd
+++ b/src/ui_parts/zoom_menu.gd
@@ -1,7 +1,7 @@
 extends HBoxContainer
 
 const MIN_ZOOM = 0.125
-const MAX_ZOOM = 64.0
+const MAX_ZOOM = 256.0
 
 signal zoom_changed(zoom_level: float)
 signal zoom_reset_pressed
@@ -38,8 +38,14 @@ func zoom_reset() -> void:
 
 
 func update_buttons_appearance() -> void:
-	zoom_reset_button.text = String.num(zoom_level * 100,
-			2 if zoom_level < 0.1 else 1 if zoom_level < 10.0 else 0) + "%"
+	if zoom_level < 0.1:
+		zoom_reset_button.text = String.num(zoom_level * 100, 2) + "%"
+	elif zoom_level < 10.0:
+		zoom_reset_button.text = String.num(zoom_level * 100, 1) + "%"
+	elif zoom_level < 100.0:
+		zoom_reset_button.text = String.num_uint64(roundi(zoom_level * 100)) + "%"
+	else:
+		zoom_reset_button.text = String.num(zoom_level, 1) + "x"
 	
 	var is_max_zoom := zoom_level > MAX_ZOOM or is_equal_approx(zoom_level, MAX_ZOOM)
 	var is_min_zoom := zoom_level < MIN_ZOOM or is_equal_approx(zoom_level, MIN_ZOOM)


### PR DESCRIPTION
Now SVGs only render the rect that's visible on the screen.

Pros:

- There is no longer an extreme performance penalty from zooming far in (like freezing for more than a second) or changing the SVG while zoomed far in.
- You can zoom far in without any pixelation.

Cons:

- There is now a penalty for panning, but it's not noticeable usually. It can be noticeable for big SVGs, where the penalty is mostly from parsing during a tag duplication.

-----

Misc changes:

- Removed alpha edge fixing in the display texture, seems to have randomly fixed itself? This should make any render happen 4x faster.
- Increased max zoom to 256x (from 64x).
- Turns #341 into an upstream bug.