### PR TITLE
Allow to plug different content-based controls into a TagEditor

### DIFF
--- a/src/ui_elements/tag_content_unknown.gd
+++ b/src/ui_elements/tag_content_unknown.gd
@@ -1,0 +1,60 @@
+extends VBoxContainer
+
+const UnknownField = preload("res://src/ui_elements/unknown_field.tscn")
+const TransformField = preload("res://src/ui_elements/transform_field.tscn")
+const NumberField = preload("res://src/ui_elements/number_field.tscn")
+const NumberSlider = preload("res://src/ui_elements/number_field_with_slider.tscn")
+const ColorField = preload("res://src/ui_elements/color_field.tscn")
+const PathField = preload("res://src/ui_elements/path_field.tscn")
+const EnumField = preload("res://src/ui_elements/enum_field.tscn")
+
+var unknown_container: HFlowContainer  # Only created if there are unknown attributes.
+@onready var paint_container: FlowContainer = $PaintAttributes
+@onready var shape_container: FlowContainer = $ShapeAttributes
+
+var tag: Tag
+var tid: PackedInt32Array
+
+func _ready() -> void:
+	# Fill up the containers. Start with unknown attributes, if there are any.
+	if not tag.unknown_attributes.is_empty():
+		unknown_container = HFlowContainer.new()
+		add_child(unknown_container)
+		move_child(unknown_container, 0)
+		for attribute in tag.unknown_attributes:
+			var input_field := UnknownField.instantiate()
+			input_field.attribute = attribute
+			input_field.attribute_name = attribute.name
+			unknown_container.add_child(input_field)
+	# Continue with supported attributes.
+	for attribute_key in tag.attributes:
+		var attribute: Attribute = tag.attributes[attribute_key]
+		var input_field: Control
+		if attribute is AttributeTransform:
+			input_field = TransformField.instantiate()
+		elif attribute is AttributeNumeric:
+			match attribute.mode:
+				AttributeNumeric.Mode.FLOAT:
+					input_field = NumberField.instantiate()
+				AttributeNumeric.Mode.UFLOAT:
+					input_field = NumberField.instantiate()
+					input_field.allow_lower = false
+				AttributeNumeric.Mode.NFLOAT:
+					input_field = NumberSlider.instantiate()
+					input_field.allow_lower = false
+					input_field.allow_higher = false
+					input_field.slider_step = 0.01
+		elif attribute is AttributeColor:
+			input_field = ColorField.instantiate()
+		elif attribute is AttributePath:
+			input_field = PathField.instantiate()
+		elif attribute is AttributeEnum:
+			input_field = EnumField.instantiate()
+		input_field.attribute = attribute
+		input_field.attribute_name = attribute_key
+		input_field.focused.connect(Indications.normal_select.bind(tid))
+		# Add the attribute to its corresponding container.
+		if attribute_key in tag.known_shape_attributes:
+			shape_container.add_child(input_field)
+		elif attribute_key in tag.known_inheritable_attributes:
+			paint_container.add_child(input_field)

--- a/src/ui_elements/tag_content_unknown.tscn
+++ b/src/ui_elements/tag_content_unknown.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://b70dhqt8ldcmc"]
+
+[ext_resource type="Script" path="res://src/ui_elements/tag_content_unknown.gd" id="1_vy7fr"]
+
+[node name="TagContentUnknown" type="VBoxContainer"]
+size_flags_horizontal = 3
+script = ExtResource("1_vy7fr")
+
+[node name="PaintAttributes" type="HFlowContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ShapeAttributes" type="HFlowContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3

--- a/src/ui_parts/tag_editor.tscn
+++ b/src/ui_parts/tag_editor.tscn
@@ -51,20 +51,7 @@ mouse_filter = 2
 [node name="MainContainer" type="VBoxContainer" parent="Content"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 12
-
-[node name="AttributeContainer" type="VBoxContainer" parent="Content/MainContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="PaintAttributes" type="HFlowContainer" parent="Content/MainContainer/AttributeContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="ShapeAttributes" type="HFlowContainer" parent="Content/MainContainer/AttributeContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
+theme_override_constants/separation = 8
 
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]
 [connection signal="gui_input" from="Title/TitleBox/TitleButton" to="." method="_on_title_button_gui_input"]


### PR DESCRIPTION
Implements the TagUnknown one initially. For the time being this is the only one that can be created and used. But I'm already looking into creating one for `<circle>` to start off.

Also fixes the order of displayed tags when dragging being the opposite of what's expected.