### PR TITLE
Small path command editor optimization

### DIFF
--- a/src/ui_elements/CustomSpacedHBoxContainer.gd
+++ b/src/ui_elements/CustomSpacedHBoxContainer.gd
@@ -12,7 +12,7 @@ func set_spacing_array(new_arr: Array) -> void:
 	queue_sort()
 
 func _sort_children():
-	var current_x: float = 0
+	var current_x := 0.0
 	var spacing_arr_size := _spacing_array.size()
 	
 	for i in get_child_count():

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -1,5 +1,5 @@
 ## An editor for a single path command.
-extends PanelContainer
+extends MarginContainer
 
 signal cmd_update_value(idx: int, new_value: float, property: StringName)
 signal cmd_delete(idx: int)
@@ -329,25 +329,20 @@ func _gui_input(event: InputEvent) -> void:
 			open_actions(true)
 
 func determine_selection_highlight() -> void:
-	var stylebox: StyleBox
+	RenderingServer.canvas_item_clear(get_canvas_item())
 	if Indications.semi_selected_tid == tid and cmd_idx in Indications.inner_selections:
-		stylebox = StyleBoxFlat.new()
+		var stylebox := StyleBoxFlat.new()
 		stylebox.set_corner_radius_all(3)
 		if Indications.semi_hovered_tid == tid and Indications.inner_hovered == cmd_idx:
 			stylebox.bg_color = Color(0.7, 0.7, 1.0, 0.18)
 		else:
 			stylebox.bg_color = Color(0.6, 0.6, 1.0, 0.16)
+		stylebox.draw(get_canvas_item(), Rect2(Vector2.ZERO, size))
 	elif Indications.semi_hovered_tid == tid and Indications.inner_hovered == cmd_idx:
-		stylebox = StyleBoxFlat.new()
+		var stylebox := StyleBoxFlat.new()
 		stylebox.set_corner_radius_all(3)
 		stylebox.bg_color = Color(0.8, 0.8, 1.0, 0.05)
-	else:
-		stylebox = StyleBoxEmpty.new()
-	stylebox.content_margin_left = 3
-	stylebox.content_margin_right = 2
-	stylebox.content_margin_top = 2
-	stylebox.content_margin_bottom = 2
-	add_theme_stylebox_override(&"panel", stylebox)
+		stylebox.draw(get_canvas_item(), Rect2(Vector2.ZERO, size))
 
 
 func _on_mouse_exited():

--- a/src/ui_elements/path_command_editor.tscn
+++ b/src/ui_elements/path_command_editor.tscn
@@ -1,16 +1,17 @@
-[gd_scene load_steps=6 format=3 uid="uid://dcdrc3r60bgg3"]
+[gd_scene load_steps=5 format=3 uid="uid://dcdrc3r60bgg3"]
 
 [ext_resource type="Script" path="res://src/ui_elements/path_command_editor.gd" id="1_om2fk"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="2_o5eem"]
 [ext_resource type="Texture2D" uid="uid://cmepkbqde0jh0" path="res://visual/icons/SmallMore.svg" id="3_a76tm"]
 [ext_resource type="Script" path="res://src/ui_elements/CustomSpacedHBoxContainer.gd" id="3_p38uu"]
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_sewij"]
-
-[node name="PathCommandEditor" type="PanelContainer"]
+[node name="PathCommandEditor" type="MarginContainer"]
 offset_right = 38.0
 offset_bottom = 14.0
-theme_override_styles/panel = SubResource("StyleBoxEmpty_sewij")
+theme_override_constants/margin_left = 3
+theme_override_constants/margin_top = 2
+theme_override_constants/margin_right = 2
+theme_override_constants/margin_bottom = 2
 script = ExtResource("1_om2fk")
 
 [node name="HBox" type="HBoxContainer" parent="."]


### PR DESCRIPTION
Seems to save 12ns for every path command editor.

The inspector rebuild for the fox, for example, involves 86 path command editors, so that's 1ms.