### PR TITLE
Lots of bugfixes, codebase enhancements

### DIFF
--- a/src/HandlerGUI.gd
+++ b/src/HandlerGUI.gd
@@ -7,7 +7,7 @@ var overlay_ref: ColorRect
 func _ready() -> void:
 	get_window().files_dropped.connect(_on_files_dropped)
 
-func _on_files_dropped(files: PackedStringArray):
+func _on_files_dropped(files: PackedStringArray) -> void:
 	if not has_overlay:
 		SVG.apply_svg_from_path(files[0])
 
@@ -40,3 +40,41 @@ func remove_overlay() -> void:
 	overlay_ref.queue_free()
 	has_overlay = false
 	get_tree().paused = false
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"import"):
+		get_viewport().set_input_as_handled()
+		SVG.open_import_dialog()
+	elif event.is_action_pressed(&"export"):
+		get_viewport().set_input_as_handled()
+		SVG.open_export_dialog()
+	elif event.is_action_pressed(&"save"):
+		get_viewport().set_input_as_handled()
+		SVG.open_save_dialog("svg", SVG.native_file_save, SVG.save_svg_to_file)
+
+func _unhandled_input(event) -> void:
+	if event.is_action_pressed(&"redo"):
+		get_viewport().set_input_as_handled()
+		SVG.redo()
+	elif event.is_action_pressed(&"undo"):
+		get_viewport().set_input_as_handled()
+		SVG.undo()
+	
+	if get_viewport().gui_is_dragging():
+		return
+	
+	if event.is_action_pressed(&"ui_cancel"):
+		Indications.clear_all_selections()
+	elif event.is_action_pressed(&"delete"):
+		Indications.delete_selected()
+	elif event.is_action_pressed(&"move_up"):
+		Indications.move_up_selected()
+	elif event.is_action_pressed(&"move_down"):
+		Indications.move_down_selected()
+	elif event.is_action_pressed(&"duplicate"):
+		Indications.duplicate_selected()
+	elif event.is_action_pressed(&"select_all"):
+		Indications.select_all()
+	elif event is InputEventKey:
+		Indications.respond_to_key_input(event)

--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -50,6 +50,7 @@ func update_tags() -> void:
 		parsing_finished.emit(&"")
 		root_tag.replace_self(SVGParser.text_to_svg(text))
 
+
 func update_text(undo_redo := true) -> void:
 	if undo_redo:
 		UR.create_action("")
@@ -60,32 +61,18 @@ func update_text(undo_redo := true) -> void:
 	else:
 		text = SVGParser.svg_to_text(root_tag)
 
+func undo() -> void:
+	if UR.has_undo():
+		UR.undo()
+		update_tags()
+
+func redo() -> void:
+	if UR.has_redo():
+		UR.redo()
+		update_tags()
+
 func _on_undo_redo() -> void:
 	GlobalSettings.modify_save_data(&"svg_text", text)
-
-
-func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed(&"redo"):
-		get_viewport().set_input_as_handled()
-		if UR.has_redo():
-			UR.redo()
-			update_tags()
-	elif event.is_action_pressed(&"undo"):
-		get_viewport().set_input_as_handled()
-		if UR.has_undo():
-			UR.undo()
-			update_tags()
-
-func _input(event: InputEvent) -> void:
-	if event.is_action_pressed(&"import"):
-		get_viewport().set_input_as_handled()
-		open_import_dialog()
-	elif event.is_action_pressed(&"export"):
-		get_viewport().set_input_as_handled()
-		open_export_dialog()
-	elif event.is_action_pressed(&"save"):
-		get_viewport().set_input_as_handled()
-		open_save_dialog("svg", native_file_save, save_svg_to_file)
 
 
 func open_import_dialog() -> void:
@@ -165,7 +152,7 @@ func finish_import(svg_text: String, file_path: String) -> void:
 	apply_svg_text(svg_text)
 
 
-func save_svg_to_file(path: String):
+func save_svg_to_file(path: String) -> void:
 	var FA := FileAccess.open(path, FileAccess.WRITE)
 	FA.store_string(text)
 

--- a/src/data_classes/AttributePath.gd
+++ b/src/data_classes/AttributePath.gd
@@ -75,7 +75,6 @@ func get_subpath(idx: int) -> Vector2i:
 		output.y += 1
 	return output
 
-
 func get_implied_S_control(cmd_idx: int) -> Vector2:
 	var cmd := get_command(cmd_idx)
 	var prev_cmd := get_command(cmd_idx - 1)
@@ -127,15 +126,15 @@ sync_mode := SyncMode.LOUD) -> void:
 		cmd.set(property, new_value)
 		sync_after_commands_change(sync_mode)
 
-func insert_command(idx: int, command_char: String) -> void:
+func insert_command(idx: int, command_char: String, sync_mode := SyncMode.LOUD) -> void:
 	var new_cmd: PathCommand = PathCommand.translation_dict[command_char.to_upper()].new()
 	if Utils.is_string_lower(command_char):
 		new_cmd.toggle_relative()
 	_commands.insert(idx, new_cmd)
-	sync_after_commands_change()
+	sync_after_commands_change(sync_mode)
 
 
-func convert_command(idx: int, command_char: String) -> void:
+func convert_command(idx: int, command_char: String, sync_mode := SyncMode.LOUD) -> void:
 	var old_cmd := get_command(idx)
 	if old_cmd.command_char == command_char:
 		return
@@ -181,10 +180,10 @@ func convert_command(idx: int, command_char: String) -> void:
 	_commands.insert(idx, new_cmd)
 	if relative:
 		_commands[idx].toggle_relative()
-	sync_after_commands_change()
+	sync_after_commands_change(sync_mode)
 
 
-func delete_commands(indices: Array[int]) -> void:
+func delete_commands(indices: Array[int], sync_mode := SyncMode.LOUD) -> void:
 	if indices.is_empty():
 		return
 	
@@ -193,8 +192,8 @@ func delete_commands(indices: Array[int]) -> void:
 	indices.reverse()
 	for idx in indices:
 		_commands.remove_at(idx)
-	sync_after_commands_change()
+	sync_after_commands_change(sync_mode)
 
-func toggle_relative_command(idx: int) -> void:
+func toggle_relative_command(idx: int, sync_mode := SyncMode.LOUD) -> void:
 	_commands[idx].toggle_relative()
-	sync_after_commands_change()
+	sync_after_commands_change(sync_mode)

--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -14,7 +14,7 @@ func is_standalone() -> bool:
 	return child_tags.is_empty()
 
 func _init():
-	for attribute in attributes.values():
+	for attribute: Attribute in attributes.values():
 		attribute.propagate_value_changed.connect(emit_attribute_changed)
 
 func set_unknown_attributes(attribs: Array[AttributeUnknown]) -> void:
@@ -22,7 +22,7 @@ func set_unknown_attributes(attribs: Array[AttributeUnknown]) -> void:
 	for attribute in unknown_attributes:
 		attribute.propagate_value_changed.connect(emit_attribute_changed)
 
-func emit_attribute_changed(undo_redo: bool):
+func emit_attribute_changed(undo_redo: bool) -> void:
 	attribute_changed.emit(undo_redo)
 
 func get_child_count() -> int:

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -9,7 +9,7 @@ const known_shape_attributes = ["cx", "cy", "r"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",
 		"stroke", "stroke-opacity", "stroke-width"]
 
-func _init() -> void:
+func _init(pos := Vector2.ZERO) -> void:
 	attributes = {
 		"transform": AttributeTransform.new(),
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -22,6 +22,8 @@ func _init() -> void:
 		"stroke-opacity": AttributeNumeric.new(AttributeNumeric.Mode.NFLOAT, "1"),
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 	}
+	attributes.cx.set_num(pos.x)
+	attributes.cy.set_num(pos.y)
 	super()
 
 

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -9,7 +9,7 @@ const known_shape_attributes = ["cx", "cy", "rx", "ry"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",
 		"stroke", "stroke-opacity", "stroke-width"]
 
-func _init() -> void:
+func _init(pos := Vector2.ZERO) -> void:
 	attributes = {
 		"transform": AttributeTransform.new(),
 		"cx": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -23,6 +23,8 @@ func _init() -> void:
 		"stroke-opacity": AttributeNumeric.new(AttributeNumeric.Mode.NFLOAT, "1"),
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 	}
+	attributes.cx.set_num(pos.x)
+	attributes.cy.set_num(pos.y)
 	super()
 
 

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -9,7 +9,7 @@ const known_shape_attributes = ["x1", "y1", "x2", "y2"]
 const known_inheritable_attributes = ["transform", "opacity", "stroke", "stroke-opacity",
 		"stroke-width", "stroke-linecap"]
 
-func _init() -> void:
+func _init(pos := Vector2.ZERO) -> void:
 	attributes = {
 		"transform": AttributeTransform.new(),
 		"x1": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -22,6 +22,10 @@ func _init() -> void:
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 		"stroke-linecap": AttributeEnum.new(["butt", "round", "square"], 0),
 	}
+	attributes.x1.set_num(pos.x)
+	attributes.y1.set_num(pos.y)
+	attributes.x2.set_num(pos.x + 1)
+	attributes.y2.set_num(pos.y)
 	super()
 
 

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -9,7 +9,7 @@ const known_shape_attributes = ["d"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",
 		"stroke", "stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin"]
 
-func _init() -> void:
+func _init(pos := Vector2.ZERO) -> void:
 	attributes = {
 		"transform": AttributeTransform.new(),
 		"d": AttributePath.new(),
@@ -22,6 +22,9 @@ func _init() -> void:
 		"stroke-linecap": AttributeEnum.new(["butt", "round", "square"], 0),
 		"stroke-linejoin": AttributeEnum.new(["miter", "round", "bevel"], 0),
 	}
+	attributes.d.insert_command(0, "M")
+	attributes.d.set_command_property(0, &"x", pos.x)
+	attributes.d.set_command_property(0, &"y", pos.y)
 	super()
 
 func can_replace(_new_tag: String) -> bool:

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -9,7 +9,7 @@ const known_shape_attributes = ["x", "y", "width", "height", "rx", "ry"]
 const known_inheritable_attributes = ["transform", "opacity", "fill", "fill-opacity",
 		"stroke", "stroke-opacity", "stroke-width", "stroke-linejoin"]
 
-func _init() -> void:
+func _init(pos := Vector2.ZERO) -> void:
 	attributes = {
 		"transform": AttributeTransform.new(),
 		"x": AttributeNumeric.new(AttributeNumeric.Mode.FLOAT, "0"),
@@ -26,6 +26,8 @@ func _init() -> void:
 		"stroke-width": AttributeNumeric.new(AttributeNumeric.Mode.UFLOAT, "1"),
 		"stroke-linejoin": AttributeEnum.new(["miter", "round", "bevel"], 0),
 	}
+	attributes.x.set_num(pos.x)
+	attributes.y.set_num(pos.y)
 	super()
 
 

--- a/src/ui_elements/color_field.gd
+++ b/src/ui_elements/color_field.gd
@@ -12,7 +12,7 @@ const checkerboard = preload("res://visual/icons/backgrounds/ColorButtonBG.svg")
 @onready var color_edit: LineEdit = $LineEdit
 @onready var color_popup: Popup
 
-func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR):
+func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> void:
 	# Validate the value.
 	if not is_valid(new_value):
 		sync(attribute.get_value())

--- a/src/ui_elements/enum_field.gd
+++ b/src/ui_elements/enum_field.gd
@@ -11,7 +11,7 @@ const bold_font = preload("res://visual/fonts/FontBold.ttf")
 @onready var indicator: LineEdit = $LineEdit
 @onready var button: Button = $Button
 
-func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR):
+func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> void:
 	sync(attribute.autoformat(new_value))
 	if attribute.get_value() != new_value or update_type == Utils.UpdateType.FINAL:
 		match update_type:

--- a/src/ui_elements/flag_field.gd
+++ b/src/ui_elements/flag_field.gd
@@ -6,7 +6,7 @@ var hovered := false
 signal value_changed(new_value: int)
 var _value: int
 
-func set_value(new_value: int, emit_value_changed := true):
+func set_value(new_value: int, emit_value_changed := true) -> void:
 	if _value != new_value:
 		_value = new_value
 		if emit_value_changed:

--- a/src/ui_elements/good_color_picker.gd
+++ b/src/ui_elements/good_color_picker.gd
@@ -193,7 +193,7 @@ func move_slider(idx: int, offset: float) -> void:
 	set_display_color(new_color)
 	widgets_arr[idx].queue_redraw()
 
-func set_color_channel(col: Color, channel: String, offset: float):
+func set_color_channel(col: Color, channel: String, offset: float) -> Color:
 	match channel:
 		"r": col.r = clampf(offset, 0.0, 1.0)
 		"g": col.g = clampf(offset, 0.0, 1.0)

--- a/src/ui_elements/mini_number_field.gd
+++ b/src/ui_elements/mini_number_field.gd
@@ -7,7 +7,7 @@ var mode := Mode.DEFAULT
 signal value_changed(new_value: float)
 var _value := NAN  # Must not be updated directly.
 
-func set_value(new_value: float, no_signal := false):
+func set_value(new_value: float, no_signal := false) -> void:
 	if not is_finite(new_value):
 		text = NumberArrayParser.basic_num_to_text(_value)
 		return

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -59,7 +59,7 @@ func _gui_input(event: InputEvent) -> void:
 						SVG.root_tag.get_tag(tid).attributes.d.get_subpath(cmd_idx)
 				for idx in range(subpath_range.x, subpath_range.y + 1):
 					Indications.ctrl_select(tid, idx)
-			elif event.ctrl_pressed:
+			elif event.is_command_or_control_pressed():
 				Indications.ctrl_select(tid, cmd_idx)
 			elif event.shift_pressed:
 				Indications.shift_select(tid, cmd_idx)

--- a/src/ui_elements/setting_check_box.tscn
+++ b/src/ui_elements/setting_check_box.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://chgcy63ldo7x5"]
+[gd_scene load_steps=2 format=3 uid="uid://ctsee23lxlrib"]
 
 [ext_resource type="Script" path="res://src/ui_elements/setting_check_box.gd" id="1_xy5x4"]
 

--- a/src/ui_elements/transform_field.gd
+++ b/src/ui_elements/transform_field.gd
@@ -10,7 +10,7 @@ const TransformPopup = preload("res://src/ui_elements/transform_popup.tscn")
 @onready var line_edit: BetterLineEdit = $LineEdit
 @onready var popup_button: Button = $Button
 
-func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR):
+func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> void:
 	sync(attribute.autoformat(new_value))
 	if attribute.get_value() != new_value or update_type == Utils.UpdateType.FINAL:
 		match update_type:

--- a/src/ui_elements/unknown_field.gd
+++ b/src/ui_elements/unknown_field.gd
@@ -6,7 +6,7 @@ signal focused
 var attribute: AttributeUnknown
 var attribute_name: String
 
-func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR):
+func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> void:
 	sync(new_value)
 	if attribute.get_value() != new_value or update_type == Utils.UpdateType.FINAL:
 		match update_type:

--- a/src/ui_parts/about_menu.gd
+++ b/src/ui_parts/about_menu.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 	add_section("Project Founder and Manager", AppInfo.project_founder_and_manager)
 	add_section("Developers", AppInfo.authors)
 
-func add_section(section_title: String, authors: Array[String]):
+func add_section(section_title: String, authors: Array[String]) -> void:
 	authors_label.push_bold()
 	authors_label.add_text(section_title + ":")
 	authors_label.pop()

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -669,7 +669,7 @@ func respond_to_input_event(event: InputEvent) -> void:
 							dragged_handle.path_attribute.get_subpath(inner_idx)
 					for idx in range(subpath_range.x, subpath_range.y + 1):
 						Indications.ctrl_select(dragged_tid, idx)
-				elif event.ctrl_pressed:
+				elif event.is_command_or_control_pressed():
 					Indications.ctrl_select(dragged_tid, inner_idx)
 				elif event.shift_pressed:
 					Indications.shift_select(dragged_tid, inner_idx)
@@ -755,27 +755,9 @@ func create_tag_context(pos: Vector2) -> ContextPopupType:
 func add_tag_at_pos(tag_name: String, pos: Vector2) -> void:
 	var tag: Tag
 	match tag_name:
-		"path":
-			tag = TagPath.new()
-			tag.attributes.d.insert_command(0, "M")
-			tag.attributes.d.set_command_property(0, &"x", pos.x)
-			tag.attributes.d.set_command_property(0, &"y", pos.y)
-		"circle":
-			tag = TagCircle.new()
-			tag.attributes.cx.set_num(pos.x)
-			tag.attributes.cy.set_num(pos.y)
-		"ellipse":
-			tag = TagEllipse.new()
-			tag.attributes.cx.set_num(pos.x)
-			tag.attributes.cy.set_num(pos.y)
-		"rect":
-			tag = TagRect.new()
-			tag.attributes.x.set_num(pos.x)
-			tag.attributes.y.set_num(pos.y)
-		"line":
-			tag = TagLine.new()
-			tag.attributes.x1.set_num(pos.x)
-			tag.attributes.y1.set_num(pos.y)
-			tag.attributes.x2.set_num(pos.x + 1)
-			tag.attributes.y2.set_num(pos.y)
+		"path": tag = TagPath.new(pos)
+		"circle": tag = TagCircle.new(pos)
+		"ellipse": tag = TagEllipse.new(pos)
+		"rect": tag = TagRect.new(pos)
+		"line": tag = TagLine.new(pos)
 	SVG.root_tag.add_tag(tag, PackedInt32Array([SVG.root_tag.get_child_count()]))

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -129,7 +129,7 @@ func _gui_input(event: InputEvent) -> void:
 			if event.is_pressed():
 				if event.shift_pressed:
 					Indications.shift_select(tid)
-				elif event.ctrl_pressed:
+				elif event.is_command_or_control_pressed():
 					Indications.ctrl_select(tid)
 				elif not tid in Indications.selected_tids:
 					Indications.normal_select(tid)
@@ -237,5 +237,5 @@ func _draw() -> void:
 	drop_sb.draw(surface, Rect2(Vector2.ZERO, get_size()))
 
 # Block dragging from starting when pressing the title button.
-func _on_title_button_gui_input(event):
+func _on_title_button_gui_input(event) -> void:
 	title_button.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)


### PR DESCRIPTION
Now HandlerGUI handles all inputs; fixes #483

Uses `sync_mode` for various AttributePath operations, but it's not used right now.

Initializing a shape tags now requires a coordinate, with (0, 0) as a default.

⌘ now works like Ctrl in more places (screw Mac lmao)

Added type declarations to some functions.

Adding a path now adds the first move command automatically.

