### PR TITLE
Fix code editor RMB not moving the caret

### DIFF
--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -102,3 +102,5 @@ func _gui_input(event: InputEvent) -> void:
 			var viewport := get_viewport()
 			Utils.popup_under_pos(context_popup, viewport.get_mouse_position(), viewport)
 			accept_event()
+			# Wow, no way to find out the column of a given click? Okay...
+			# TODO Make it so LineEdit caret automatically moves to the clicked position.

--- a/src/ui_elements/BetterTextEdit.gd
+++ b/src/ui_elements/BetterTextEdit.gd
@@ -119,6 +119,9 @@ func _gui_input(event: InputEvent) -> void:
 			var viewport := get_viewport()
 			Utils.popup_under_pos(context_popup, viewport.get_mouse_position(), viewport)
 			accept_event()
+			var click_pos := get_line_column_at_pos(event.position)
+			set_caret_line(click_pos.y, false)
+			set_caret_column(click_pos.x, false)
 	else:
 		# Set these inputs as handled, so the default UndoRedo doesn't eat them.
 		if event.is_action_pressed("redo"):

--- a/src/ui_parts/code_editor.tscn
+++ b/src/ui_parts/code_editor.tscn
@@ -143,7 +143,6 @@ custom_minimum_size = Vector2(0, 96)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-highlight_all_occurrences = true
 script = ExtResource("8_ser4i")
 block_non_ascii = true
 

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -44,12 +44,16 @@ func render_handle_textures() -> void:
 	for handle_type in [Handle.Display.BIG, Handle.Display.SMALL]:
 		var handle_type_svg: String = handles_svg_dict[handle_type]
 		img.load_svg_from_string(handle_type_svg % [inside_str, normal_str])
+		img.fix_alpha_edges()
 		normal_handle_textures[handle_type] = ImageTexture.create_from_image(img)
 		img.load_svg_from_string(handle_type_svg % [inside_str, hovered_str])
+		img.fix_alpha_edges()
 		hovered_handle_textures[handle_type] = ImageTexture.create_from_image(img)
 		img.load_svg_from_string(handle_type_svg % [inside_str, selected_str])
+		img.fix_alpha_edges()
 		selected_handle_textures[handle_type] = ImageTexture.create_from_image(img)
 		img.load_svg_from_string(handle_type_svg % [inside_str, hovered_selected_str])
+		img.fix_alpha_edges()
 		hovered_selected_handle_textures[handle_type] = ImageTexture.create_from_image(img)
 	
 	queue_redraw()


### PR DESCRIPTION
Fixes it only for BetterTextEdit because Godot's LineEdit is not configurable enough yet. Maybe with some quirky logic it'll be doable, but maybe another time.

Also fixes an issue with the new system for rendering handles.