### PR TITLE
Fix a lot of bugs

### DIFF
--- a/src/Indications.gd
+++ b/src/Indications.gd
@@ -62,11 +62,6 @@ func _ready() -> void:
 	SVG.root_tag.tags_moved_to.connect(_on_tags_moved_to)
 	SVG.root_tag.changed_unknown.connect(clear_selection)
 
-## A temporary normal_select for on click.
-func temporary_normal_select(tid: PackedInt32Array) -> void:
-	if not tid in selected_tids:
-		selected_tids.append(tid.duplicate())
-		selection_changed.emit()
 
 ## Override the selected tags with a single new selected tag.
 ## If inner_idx is given, this will be an inner selection.
@@ -312,8 +307,9 @@ func _on_tags_moved_in_parent(parent_tid: PackedInt32Array, indices: Array[int])
 		selection_changed.emit()
 
 func _on_tags_moved_to(new_tids: Array[PackedInt32Array]) -> void:
-	selected_tids.clear()
-	selected_tids.append_array(new_tids.duplicate())
+	# FIXME The contributor that implemented tag drag & drop couldn't implement this.
+	# For now I'm clearing all selections to avoid crashes.
+	clear_all_selections()
 	selection_changed.emit()
 
 

--- a/src/Utils.gd
+++ b/src/Utils.gd
@@ -146,12 +146,9 @@ static func filter_tids_descendant(tids: Array[PackedInt32Array]) -> Array[Packe
 		var check_tid: PackedInt32Array = []
 		for part in tid:
 			check_tid.append(part)
-			if ( check_tid in new_tids and not check_tid == tid
-				and is_tid_parent(check_tid,tid)
-			):
+			if check_tid in new_tids and check_tid != tid and is_tid_parent(check_tid, tid):
 				return false
-		return true
-		)
+		return true)
 	return new_tids
 
 # [0] > [1] > [1, 2] > [2]

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -253,7 +253,7 @@ func move_tags_to(tids: Array[PackedInt32Array], to: PackedInt32Array) -> void:
 		reference_pos = to_parent_tag.child_tags.find(reference_pos_tag)
 	# Add back removed tags.
 	var shift_pos = 0
-	var new_tids: Array[PackedInt32Array]
+	var new_tids: Array[PackedInt32Array] = []
 	for tag in tags_to_move:
 		if reference_pos_tag and reference_pos > -1:
 			to_parent_tag.child_tags.insert(reference_pos + shift_pos, tag)

--- a/src/ui_elements/path_field.gd
+++ b/src/ui_elements/path_field.gd
@@ -48,7 +48,7 @@ func rebuild_commands() -> void:
 		var command_editor := CommandEditor.instantiate()
 		command_editor.path_command = attribute.get_command(command_idx)
 		# TODO Fix this mess, it's needed for individual path commands selection.
-		command_editor.tid = get_node(^"../../../../../..").tid
+		command_editor.tid = get_node(^"../../../../..").tid
 		command_editor.cmd_idx = command_idx
 		command_editor.cmd_update_value.connect(_update_command_value)
 		command_editor.cmd_delete.connect(_delete)

--- a/src/ui_parts/display_texture.gd
+++ b/src/ui_parts/display_texture.gd
@@ -34,12 +34,12 @@ func _process(_delta: float) -> void:
 
 
 func svg_update() -> void:
-	var image_zoom := 1.0 if rasterized else Indications.zoom
+	var image_zoom := 1.0 if rasterized and Indications.zoom > 1.0 else Indications.zoom
 	var pixel_size := 1 / image_zoom
 	
 	var svg_tag: TagSVG = SVG.root_tag.create_duplicate()
 	# Translate to canvas coords.
-	var display_rect := view_rect.grow(pixel_size)
+	var display_rect := view_rect.grow(pixel_size * 2)
 	display_rect.position = display_rect.position.snapped(Vector2(pixel_size, pixel_size))
 	display_rect.position.x = maxf(display_rect.position.x, 0.0)
 	display_rect.position.y = maxf(display_rect.position.y, 0.0)

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -35,12 +35,6 @@ func add_tag(tag_name: String) -> void:
 	SVG.root_tag.add_tag(new_tag, new_tid)
 
 
-func _on_tag_container_gui_input(event: InputEvent) -> void:
-	if event is InputEventMouseButton and event.is_pressed() and\
-	event.button_index == MOUSE_BUTTON_LEFT and not event.ctrl_pressed:
-		Indications.clear_selection()
-		Indications.clear_inner_selection()
-
 func _on_add_button_pressed() -> void:
 	var btn_array: Array[Button] = []
 	for tag_name in ["path", "circle", "ellipse", "rect", "line"]:

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://src/ui_parts/inspector.gd" id="1_16ggy"]
 [ext_resource type="PackedScene" uid="uid://bktmk76u7dsu0" path="res://src/ui_parts/root_tag_editor.tscn" id="2_jnl50"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="3_vo6hf"]
-[ext_resource type="Script" path="res://src/ui_parts/TagsContainer.gd" id="4_i4hc2"]
+[ext_resource type="Script" path="res://src/ui_parts/tag_container.gd" id="4_i4hc2"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4j4hv"]
 draw_center = false
@@ -51,6 +51,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_4j4hv")
+script = ExtResource("4_i4hc2")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/TagContainer"]
 unique_name_in_owner = true
@@ -64,8 +65,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 5
-script = ExtResource("4_i4hc2")
 
 [connection signal="pressed" from="VBoxContainer/AddButton" to="." method="_on_add_button_pressed"]
-[connection signal="gui_input" from="VBoxContainer/TagContainer" to="." method="_on_tag_container_gui_input"]
-[connection signal="mouse_exited" from="VBoxContainer/TagContainer/ScrollContainer/Tags" to="VBoxContainer/TagContainer/ScrollContainer/Tags" method="_on_mouse_exited"]
+[connection signal="gui_input" from="VBoxContainer/TagContainer" to="VBoxContainer/TagContainer" method="_on_gui_input"]
+[connection signal="mouse_exited" from="VBoxContainer/TagContainer" to="VBoxContainer/TagContainer" method="_on_mouse_exited"]

--- a/src/ui_parts/tag_container.gd
+++ b/src/ui_parts/tag_container.gd
@@ -1,26 +1,26 @@
-extends VBoxContainer
+extends PanelContainer
 
-const safe_margin = 0.18
+const safe_margin = 1 / 6.0
 
-@onready var scroll_container: ScrollContainer = %ScrollContainer
+@onready var scroll_container: ScrollContainer = $ScrollContainer
+@onready var tags: VBoxContainer = %Tags
 
 var is_drag_begin := false
 var to_refresh_mouse_exit: Control
 
 
 func _process(_delta: float) -> void:
-	# Scroll with moving draged object.
+	# Scroll with moving dragged object.
 	if scroll_container != null and is_drag_begin:
-		var working_area := scroll_container.get_global_rect()
-		var shrink_ratio := safe_margin * float(working_area.size.y)
-		var safe_area := working_area.grow_individual(0, -shrink_ratio, 0, -shrink_ratio)
-		working_area = working_area.grow_individual(0, shrink_ratio/3, 0, shrink_ratio/3)
-		var mouse_position := get_global_mouse_position()
-		if working_area.has_point(mouse_position) and not safe_area.has_point(mouse_position):
-			if safe_area.position.y < mouse_position.y:
-				scroll_container.scroll_vertical += 5
+		var full_area := scroll_container.get_global_rect()
+		var no_scroll_area := full_area.grow_individual(
+				0, -safe_margin * full_area.size.y, 0, -safe_margin * full_area.size.y)
+		var mouse_pos := get_global_mouse_position()
+		if full_area.has_point(mouse_pos) and not no_scroll_area.has_point(mouse_pos):
+			if no_scroll_area.position.y < mouse_pos.y:
+				scroll_container.scroll_vertical += 6
 			else:
-				scroll_container.scroll_vertical -= 5
+				scroll_container.scroll_vertical -= 6
 
 
 func _can_drop_data(_at_position: Vector2, current_tid: Variant) -> bool:
@@ -29,7 +29,7 @@ func _can_drop_data(_at_position: Vector2, current_tid: Variant) -> bool:
 		if child != null:
 			if child.tid in current_tid:
 				return false
-			child.determine_selection_highlight(child.DropState.DOWN)
+			child.drop_state = child.DropState.DOWN
 			to_refresh_mouse_exit = child
 		return true
 	return false
@@ -56,7 +56,7 @@ func _notification(what: int) -> void:
 func calculate_drop_location() -> Control:
 	var at_position := get_global_mouse_position()
 	var child: Control
-	for child_i in get_children():
+	for child_i in tags.get_children():
 		if at_position.y > child_i.global_position.y:
 			child = child_i
 	return child
@@ -66,7 +66,15 @@ func _on_mouse_exited() -> void:
 	if to_refresh_mouse_exit != null:
 		if is_drag_begin:
 			var state = to_refresh_mouse_exit.calculate_drop_location(get_global_mouse_position())
-			to_refresh_mouse_exit.determine_selection_highlight(state)
+			to_refresh_mouse_exit.drop_state = state
 		else:
-			to_refresh_mouse_exit.determine_selection_highlight()
+			to_refresh_mouse_exit.drop_state = to_refresh_mouse_exit.DropState.OUTSIDE
+			
 		to_refresh_mouse_exit = null
+
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.is_pressed() and\
+	event.button_index == MOUSE_BUTTON_LEFT and not event.ctrl_pressed:
+		Indications.clear_selection()
+		Indications.clear_inner_selection()

--- a/src/ui_parts/tag_editor.tscn
+++ b/src/ui_parts/tag_editor.tscn
@@ -4,72 +4,73 @@
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="2_0lxvf"]
 [ext_resource type="Texture2D" uid="uid://cmepkbqde0jh0" path="res://visual/icons/SmallMore.svg" id="2_2n846"]
 
-[node name="TagEditor" type="PanelContainer"]
-offset_right = 49.0
-offset_bottom = 30.0
+[node name="TagEditor" type="VBoxContainer"]
+offset_left = 2.0
+offset_top = 2.0
+offset_right = 55.0
+offset_bottom = 32.0
+mouse_filter = 0
+theme_override_constants/separation = 0
 script = ExtResource("1_7i0c4")
 
-[node name="Layout" type="VBoxContainer" parent="."]
-layout_mode = 2
-theme_override_constants/separation = 0
-
-[node name="Title" type="PanelContainer" parent="Layout"]
+[node name="Title" type="PanelContainer" parent="."]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="TitleBox" type="HBoxContainer" parent="Layout/Title"]
+[node name="TitleBox" type="HBoxContainer" parent="Title"]
 layout_mode = 2
 theme_override_constants/separation = 6
 alignment = 1
 
-[node name="TitleIcon" type="TextureRect" parent="Layout/Title/TitleBox"]
+[node name="TitleIcon" type="TextureRect" parent="Title/TitleBox"]
 custom_minimum_size = Vector2(18, 18)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 mouse_filter = 2
 
-[node name="TitleLabel" type="Label" parent="Layout/Title/TitleBox"]
+[node name="TitleLabel" type="Label" parent="Title/TitleBox"]
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_fonts/font = ExtResource("2_0lxvf")
 theme_override_font_sizes/font_size = 12
 horizontal_alignment = 1
 
-[node name="TitleButton" type="Button" parent="Layout/Title/TitleBox"]
+[node name="TitleButton" type="Button" parent="Title/TitleBox"]
 layout_mode = 2
 focus_mode = 0
+mouse_filter = 1
 mouse_default_cursor_shape = 2
 theme_type_variation = &"FlatButton"
 icon = ExtResource("2_2n846")
 
-[node name="Content" type="PanelContainer" parent="Layout"]
+[node name="Content" type="PanelContainer" parent="."]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="MainContainer" type="VBoxContainer" parent="Layout/Content"]
+[node name="MainContainer" type="VBoxContainer" parent="Content"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 12
 
-[node name="AttributeContainer" type="VBoxContainer" parent="Layout/Content/MainContainer"]
+[node name="AttributeContainer" type="VBoxContainer" parent="Content/MainContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="UnknownAttributes" type="HFlowContainer" parent="Layout/Content/MainContainer/AttributeContainer"]
+[node name="UnknownAttributes" type="HFlowContainer" parent="Content/MainContainer/AttributeContainer"]
 visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="PaintAttributes" type="HFlowContainer" parent="Layout/Content/MainContainer/AttributeContainer"]
+[node name="PaintAttributes" type="HFlowContainer" parent="Content/MainContainer/AttributeContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ShapeAttributes" type="HFlowContainer" parent="Layout/Content/MainContainer/AttributeContainer"]
+[node name="ShapeAttributes" type="HFlowContainer" parent="Content/MainContainer/AttributeContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
 [connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
-[connection signal="pressed" from="Layout/Title/TitleBox/TitleButton" to="." method="_on_title_button_pressed"]
+[connection signal="pressed" from="Title/TitleBox/TitleButton" to="." method="_on_title_button_pressed"]

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -43,6 +43,7 @@ func center_frame() -> void:
 	var w_ratio := available_size.x / SVG.root_tag.width
 	var h_ratio := available_size.y / SVG.root_tag.height
 	zoom_menu.set_zoom(nearest_po2(ceili(minf(w_ratio, h_ratio) * 32)) / 64.0)
+	adjust_view()
 	set_view((SVG.root_tag.get_size() - size / Indications.zoom) / 2)
 
 


### PR DESCRIPTION
Fixes bottom/right camera limit bug from a recent PR.

Fixes logic around tag selections when clicking and releasing to make moving tags nicer.

Deselects everything after tag moving (the current logic is faulty and leads to crashes, this is a temporary solution).

Resolves some warnings and errors.

Fixes tall tags having very exaggerated margins for dropping tags above/below.

Fixes tags now having 2px margins around them.

Improves performance and organization a little (I think).

Fixes being able to drop inside child tags.

Fixes bad performance when rasterizing an SVG with high resolution.

Fixes rasterized SVG flickering at the edges.