### PR TITLE
More small improvements to transform editing

### DIFF
--- a/src/data_classes/AttributeTransform.gd
+++ b/src/data_classes/AttributeTransform.gd
@@ -10,6 +10,12 @@ func _init(new_default: String, new_init := "") -> void:
 func _sync() -> void:
 	_transform = TransformParser.text_to_transform(get_value())
 
+func autoformat(text: String) -> String:
+	if GlobalSettings.number_enable_autoformatting:
+		return TransformParser.transform_to_text(TransformParser.text_to_transform(text))
+	else:
+		return text
+
 func set_transform(new_transform: Transform2D, sync_mode := SyncMode.LOUD) -> void:
 	_transform = new_transform
 	super.set_value(TransformParser.transform_to_text(new_transform), sync_mode)

--- a/src/ui_elements/matrix_popup.gd
+++ b/src/ui_elements/matrix_popup.gd
@@ -21,12 +21,13 @@ func initialize() -> void:
 	y2_edit.text = String.num(transform[1].y, 4)
 	o2_edit.text = String.num(transform[2].y, 4)
 
-func text_submitted(_new_text: String) -> void:
-	var new_transform := "matrix(%s %s %s %s %s %s)" % [x1_edit.text, x2_edit.text,
-			y1_edit.text, y2_edit.text, o1_edit.text, o2_edit.text]
-	matrix_edited.emit(new_transform)
+func _on_text_submitted(_new_text: String) -> void:
+	update_matrix()
 
-func focus_exited() -> void:
+func _on_focus_exited() -> void:
+	update_matrix()
+
+func update_matrix() -> void:
 	var new_transform := "matrix(%s %s %s %s %s %s)" % [x1_edit.text, x2_edit.text,
 			y1_edit.text, y2_edit.text, o1_edit.text, o2_edit.text]
 	matrix_edited.emit(new_transform)

--- a/src/ui_elements/matrix_popup.tscn
+++ b/src/ui_elements/matrix_popup.tscn
@@ -1,31 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://dyc4so8qdkmmc"]
+[gd_scene load_steps=3 format=3 uid="uid://dyc4so8qdkmmc"]
 
-[ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="1_1yplx"]
 [ext_resource type="Script" path="res://src/ui_elements/matrix_popup.gd" id="1_8jhhm"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fnyvh"]
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(1, 1, 1, 0.0666667)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_xcqgp"]
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.2, 0.34902, 0.501961, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
+[ext_resource type="PackedScene" uid="uid://dad7fkhmsooc6" path="res://src/ui_elements/number_edit.tscn" id="2_o5qpg"]
 
 [node name="MatrixPopup" type="Popup"]
 disable_3d = true
@@ -43,81 +19,51 @@ offset_bottom = 4.0
 layout_mode = 2
 columns = 3
 
-[node name="X1" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="X1" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "x1"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[node name="Y1" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="Y1" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "y1"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[node name="O1" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="O1" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "o1"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[node name="X2" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="X2" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "x2"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[node name="Y2" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="Y2" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "y2"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[node name="O2" type="LineEdit" parent="PanelContainer/GridContainer"]
+[node name="O2" parent="PanelContainer/GridContainer" instance=ExtResource("2_o5qpg")]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "o2"
-focus_mode = 1
-mouse_filter = 1
-script = ExtResource("1_1yplx")
-hover_stylebox = SubResource("StyleBoxFlat_fnyvh")
-focus_stylebox = SubResource("StyleBoxFlat_xcqgp")
 code_font_tooltip = true
 
-[connection signal="focus_exited" from="PanelContainer/GridContainer/X1" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/X1" to="." method="text_submitted"]
-[connection signal="focus_exited" from="PanelContainer/GridContainer/Y1" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/Y1" to="." method="text_submitted"]
-[connection signal="focus_exited" from="PanelContainer/GridContainer/O1" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/O1" to="." method="text_submitted"]
-[connection signal="focus_exited" from="PanelContainer/GridContainer/X2" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/X2" to="." method="text_submitted"]
-[connection signal="focus_exited" from="PanelContainer/GridContainer/Y2" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/Y2" to="." method="text_submitted"]
-[connection signal="focus_exited" from="PanelContainer/GridContainer/O2" to="." method="focus_exited"]
-[connection signal="text_submitted" from="PanelContainer/GridContainer/O2" to="." method="text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/X1" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/X1" to="." method="_on_text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/Y1" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/Y1" to="." method="_on_text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/O1" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/O1" to="." method="_on_text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/X2" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/X2" to="." method="_on_text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/Y2" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/Y2" to="." method="_on_text_submitted"]
+[connection signal="focus_exited" from="PanelContainer/GridContainer/O2" to="." method="_on_focus_exited"]
+[connection signal="text_submitted" from="PanelContainer/GridContainer/O2" to="." method="_on_text_submitted"]

--- a/src/ui_elements/number_field_with_slider.gd
+++ b/src/ui_elements/number_field_with_slider.gd
@@ -84,6 +84,11 @@ var slider_dragged := false:
 			queue_redraw()
 			if not slider_hovered:
 				get_viewport().update_mouse_cursor_state()
+				# FIXME workaround because "button_pressed" remains true
+				# if you unclick while outside of the area, for some reason.
+				# Couldn't replicate this in a minimal project.
+				remove_child(slider)
+				add_child(slider)
 
 var slider_hovered := false:
 	set(new_value):

--- a/src/ui_elements/number_field_with_slider.tscn
+++ b/src/ui_elements/number_field_with_slider.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bp2vpf7g8w8aj"]
+[gd_scene load_steps=5 format=3 uid="uid://bp2vpf7g8w8aj"]
 
 [ext_resource type="Script" path="res://src/ui_elements/number_field_with_slider.gd" id="1_ymm02"]
 [ext_resource type="Script" path="res://src/ui_elements/BetterLineEdit.gd" id="2_ytia1"]
@@ -22,34 +22,6 @@ border_width_bottom = 2
 border_color = Color(0.2, 0.34902, 0.501961, 1)
 corner_radius_top_left = 5
 corner_radius_bottom_left = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wwc4n"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-draw_center = false
-border_width_left = 1
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.152941, 0.152941, 0.2, 1)
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fd68s"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-draw_center = false
-border_width_left = 1
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.152941, 0.152941, 0.2, 1)
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
 
 [node name="NumberFieldWithSlider" type="HBoxContainer"]
 custom_minimum_size = Vector2(0, 22)
@@ -77,12 +49,10 @@ layout_mode = 2
 focus_mode = 0
 mouse_default_cursor_shape = 2
 theme_type_variation = &"LeftConnectedButtonTransparent"
-theme_override_styles/hover = SubResource("StyleBoxFlat_wwc4n")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_fd68s")
+keep_pressed_outside = true
 
 [connection signal="focus_exited" from="LineEdit" to="." method="_on_focus_exited"]
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
 [connection signal="gui_input" from="Slider" to="." method="_on_slider_gui_input"]
-[connection signal="mouse_entered" from="Slider" to="." method="_on_slider_mouse_entered"]
 [connection signal="mouse_exited" from="Slider" to="." method="_on_slider_mouse_exited"]
 [connection signal="resized" from="Slider" to="." method="_on_slider_resized"]

--- a/src/ui_elements/transform_field.gd
+++ b/src/ui_elements/transform_field.gd
@@ -48,13 +48,12 @@ func _on_focus_entered() -> void:
 func _on_text_submitted(submitted_text: String) -> void:
 	set_value(submitted_text)
 
-func matrix_popup_edited(new_matrix: String) -> void:
+func _on_matrix_popup_edited(new_matrix: String) -> void:
 	set_value(new_matrix)
 
 func sync(new_value: String) -> void:
 	if line_edit != null:
 		line_edit.text = new_value
-		
 		if new_value == attribute.default:
 			line_edit.add_theme_color_override(&"font_color", Color(0.64, 0.64, 0.64))
 		else:
@@ -64,7 +63,7 @@ func sync(new_value: String) -> void:
 func _on_button_pressed() -> void:
 	var matrix_popup := MatrixPopup.instantiate()
 	matrix_popup.transform = attribute.get_transform()
-	matrix_popup.matrix_edited.connect(matrix_popup_edited)
+	matrix_popup.matrix_edited.connect(_on_matrix_popup_edited)
 	add_child(matrix_popup)
 	matrix_popup.initialize()
 	Utils.popup_under_control(matrix_popup, line_edit)

--- a/src/ui_elements/transform_field.tscn
+++ b/src/ui_elements/transform_field.tscn
@@ -8,24 +8,20 @@
 draw_center = false
 border_width_left = 2
 border_width_top = 2
-border_width_right = 2
+border_width_right = 1
 border_width_bottom = 2
 border_color = Color(1, 1, 1, 0.0666667)
 corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h7r5w"]
 draw_center = false
 border_width_left = 2
 border_width_top = 2
-border_width_right = 2
+border_width_right = 1
 border_width_bottom = 2
 border_color = Color(0.2, 0.34902, 0.501961, 1)
 corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [node name="TransformField" type="HBoxContainer"]
@@ -42,6 +38,7 @@ theme_type_variation = &"RightConnectedLineEdit"
 script = ExtResource("2_aucxm")
 hover_stylebox = SubResource("StyleBoxFlat_ynuh7")
 focus_stylebox = SubResource("StyleBoxFlat_h7r5w")
+code_font_tooltip = true
 
 [node name="Button" type="Button" parent="."]
 custom_minimum_size = Vector2(15, 0)


### PR DESCRIPTION
Uses NumberEdit instead of LineEdits for the matrix editor, lets it handle expressions.

Fixes autoformatting not working.

Fixes hover and pressed theme on number_with_slider.

Uses code font for the "transform" attribute's hover.