### PR TITLE
Improve transform editor a little

### DIFF
--- a/src/data_classes/AttributeTransform.gd
+++ b/src/data_classes/AttributeTransform.gd
@@ -3,9 +3,9 @@ class_name AttributeTransform extends Attribute
 
 var _transform := Transform2D.IDENTITY
 
-func _init(new_default: String, new_init := "") -> void:
-	default = new_default
-	set_value(new_init if !new_init.is_empty() else new_default, SyncMode.SILENT)
+func _init() -> void:
+	default = ""
+	set_value(default, SyncMode.SILENT)
 
 func _sync() -> void:
 	_transform = TransformParser.text_to_transform(get_value())

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -10,7 +10,7 @@ const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opac
 
 func _init() -> void:
 	attributes = {
-		"transform": AttributeTransform.new("matrix(1 0 0 1 0 0)"),
+		"transform": AttributeTransform.new(),
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"cy": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"r": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "0", "1"),

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -10,7 +10,7 @@ const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opac
 
 func _init() -> void:
 	attributes = {
-		"transform": AttributeTransform.new("matrix(1 0 0 1 0 0)"),
+		"transform": AttributeTransform.new(),
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"cy": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"rx": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "0", "1"),

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -10,7 +10,7 @@ const known_inheritable_attributes = ["transform", "opacity", "stroke", "stroke-
 
 func _init() -> void:
 	attributes = {
-		"transform": AttributeTransform.new("matrix(1 0 0 1 0 0)"),
+		"transform": AttributeTransform.new(),
 		"x1": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"y1": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"x2": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0", "1"),

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -10,7 +10,7 @@ const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opac
 
 func _init() -> void:
 	attributes = {
-		"transform": AttributeTransform.new("matrix(1 0 0 1 0 0)"),
+		"transform": AttributeTransform.new(),
 		"d": AttributePath.new(),
 		"opacity": AttributeNumeric.new(AttributeNumeric.Mode.NFLOAT, "1"),
 		"fill": AttributeColor.new("#000"),

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -10,7 +10,7 @@ const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opac
 
 func _init() -> void:
 	attributes = {
-		"transform": AttributeTransform.new("matrix(1 0 0 1 0 0)"),
+		"transform": AttributeTransform.new(),
 		"x": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"y": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
 		"width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "0", "1"),

--- a/src/ui_elements/matrix_popup.tscn
+++ b/src/ui_elements/matrix_popup.tscn
@@ -6,7 +6,7 @@
 [node name="MatrixPopup" type="Popup"]
 disable_3d = true
 transparent_bg = true
-size = Vector2i(128, 150)
+size = Vector2i(128, 52)
 visible = true
 script = ExtResource("1_8jhhm")
 

--- a/src/ui_elements/path_field.tscn
+++ b/src/ui_elements/path_field.tscn
@@ -68,6 +68,7 @@ custom_minimum_size = Vector2(344, 0)
 layout_mode = 2
 size_flags_horizontal = 0
 focus_mode = 1
+placeholder_text = "No path data"
 script = ExtResource("2_48xgh")
 hover_stylebox = SubResource("StyleBoxFlat_4rmxx")
 focus_stylebox = SubResource("StyleBoxFlat_wqlhg")

--- a/src/ui_elements/transform_field.tscn
+++ b/src/ui_elements/transform_field.tscn
@@ -35,6 +35,7 @@ size_flags_horizontal = 3
 focus_mode = 1
 mouse_filter = 1
 theme_type_variation = &"RightConnectedLineEdit"
+placeholder_text = "No transforms"
 script = ExtResource("2_aucxm")
 hover_stylebox = SubResource("StyleBoxFlat_ynuh7")
 focus_stylebox = SubResource("StyleBoxFlat_h7r5w")

--- a/visual/main_theme.tres
+++ b/visual/main_theme.tres
@@ -795,6 +795,7 @@ LeftConnectedLineEdit/styles/normal = SubResource("StyleBoxFlat_k1x4s")
 LeftConnectedLineEdit/styles/read_only = SubResource("StyleBoxFlat_ff1pj")
 LineEdit/colors/caret_color = Color(0.866667, 0.933333, 1, 0.866667)
 LineEdit/colors/font_color = Color(0.866667, 0.933333, 1, 1)
+LineEdit/colors/font_placeholder_color = Color(1, 1, 1, 0.333333)
 LineEdit/colors/selection_color = Color(0.4, 0.54902, 1, 0.4)
 LineEdit/font_sizes/font_size = 12
 LineEdit/fonts/font = ExtResource("5_nfqug")


### PR DESCRIPTION
Fixes oversized matrix popup. Changes AttributeTransform to default to an empty string, making it represented by a "No transforms" placeholder.