### PR TITLE
Minor fixups and polish of path command editors

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -59,6 +59,7 @@ timers/tooltip_delay_sec=0.4
 import={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":0,"physical_keycode":79,"key_label":0,"unicode":111,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"echo":false,"script":null)
 ]
 }
 export={

--- a/src/ui_elements/flag_field.tscn
+++ b/src/ui_elements/flag_field.tscn
@@ -1,7 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://br8g7w38jguh4"]
+[gd_scene load_steps=6 format=3 uid="uid://br8g7w38jguh4"]
 
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="1_p8s8y"]
 [ext_resource type="Script" path="res://src/ui_elements/flag_field.gd" id="2_0bhg4"]
+
+[sub_resource type="FontVariation" id="FontVariation_46ud6"]
+base_font = ExtResource("1_p8s8y")
+spacing_top = -1
+spacing_bottom = -1
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_oo47u"]
 content_margin_left = 5.0
@@ -21,19 +26,20 @@ content_margin_right = 5.0
 content_margin_bottom = 0.0
 bg_color = Color(0.12, 0.4, 0.12, 1)
 border_width_bottom = 2
-border_color = Color(0.4675, 0.85, 0.085, 1)
+border_color = Color(0.466667, 0.85098, 0.0862745, 1)
 corner_radius_top_left = 3
 corner_radius_top_right = 3
 
 [node name="FlagField" type="Button"]
-offset_right = 13.0
-offset_bottom = 20.0
+custom_minimum_size = Vector2(0, 18)
+offset_right = 19.0
+offset_bottom = 18.0
 focus_mode = 0
 mouse_filter = 1
 mouse_default_cursor_shape = 2
 theme_override_colors/font_color = Color(1, 0.75, 0.75, 1)
 theme_override_colors/font_pressed_color = Color(0.74902, 1, 0.74902, 1)
-theme_override_fonts/font = ExtResource("1_p8s8y")
+theme_override_fonts/font = SubResource("FontVariation_46ud6")
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_oo47u")
 theme_override_styles/hover = SubResource("StyleBoxFlat_oo47u")

--- a/src/ui_elements/mini_number_field.tscn
+++ b/src/ui_elements/mini_number_field.tscn
@@ -15,9 +15,9 @@ border_color = Color(0.501961, 1, 1, 0.4)
 corner_detail = 1
 
 [node name="MiniNumberField" type="LineEdit"]
-custom_minimum_size = Vector2(44, 19)
+custom_minimum_size = Vector2(0, 18)
 offset_right = 44.0
-offset_bottom = 19.0
+offset_bottom = 14.0
 mouse_filter = 1
 theme_type_variation = &"MiniLineEdit"
 script = ExtResource("1_ggi5v")

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -112,10 +112,8 @@ func _draw() -> void:
 	if not active:
 		# Draw the relative/absolute button.
 		var relative_button_rect := Rect2(Vector2(3, 2), Vector2(18, size.y - 4))
-		if Utils.is_string_upper(cmd_char):
-			draw_style_box(absolute_button_normal, relative_button_rect)
-		else:
-			draw_style_box(relative_button_normal, relative_button_rect)
+		draw_style_box(absolute_button_normal if Utils.is_string_upper(cmd_char) else\
+				relative_button_normal, relative_button_rect)
 		draw_string(code_font, Vector2(6, size.y - 6), cmd_char,
 				HORIZONTAL_ALIGNMENT_CENTER, 12, 13)
 		# Draw the action button.
@@ -128,18 +126,18 @@ func _draw() -> void:
 				var stylebox := get_theme_stylebox(&"normal", &"MiniLineEdit")
 				var font_size := get_theme_font_size(&"font_size", &"MiniLineEdit")
 				var font_color := get_theme_color(&"font_outline_color", &"MiniLineEdit")
-				var rect := Rect2(Vector2(25, 2), Vector2(44, 19))
+				var rect := Rect2(Vector2(25, 2), Vector2(44, 18))
 				draw_numfield(rect, stylebox, &"rx", font_size, font_color)
 				rect.position.x = rect.end.x + 3
 				draw_numfield(rect, stylebox, &"ry", font_size, font_color)
 				rect.position.x = rect.end.x + 4
 				draw_numfield(rect, stylebox, &"rot", font_size, font_color)
 				rect.position.x = rect.end.x + 4
-				rect.size = Vector2(19, 20)
+				rect.size.x = 19
 				var flag_field := FlagField.instantiate()
 				draw_style_box(flag_field.get_theme_stylebox(&"normal" if\
 						path_command.large_arc_flag == 0 else &"pressed"), rect)
-				draw_string(code_font, rect.position + Vector2(5, 15),
+				draw_string(code_font, rect.position + Vector2(5, 14),
 						NumberArrayParser.num_to_text(path_command.large_arc_flag),
 						HORIZONTAL_ALIGNMENT_LEFT, rect.size.x, 14,
 						flag_field.get_theme_color(&"font_color" if\
@@ -147,14 +145,14 @@ func _draw() -> void:
 				rect.position.x = rect.end.x + 4
 				draw_style_box(flag_field.get_theme_stylebox(&"normal" if\
 						path_command.sweep_flag == 0 else &"pressed"), rect)
-				draw_string(code_font, rect.position + Vector2(5, 15),
+				draw_string(code_font, rect.position + Vector2(5, 14),
 						NumberArrayParser.num_to_text(path_command.sweep_flag),
 						HORIZONTAL_ALIGNMENT_LEFT, rect.size.x, 14,
 						flag_field.get_theme_color(&"font_color" if\
 						path_command.sweep_flag == 0 else &"font_pressed_color"))
 				flag_field.free()
 				rect.position.x = rect.end.x + 4
-				rect.size = Vector2(44, 19)
+				rect.size.x = 44
 				draw_numfield(rect, stylebox, &"x", font_size, font_color)
 				rect.position.x = rect.end.x + 3
 				draw_numfield(rect, stylebox, &"y", font_size, font_color)
@@ -166,13 +164,13 @@ func _draw() -> void:
 				var stylebox := get_theme_stylebox(&"normal", &"MiniLineEdit")
 				var font_size := get_theme_font_size(&"font_size", &"MiniLineEdit")
 				var font_color := get_theme_color(&"font_outline_color", &"MiniLineEdit")
-				var rect := Rect2(Vector2(25, 2), Vector2(44, 19))
+				var rect := Rect2(Vector2(25, 2), Vector2(44, 18))
 				draw_numfield(rect, stylebox, &"x", font_size, font_color)
 			"V":
 				var stylebox := get_theme_stylebox(&"normal", &"MiniLineEdit")
 				var font_size := get_theme_font_size(&"font_size", &"MiniLineEdit")
 				var font_color := get_theme_color(&"font_outline_color", &"MiniLineEdit")
-				var rect := Rect2(Vector2(25, 2), Vector2(44, 19))
+				var rect := Rect2(Vector2(25, 2), Vector2(44, 18))
 				draw_numfield(rect, stylebox, &"y", font_size, font_color)
 
 func draw_numfield(rect: Rect2, stylebox: StyleBoxFlat, property: StringName,\
@@ -186,7 +184,7 @@ func draw_numfield_arr(spacings: Array, names: Array[StringName]) -> void:
 	var stylebox := get_theme_stylebox(&"normal", &"MiniLineEdit")
 	var font_size := get_theme_font_size(&"font_size", &"MiniLineEdit")
 	var font_color := get_theme_color(&"font_outline_color", &"MiniLineEdit")
-	var rect := Rect2(Vector2(25, 2), Vector2(44, 19))
+	var rect := Rect2(Vector2(25, 2), Vector2(44, 18))
 	draw_numfield(rect, stylebox, names[0], font_size, font_color)
 	for i in spacings.size():
 		rect.position.x = rect.end.x + spacings[i]
@@ -218,10 +216,11 @@ func _on_mouse_entered() -> void:
 	relative_button.focus_mode = Control.FOCUS_NONE
 	relative_button.mouse_filter = Control.MOUSE_FILTER_PASS
 	relative_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
-	relative_button.add_theme_font_override(&"font", code_font)
-	relative_button.add_theme_font_size_override(&"font_size", 13)
 	relative_button.text = cmd_char
 	relative_button.begin_bulk_theme_override()
+	relative_button.add_theme_font_override(&"font", code_font)
+	relative_button.add_theme_font_size_override(&"font_size", 13)
+	relative_button.add_theme_color_override(&"font_color", Color(1, 1, 1))
 	if Utils.is_string_upper(cmd_char):
 		relative_button.tooltip_text = "%s (%s)" %\
 				[Utils.path_command_char_dict[cmd_char.to_upper()], tr(&"absolute")]

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -6,7 +6,8 @@ const autoformat_menu = preload("res://src/ui_parts/autoformat_menu.tscn")
 @onready var code_edit: TextEdit = $ScriptEditor/SVGCodeEdit
 @onready var error_bar: PanelContainer = $ScriptEditor/ErrorBar
 @onready var error_label: RichTextLabel = $ScriptEditor/ErrorBar/Label
-@onready var size_label: Label = %SizeLabel
+@onready var size_label: Label = %SizeLabelContainer/SizeLabel
+@onready var size_label_container: PanelContainer = %SizeLabelContainer
 @onready var file_button: Button = %FileButton
 
 func _ready() -> void:
@@ -89,7 +90,9 @@ func _input(event: InputEvent) -> void:
 
 
 func update_size_label() -> void:
-	size_label.text = String.humanize_size(code_edit.text.length())
+	var svg_text_size := SVG.text.length()
+	size_label.text = String.humanize_size(svg_text_size)
+	size_label_container.tooltip_text = String.num_uint64(svg_text_size) + " B"
 
 func update_file_button() -> void:
 	var file_path := GlobalSettings.save_data.current_file_path

--- a/src/ui_parts/code_editor.tscn
+++ b/src/ui_parts/code_editor.tscn
@@ -13,7 +13,7 @@
 content_margin_left = 8.0
 content_margin_top = 3.0
 content_margin_right = 6.0
-content_margin_bottom = 2.0
+content_margin_bottom = 1.0
 bg_color = Color(0.0975, 0.0975, 0.15, 1)
 border_width_left = 2
 border_width_top = 2
@@ -84,13 +84,13 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
 icon = ExtResource("2_k8onw")
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/CodeButtons"]
+[node name="SizeLabelContainer" type="PanelContainer" parent="PanelContainer/CodeButtons"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 theme_override_styles/panel = SubResource("StyleBoxFlat_rppt3")
 
-[node name="SizeLabel" type="Label" parent="PanelContainer/CodeButtons/PanelContainer"]
-unique_name_in_owner = true
+[node name="SizeLabel" type="Label" parent="PanelContainer/CodeButtons/SizeLabelContainer"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("2_p4nol")
 theme_override_font_sizes/font_size = 12


### PR DESCRIPTION
Tweaks some sizes and colors of the things in path command editors. Also adds a tooltip of the actual SVG size to the label that tells its size, and a Ctrl+I alternative shortcut for importing.