### PR TITLE
Improve panning button mask

### DIFF
--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -57,7 +57,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	
 	if event is InputEventMouseMotion and\
-	event.button_mask in [MOUSE_BUTTON_MASK_LEFT, MOUSE_BUTTON_MASK_MIDDLE]:
+	event.button_mask & (MOUSE_BUTTON_MASK_LEFT | MOUSE_BUTTON_MASK_MIDDLE):
 		
 		# Zooming with ctrl + middle mouse button.
 		if event.ctrl_pressed and event.button_mask == MOUSE_BUTTON_MASK_MIDDLE:


### PR DESCRIPTION
It would stop panning if both middle and left mouse buttons were held at once.
Both are valid panning buttons so i dont see a reason for it to be exclusive.