### PR TITLE
Preload tag icons for performance

### DIFF
--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -3,6 +3,7 @@ class_name TagCircle extends Tag
 
 const name = "circle"
 const possible_conversions = ["ellipse", "rect", "path"]
+const icon = preload("res://visual/icons/tag/circle.svg")
 
 const known_shape_attributes = ["cx", "cy", "r"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -3,6 +3,7 @@ class_name TagEllipse extends Tag
 
 const name = "ellipse"
 const possible_conversions = ["circle", "rect", "path"]
+const icon = preload("res://visual/icons/tag/ellipse.svg")
 
 const known_shape_attributes = ["cx", "cy", "rx", "ry"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -3,6 +3,7 @@ class_name TagLine extends Tag
 
 const name = "line"
 const possible_conversions = ["path"]
+const icon = preload("res://visual/icons/tag/line.svg")
 
 const known_shape_attributes = ["x1", "y1", "x2", "y2"]
 const known_inheritable_attributes = ["transform", "opacity", "stroke", "stroke-opacity",

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -3,6 +3,7 @@ class_name TagPath extends Tag
 
 const name = "path"
 const possible_conversions = []
+const icon = preload("res://visual/icons/tag/path.svg")
 
 const known_shape_attributes = ["d"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -3,6 +3,7 @@ class_name TagRect extends Tag
 
 const name = "rect"
 const possible_conversions = ["circle", "ellipse", "path"]
+const icon = preload("res://visual/icons/tag/rect.svg")
 
 const known_shape_attributes = ["x", "y", "width", "height", "rx", "ry"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",

--- a/src/data_classes/TagUnknown.gd
+++ b/src/data_classes/TagUnknown.gd
@@ -5,6 +5,7 @@ var name: String
 const possible_conversions = []
 const known_shape_attributes = []
 const known_inheritable_attributes = []
+const icon = preload("res://visual/icons/tag/unknown.svg")
 
 func _init(new_name: String) -> void:
 	name = new_name

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -39,7 +39,7 @@ func _on_add_button_pressed() -> void:
 	var btn_array: Array[Button] = []
 	for tag_name in ["path", "circle", "ellipse", "rect", "line"]:
 		var btn := Utils.create_btn(tag_name, add_tag.bind(tag_name), false,
-				load("res://visual/icons/tag/" + tag_name + ".svg"))
+				load("res://visual/icons/tag/%s.svg" % tag_name))
 		btn.add_theme_font_override(&"font", load("res://visual/fonts/FontMono.ttf"))
 		btn_array.append(btn)
 	

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -1,7 +1,5 @@
 extends VBoxContainer
 
-const unknown_icon = preload("res://visual/icons/tag/unknown.svg")
-
 const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 const TagEditor = preload("tag_editor.tscn")
 const TransformField = preload("res://src/ui_elements/transform_field.tscn")
@@ -39,8 +37,7 @@ func _ready() -> void:
 	RenderingServer.canvas_item_set_z_index(surface, 1)
 	title_label.text = tag.name
 	Utils.set_max_text_width(title_label, 180.0, 0.0)  # Handle TagUnknown gracefully.
-	title_icon.texture = unknown_icon if tag is TagUnknown\
-			else load("res://visual/icons/tag/" + tag.name + ".svg")
+	title_icon.texture = tag.icon
 	Indications.selection_changed.connect(determine_selection_highlight)
 	Indications.hover_changed.connect(determine_selection_highlight)
 	determine_selection_highlight()


### PR DESCRIPTION
I added a const dictionary in Utils that maps the names of tags to their icons. This improves performance and makes the code a little cleaner. While I did add the dictionary to Utils, it could just as easily go in one of the other autoloads instead if that would be preferred.