### PR TITLE
Subpath selection with Ctrl

### DIFF
--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -307,7 +307,8 @@ func _gui_input(event: InputEvent) -> void:
 	elif event is InputEventMouseButton and event.is_pressed():
 		if event.button_index == MOUSE_BUTTON_LEFT:
 			if event.double_click:
-				Indications.clear_inner_selection()
+				# Unselect the tag, so then it's selected again.
+				Indications.ctrl_select(tid, cmd_idx)
 				var subpath_range: Vector2i =\
 						SVG.root_tag.get_by_tid(tid).attributes.d.get_subpath(cmd_idx)
 				for idx in range(subpath_range.x, subpath_range.y + 1):

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -700,8 +700,9 @@ func _unhandled_input(event: InputEvent) -> void:
 			if hovered_handle is PathHandle:
 				inner_idx = hovered_handle.command_index
 			
-			if event.double_click and hovered_handle is PathHandle:
-				Indications.clear_inner_selection()
+			if event.double_click and inner_idx != -1:
+				# Unselect the tag, so then it's selected again.
+				Indications.ctrl_select(dragged_tid, inner_idx)
 				var subpath_range: Vector2i =\
 						hovered_handle.path_attribute.get_subpath(inner_idx)
 				for idx in range(subpath_range.x, subpath_range.y + 1):


### PR DESCRIPTION
Now you can select multiple subpaths with Ctrl, instead of the old one randomly being unselected.