### PR TITLE
Fix transform editor popup button being draggable

### DIFF
--- a/src/ui_elements/transform_field.gd
+++ b/src/ui_elements/transform_field.gd
@@ -8,6 +8,7 @@ var attribute_name: String
 const TransformPopup = preload("res://src/ui_elements/transform_popup.tscn")
 
 @onready var line_edit: BetterLineEdit = $LineEdit
+@onready var popup_button: Button = $Button
 
 func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR):
 	sync(attribute.autoformat(new_value))
@@ -45,3 +46,7 @@ func _on_button_pressed() -> void:
 	transform_popup.attribute_ref = attribute
 	add_child(transform_popup)
 	Utils.popup_under_rect(transform_popup, line_edit.get_global_rect(), get_viewport())
+
+
+func _on_button_gui_input(event: InputEvent) -> void:
+	popup_button.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)

--- a/src/ui_elements/transform_field.tscn
+++ b/src/ui_elements/transform_field.tscn
@@ -53,4 +53,5 @@ expand_icon = true
 
 [connection signal="focus_entered" from="LineEdit" to="." method="_on_focus_entered"]
 [connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
+[connection signal="gui_input" from="Button" to="." method="_on_button_gui_input"]
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]


### PR DESCRIPTION
Tag moving will no longer be triggered when you click on the button next to the transform editor and start dragging it.