### PR TITLE
Merge Project Founder and Project Manager fields in About

### DIFF
--- a/AppInfo.gd
+++ b/AppInfo.gd
@@ -1,8 +1,7 @@
 ## Stores basic information about GodSVG.
 class_name AppInfo extends RefCounted
 
-const project_founders: Array[String] = ["MewPurPur"]
-const project_managers: Array[String] = ["MewPurPur"]
+const project_founder_and_manager: Array[String] = ["MewPurPur"]
 
 
 # The developers who contributed significant patches to the MIT-licensed source code

--- a/src/ui_parts/about_menu.gd
+++ b/src/ui_parts/about_menu.gd
@@ -6,8 +6,7 @@ extends PanelContainer
 func _ready() -> void:
 	version_label.text = "GodSVG " + ProjectSettings.get_setting(
 			&"application/config/version", "Version information unavailable")
-	add_section("Project Founder", AppInfo.project_founders)
-	add_section("Project Manager", AppInfo.project_managers)
+	add_section("Project Founder and Manager", AppInfo.project_founder_and_manager)
 	add_section("Developers", AppInfo.authors)
 
 func add_section(section_title: String, authors: Array[String]):


### PR DESCRIPTION
No need to separate them until the roles are actually taken by different people.