### PR TITLE
Add separate control for shortcuts that can't be modified

### DIFF
--- a/src/ui_elements/color_swatch.gd
+++ b/src/ui_elements/color_swatch.gd
@@ -62,8 +62,13 @@ func _get_drag_data(_at_position: Vector2) -> Variant:
 		preview.idx = idx
 		preview.modulate = Color(1, 1, 1, 0.85)
 		set_drag_preview(preview)
+		modulate = Color(1, 1, 1, 0.55)
 		return data
 	return null
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_DRAG_END:
+		modulate = Color(1, 1, 1)
 
 
 # For configuration swatches.

--- a/src/ui_elements/presented_shortcut.gd
+++ b/src/ui_elements/presented_shortcut.gd
@@ -1,0 +1,20 @@
+extends PanelContainer
+
+@onready var label: Label = %MainContainer/Label
+@onready var shortcut_container: HBoxContainer = %ShortcutContainer
+
+func setup(new_action: String) -> void:
+	var events := InputMap.action_get_events(new_action)
+	# Clear the existing buttons.
+	for button in shortcut_container.get_children():
+		button.queue_free()
+	# Create new ones.
+	for i in events.size():
+		var new_btn := Button.new()
+		shortcut_container.add_child.call_deferred(new_btn)
+		new_btn.custom_minimum_size.x = 144.0
+		new_btn.size_flags_horizontal = Control.SIZE_FILL
+		new_btn.theme_type_variation = "TranslucentButton"
+		new_btn.focus_mode = Control.FOCUS_NONE
+		new_btn.disabled = true
+		new_btn.text = events[i].as_text_physical_keycode()

--- a/src/ui_elements/presented_shortcut.tscn
+++ b/src/ui_elements/presented_shortcut.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=3 uid="uid://owphyjtiueai"]
+
+[ext_resource type="Script" path="res://src/ui_elements/presented_shortcut.gd" id="1_mfl8k"]
+
+[node name="PresentedShortcut" type="PanelContainer"]
+offset_right = 172.0
+offset_bottom = 62.0
+script = ExtResource("1_mfl8k")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = 2
+theme_override_constants/margin_right = 6
+theme_override_constants/margin_bottom = 6
+
+[node name="MainContainer" type="VBoxContainer" parent="MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="Label" type="Label" parent="MarginContainer/MainContainer"]
+layout_mode = 2
+horizontal_alignment = 1
+
+[node name="ShortcutContainer" type="HBoxContainer" parent="MarginContainer/MainContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+alignment = 1

--- a/src/ui_elements/setting_shortcut.gd
+++ b/src/ui_elements/setting_shortcut.gd
@@ -1,9 +1,6 @@
 extends PanelContainer
 
-const plus_icon = preload("res://visual/icons/Plus.svg")
 const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
-
-@export var shortcut_name: String
 
 @onready var label: Label = %MainContainer/Label
 @onready var reset_button: Button = %MainContainer/HBoxContainer/ResetButton
@@ -13,19 +10,14 @@ const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 var action: String
 var events: Array[InputEvent] = []
 
-var is_state_disabled := false
 var listening_idx := -1
 
 func _ready() -> void:
 	reset_button.tooltip_text = tr("Reset to default")
 
-func make_disabled() -> void:
-	label.add_theme_color_override("font_color", Color("#def8"))
-
-func setup(new_action: String, state_disabled := false) -> void:
+func setup(new_action: String) -> void:
 	action = new_action
 	events = InputMap.action_get_events(action)
-	is_state_disabled = state_disabled
 	sync()
 
 # Syncs based on current events.
@@ -54,12 +46,8 @@ func sync() -> void:
 		new_btn.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		new_btn.focus_mode = Control.FOCUS_NONE
 		if i < events.size():
-			new_btn.remove_theme_color_override("font_color")
-			new_btn.text = event_to_text(events[i])
+			new_btn.text = events[i].as_text_physical_keycode()
 			new_btn.pressed.connect(popup_options.bind(i))
-			if is_state_disabled:
-				new_btn.disabled = true
-				new_btn.mouse_default_cursor_shape = Control.CURSOR_ARROW
 		else:
 			new_btn.begin_bulk_theme_override()
 			new_btn.add_theme_color_override("font_color", Color("#def6"))
@@ -70,16 +58,10 @@ func sync() -> void:
 			if i == events.size():
 				new_btn.tooltip_text = tr("Add shortcut")
 				new_btn.pressed.connect(enter_listening_mode.bind(i))
-				if is_state_disabled:
-					new_btn.disabled = true
-					new_btn.mouse_default_cursor_shape = Control.CURSOR_ARROW
 			else:
 				new_btn.disabled = true
 				new_btn.mouse_default_cursor_shape = Control.CURSOR_ARROW
 
-
-func event_to_text(event: InputEventKey) -> String:
-	return event.as_text_physical_keycode()
 
 func popup_options(idx: int) -> void:
 	var context_popup := ContextPopup.instantiate()
@@ -134,7 +116,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		if event.is_action_pressed("ui_cancel"):
 			cancel_listening()
 		elif event.is_pressed():
-			shortcut_buttons[listening_idx].text = event_to_text(event)
+			shortcut_buttons[listening_idx].text = event.as_text_physical_keycode()
 			accept_event()
 		elif event.is_released():
 			if listening_idx < events.size():

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -3,6 +3,7 @@ extends PanelContainer
 const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 const PaletteConfigWidget = preload("res://src/ui_elements/palette_config.tscn")
 const ShortcutConfigWidget = preload("res://src/ui_elements/setting_shortcut.tscn")
+const ShortcutShowcaseWidget = preload("res://src/ui_elements/presented_shortcut.tscn")
 const plus_icon = preload("res://visual/icons/Plus.svg")
 
 const SettingCheckBox = preload("res://src/ui_elements/setting_check_box.gd")
@@ -217,13 +218,13 @@ func setup_shortcuts_tab() -> void:
 	"shorthand_quadratic_bezier_absolute", "cubic_bezier_relative",
 	"cubic_bezier_absolute", "shorthand_cubic_bezier_relative",
 	"shorthand_cubic_bezier_absolute"]:
-		var keybind_config := ShortcutConfigWidget.instantiate()
+		var keybind_config := ShortcutShowcaseWidget.instantiate()
 		shortcut_container.add_child(keybind_config)
 		if action in shortcut_descriptions:
 			keybind_config.label.text = shortcut_descriptions[action]
 		else:
 			keybind_config.label.text = action
-		keybind_config.setup(action, true)
+		keybind_config.setup(action)
 
 
 func setup_theming_tab() -> void:

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -113,7 +113,12 @@ func _get_drag_data(_at_position: Vector2) -> Variant:
 		tags_container.add_child(preview)
 	tags_container.modulate = Color(1, 1, 1, 0.85)
 	set_drag_preview(tags_container)
+	modulate = Color(1, 1, 1, 0.55)
 	return data
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_DRAG_END:
+		modulate = Color(1, 1, 1)
 
 
 func _on_title_button_pressed() -> void:


### PR DESCRIPTION
Because these can't be configured, a lot of things don't make sense for them, like the "Unused" buttons. So I made a new scene for them.

Also darkens things that are being dragged.