### PR TITLE
Fix .png extension after saving a png

### DIFF
--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -64,20 +64,25 @@ func _on_undo_redo() -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed(&"redo"):
+		get_viewport().set_input_as_handled()
 		if UR.has_redo():
 			UR.redo()
 			update_tags()
-		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed(&"undo"):
+		get_viewport().set_input_as_handled()
 		if UR.has_undo():
 			UR.undo()
 			update_tags()
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"import"):
 		get_viewport().set_input_as_handled()
-	elif event.is_action_pressed(&"import"):
 		open_import_dialog()
 	elif event.is_action_pressed(&"export"):
+		get_viewport().set_input_as_handled()
 		open_export_dialog()
 	elif event.is_action_pressed(&"save"):
+		get_viewport().set_input_as_handled()
 		open_save_dialog("svg", native_file_save, save_svg_to_file)
 
 

--- a/src/ui_parts/export_dialog.gd
+++ b/src/ui_parts/export_dialog.gd
@@ -56,7 +56,6 @@ func export(path: String) -> void:
 		path += "." + extension
 	
 	GlobalSettings.modify_save_data(&"last_used_dir", path.get_base_dir())
-	GlobalSettings.modify_save_data(&"current_file_path", path)
 	
 	match extension:
 		"png":
@@ -69,6 +68,7 @@ func export(path: String) -> void:
 			img.save_png(path)
 		_:
 			# SVG / fallback.
+			GlobalSettings.modify_save_data(&"current_file_path", path)
 			SVG.save_svg_to_file(path)
 	queue_free()
 


### PR DESCRIPTION
Fixes two unreported issues.

- Fixes the current file changing when exporting PNGs
- Fixes the text editor blocking Ctrl+S and other similar shortcuts when focused.