### PR TITLE
enable_pan_and_scale_gestures

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -203,6 +203,10 @@ shorthand_cubic_bezier_absolute={
 ]
 }
 
+[input_devices]
+
+pointing/android/enable_pan_and_scale_gestures=true
+
 [internationalization]
 
 locale/translations=PackedStringArray("res://translations/translation_sheet.bg.translation", "res://translations/translation_sheet.en.translation", "res://translations/translation_sheet.de.translation", "res://translations/translation_sheet.ru_RU.translation", "res://translations/translation_sheet.uk_UA.translation")


### PR DESCRIPTION
https://github.com/MewPurPur/GodSVG/issues/160#issuecomment-1792865080


this setting is necessary on Android to be able to zoom with gesture control