### PR TITLE
Remove unnecessary add_child() call

### DIFF
--- a/src/Indications.gd
+++ b/src/Indications.gd
@@ -506,7 +506,6 @@ func get_insert_command_after_context() -> Popup:
 		"C", "S": command_picker.disable_invalid(["T"])
 		"Q", "T": command_picker.disable_invalid(["S"])
 	command_picker.path_command_picked.connect(insert_inner_after_selection)
-	add_child(command_picker)
 	return command_picker
 
 func convert_selected_tag_to(tag_name: String) -> void:

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -200,13 +200,6 @@ func update_value(new_value: float, property: StringName) -> void:
 func toggle_relative() -> void:
 	get_path_attribute().toggle_relative_command(cmd_idx)
 
-func open_actions(popup_from_mouse := false) -> void:
-	if popup_from_mouse:
-		Utils.popup_under_mouse(Indications.get_selection_context(),
-				get_global_mouse_position())
-	else:
-		Utils.popup_under_control_centered(Indications.get_selection_context(), more_button)
-
 
 func _ready() -> void:
 	Indications.selection_changed.connect(determine_selection_state)
@@ -274,7 +267,8 @@ func _gui_input(event: InputEvent) -> void:
 			if Indications.semi_selected_tid != tid or\
 			not cmd_idx in Indications.inner_selections:
 				Indications.normal_select(tid, cmd_idx)
-			open_actions(true)
+			Utils.popup_under_mouse(Indications.get_selection_context(),
+					get_global_mouse_position())
 
 
 var current_interaction_state := Utils.InteractionType.NONE
@@ -310,7 +304,7 @@ func _on_mouse_exited():
 	Indications.remove_inner_hovered(tid, cmd_idx)
 
 func _on_more_button_pressed() -> void:
-	open_actions()
+	Utils.popup_under_control_centered(Indications.get_selection_context(), more_button)
 
 func get_path_attribute() -> AttributePath:
 	return SVG.root_tag.get_tag(tid).attributes.d

--- a/translations/translation_sheet.csv
+++ b/translations/translation_sheet.csv
@@ -25,7 +25,7 @@
 #snap_size,Snap size,Размер на захващането,Einrastgröße,Размер привязки,Розмір прилипання
 #copy_button_tooltip,Copy All Text,Копирай всичкия текст,Text kopieren,Скопировать весь текст,Скопіювати весь текст
 #import_button_tooltip,Import SVG,Импорт на SVG,SVG importieren,Импортировать SVG,Імпортувати SVG
-#export_button_tooltip,Export SVG,Експорт на SVG,SVG exportieren,Экспортировать SVG,Експортувати SVG
+#export_button_tooltip,Export,Експорт,Exportieren,Экспортировать,Експортувати
 #couple_button_tooltip,Couple/Decouple,Свържи/Отвържи,Koppeln/Entkoppeln,Объединить/Разъединить,З’єднати/Роз’єднати
 #duplicate,Duplicate,Дублирай,Duplizieren,Дублировать,Дублювати
 #move_up,Move Up,Премести нагоре,Nach oben,Подвинуть вверх,Пересунути вгору


### PR DESCRIPTION
Removes a warning and simplifies a bit of code, also changes "Export SVG" to just "Export" as it was misleading.