### PR TITLE
Remove all integer division warnings

### DIFF
--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -552,23 +552,19 @@ func _draw() -> void:
 	for polyline in hovered_selected_polylines:
 		draw_polyline(polyline, hover_selection_color, thickness, true)
 	
-	@warning_ignore('integer_division')
-	for i in normal_multiline.size() / 2:
+	for i in int(normal_multiline.size() / 2.0):
 		var i2 := i * 2
 		draw_line(normal_multiline[i2], normal_multiline[i2 + 1],
 				Color(default_color, tangent_alpha), tangent_thickness, true)
-	@warning_ignore('integer_division')
-	for i in selected_multiline.size() / 2:
+	for i in int(selected_multiline.size() / 2.0):
 		var i2 := i * 2
 		draw_line(selected_multiline[i2], selected_multiline[i2 + 1],
 				Color(selection_color, tangent_alpha), tangent_thickness, true)
-	@warning_ignore('integer_division')
-	for i in hovered_multiline.size() / 2:
+	for i in int(hovered_multiline.size() / 2.0):
 		var i2 := i * 2
 		draw_line(hovered_multiline[i2], hovered_multiline[i2 + 1],
 				Color(hover_color, tangent_alpha), tangent_thickness, true)
-	@warning_ignore('integer_division')
-	for i in hovered_selected_multiline.size() / 2:
+	for i in int(hovered_selected_multiline.size() / 2.0):
 		var i2 := i * 2
 		draw_line(hovered_selected_multiline[i2], hovered_selected_multiline[i2 + 1],
 				Color(hover_selection_color, tangent_alpha), tangent_thickness, true)

--- a/src/ui_parts/view_camera.gd
+++ b/src/ui_parts/view_camera.gd
@@ -45,8 +45,7 @@ func _draw() -> void:
 				minor_points.append(Vector2(i, size.y))
 		else:
 			var coord := snappedi(i + position.x, ticks_interval)
-			@warning_ignore('integer_division')
-			if (coord / ticks_interval) % rate == 0:
+			if int(float(coord) / ticks_interval) % rate == 0:
 				major_points.append(Vector2(i, 0))
 				major_points.append(Vector2(i, size.y))
 				default_font.draw_string(surface, Vector2(i * zoom_level + 4, 14),
@@ -64,8 +63,7 @@ func _draw() -> void:
 				minor_points.append(Vector2(size.x, i))
 		else:
 			var coord := snappedi(i + position.y, ticks_interval)
-			@warning_ignore('integer_division')
-			if int(coord / ticks_interval) % rate == 0:
+			if int(coord / float(ticks_interval)) % rate == 0:
 				major_points.append(Vector2(0, i))
 				major_points.append(Vector2(size.x, i))
 				default_font.draw_string(surface, Vector2(4, i * zoom_level + 14),


### PR DESCRIPTION
This removes all integer division warnings by explicitly casting types, instead of having Godot implicitly cast them. It should make the code slightly more clear, and allows us to avoid the current issue with warning_ignore not working properly (see https://github.com/godotengine/godot/issues/56592).