### PR TITLE
Fix subpath selection in the inspector

### DIFF
--- a/src/HandlerGUI.gd
+++ b/src/HandlerGUI.gd
@@ -54,7 +54,18 @@ func remove_overlay() -> void:
 	get_tree().paused = false
 
 
+var last_mouse_click_double := false
+
 func _input(event: InputEvent) -> void:
+	# So, it turns out that when you double click, only the press will count as such.
+	# I don't like that, and it causes problems! So mark the release as double_click too.
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.double_click:
+			last_mouse_click_double = true
+		elif last_mouse_click_double and event.is_released():
+			event.double_click = true
+			last_mouse_click_double = false
+	
 	if event.is_action_pressed("save"):
 		get_viewport().set_input_as_handled()
 		SVG.open_save_dialog("svg", SVG.native_file_save, SVG.save_svg_to_file)

--- a/src/ui_elements/path_command_editor.gd
+++ b/src/ui_elements/path_command_editor.gd
@@ -66,9 +66,12 @@ func _gui_input(event: InputEvent) -> void:
 					Indications.ctrl_select(tid, cmd_idx)
 				elif event.shift_pressed:
 					Indications.shift_select(tid, cmd_idx)
-				else:
+				elif not cmd_idx in Indications.inner_selections:
 					Indications.normal_select(tid, cmd_idx)
-			elif event.is_released() and not event.shift_pressed and not event.ctrl_pressed:
+			elif event.is_released() and not event.shift_pressed and\
+			not event.is_command_or_control_pressed() and not event.double_click and\
+			Indications.inner_selections.size() > 1 and\
+			cmd_idx in Indications.inner_selections:
 				Indications.normal_select(tid, cmd_idx)
 		elif event.button_index == MOUSE_BUTTON_RIGHT and event.is_pressed():
 			if Indications.semi_selected_tid != tid or\

--- a/src/ui_parts/tag_editor.gd
+++ b/src/ui_parts/tag_editor.gd
@@ -146,7 +146,9 @@ func _gui_input(event: InputEvent) -> void:
 					Indications.ctrl_select(tid)
 				elif not tid in Indications.selected_tids:
 					Indications.normal_select(tid)
-			elif event.is_released() and not event.shift_pressed and not event.ctrl_pressed:
+			elif event.is_released() and not event.shift_pressed and\
+			not event.is_command_or_control_pressed() and\
+			Indications.selected_tids.size() > 1 and tid in Indications.selected_tids:
 				Indications.normal_select(tid)
 			accept_event()
 		elif event.button_index == MOUSE_BUTTON_RIGHT and event.is_pressed():


### PR DESCRIPTION
Fixes a regression introduced recently.

Now all double-click release inputs will be flagged as double_click, which was somewhat necessary to solve this and other problems like this that will probably arise in the future.