### PR TITLE
Expand the functionality of drag-adding handles

### DIFF
--- a/src/Indications.gd
+++ b/src/Indications.gd
@@ -22,7 +22,7 @@ signal selection_changed
 signal proposed_drop_changed
 
 # The viewport listens for this signal to put you in handle-placing mode.
-signal added_path_handle
+signal added_object
 
 # The PackedInt32Array holds the hierarchical orders. TID means Tag ID.
 # For example, the 5th child of the 2nd child of the root tag would be (1, 4).
@@ -376,14 +376,14 @@ func _unhandled_input(event: InputEvent) -> void:
 								return
 							path_attrib.insert_command(path_cmd_count, path_cmd_char)
 							normal_select(selected_tids[0], path_cmd_count)
-							added_path_handle.emit()
+							added_object.emit()
 							break
 			return
 		
 		for action_name in path_actions_dict.keys():
 			if event.is_action_pressed(action_name):
 				insert_inner_after_selection(path_actions_dict[action_name])
-				added_path_handle.emit()
+				added_object.emit()
 				break
 
 

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -25,6 +25,10 @@ func _init() -> void:
 	super()
 
 
+func move_to(pos: Vector2) -> void:
+	attributes.cx.set_num(pos.x, Attribute.SyncMode.NO_PROPAGATION)
+	attributes.cy.set_num(pos.y, Attribute.SyncMode.INTERMEDIATE)
+
 func can_replace(new_tag: String) -> bool:
 	return new_tag in ["ellipse", "rect", "path"]
 

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -26,6 +26,10 @@ func _init() -> void:
 	super()
 
 
+func move_to(pos: Vector2) -> void:
+	attributes.cx.set_num(pos.x, Attribute.SyncMode.NO_PROPAGATION)
+	attributes.cy.set_num(pos.y, Attribute.SyncMode.INTERMEDIATE)
+
 func can_replace(new_tag: String) -> bool:
 	if new_tag == "circle":
 		return attributes.rx.get_num() == attributes.ry.get_num()

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -25,6 +25,14 @@ func _init() -> void:
 	super()
 
 
+func move_to(pos: Vector2) -> void:
+	attributes.x1.set_num(pos.x, Attribute.SyncMode.INTERMEDIATE if\
+			attributes.y1.get_num() == pos.y else Attribute.SyncMode.NO_PROPAGATION)
+	attributes.y1.set_num(pos.y, Attribute.SyncMode.INTERMEDIATE)
+	attributes.x2.set_num(pos.x + 1, Attribute.SyncMode.INTERMEDIATE if\
+			attributes.y2.get_num() == pos.y else Attribute.SyncMode.NO_PROPAGATION)
+	attributes.y2.set_num(pos.y, Attribute.SyncMode.INTERMEDIATE)
+
 func can_replace(new_tag: String) -> bool:
 	return new_tag == "path"
 

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -24,6 +24,15 @@ func _init() -> void:
 	}
 	super()
 
+
+func move_to(pos: Vector2) -> void:
+	# Since this function is currently only used when adding a tag,
+	# there's no logic for anything more than just a single MoveCommand.
+	if attributes.d.get_command_count() == 1 and\
+	attributes.d.get_command(0) is PathCommand.MoveCommand:
+		attributes.d.set_command_property(0, &"x", pos.x, Attribute.SyncMode.NO_PROPAGATION)
+		attributes.d.set_command_property(0, &"y", pos.y, Attribute.SyncMode.INTERMEDIATE)
+
 func can_replace(_new_tag: String) -> bool:
 	return false
 

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -29,6 +29,10 @@ func _init() -> void:
 	super()
 
 
+func move_to(pos: Vector2) -> void:
+	attributes.x.set_num(pos.x, Attribute.SyncMode.NO_PROPAGATION)
+	attributes.y.set_num(pos.y, Attribute.SyncMode.INTERMEDIATE)
+
 func can_replace(new_tag: String) -> bool:
 	if new_tag == "ellipse":
 		return attributes.rx.get_num() >= attributes.width.get_num() / 2 and\

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -46,9 +46,6 @@ func add_numfield() -> BetterLineEdit:
 	new_field.focus_entered.connect(Indications.normal_select.bind(tid, cmd_idx))
 	return new_field
 
-func add_flagfield() -> Button:
-	return FlagField.instantiate()
-
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion and event.button_mask == 0:
@@ -260,8 +257,8 @@ func _on_mouse_entered() -> void:
 			field_rx.mode = field_rx.Mode.ONLY_POSITIVE
 			field_ry.mode = field_ry.Mode.ONLY_POSITIVE
 			field_rot.mode = field_rot.Mode.HALF_ANGLE
-			fields = [field_rx, field_ry, field_rot, add_flagfield(), add_flagfield(),
-					add_numfield(), add_numfield()]
+			fields = [field_rx, field_ry, field_rot, FlagField.instantiate(),
+					FlagField.instantiate(), add_numfield(), add_numfield()]
 			setup_fields([3, 4, 4, 4, 4, 3],
 					["rx", "ry", "rot", "large_arc_flag", "sweep_flag", "x", "y"])
 		"C":

--- a/src/ui_parts/Handle.gd
+++ b/src/ui_parts/Handle.gd
@@ -4,7 +4,6 @@ class_name Handle extends RefCounted
 enum Display {BIG, SMALL}
 var display_mode := Display.BIG
 
-var tag: Tag
 var tid := PackedInt32Array()
 var pos: Vector2
 var transform : Transform2D

--- a/src/ui_parts/PathHandle.gd
+++ b/src/ui_parts/PathHandle.gd
@@ -7,7 +7,7 @@ var command_index: int
 var x_param: StringName
 var y_param: StringName
 
-func _init(id: PackedInt32Array, path_ref: Attribute,t_ref: AttributeTransform,
+func _init(id: PackedInt32Array, path_ref: Attribute, t_ref: AttributeTransform,
 command_idx: int, x_name := &"x", y_name := &"y") -> void:
 	path_attribute = path_ref
 	t_attribute = t_ref


### PR DESCRIPTION
**Half finished:** Make it so when you're doing things from the new viewport context popup, newly added path commands or tags get snapped to your mouse until you click, only then they get conclusively added.
**Half finished:** Make it so when you're adding curves in the viewport, the bezier handles don't overlap with the main handles. (Resolves #395)

The current idea is that when something is added, its handle gets flagged as being dragged. This no longer would apply to only path command handles, but also to XY handles like the ones in tags like \<circle>.

There's a catch though, that only that handle would be dragged, even though multiple handles might need to move, for example in \<line> and in the new curve logic. My current idea for solving this is to remove and re-add the tag every frame to recalculate how it would be added.

I'm also thinking that tags that can be added in the viewport might need some inner logic for "moving them" that takes a Vector2. This would resolve the difficulty with \<line> having two handles.