### PR TITLE
Fix checkerboards in the import and export dialogs

### DIFF
--- a/src/ui_elements/svg_preview.gd
+++ b/src/ui_elements/svg_preview.gd
@@ -1,0 +1,14 @@
+extends CenterContainer
+
+@onready var checkerboard: TextureRect = $Checkerboard
+@onready var texture_preview: TextureRect = $Checkerboard/TexturePreview
+
+func setup(svg_text: String, dimensions: Vector2) -> void:
+	var scaling_factor := size.x * 2.0 / maxf(dimensions.x, dimensions.y)
+	var img := Image.new()
+	var err := img.load_svg_from_string(svg_text, scaling_factor)
+	if err == OK:
+		img.fix_alpha_edges()
+		var img_texture := ImageTexture.create_from_image(img)
+		texture_preview.texture = img_texture
+		checkerboard.custom_minimum_size = img_texture.get_size() / 2.0

--- a/src/ui_elements/svg_preview.tscn
+++ b/src/ui_elements/svg_preview.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=6 format=3 uid="uid://xh26qa68xed4"]
+
+[ext_resource type="Script" path="res://src/ui_elements/svg_preview.gd" id="1_7anhc"]
+[ext_resource type="Shader" path="res://src/shaders/zoom_shader.gdshader" id="1_valip"]
+[ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://visual/icons/backgrounds/Checkerboard.svg" id="2_10rcm"]
+[ext_resource type="Texture2D" uid="uid://crx4kcj4o01bs" path="res://visual/icons/SmallQuestionMark.svg" id="3_05elb"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_y7eee"]
+shader = ExtResource("1_valip")
+shader_parameter/uv_scale = 2.0
+
+[node name="SVGPreview" type="CenterContainer"]
+custom_minimum_size = Vector2(128, 128)
+script = ExtResource("1_7anhc")
+
+[node name="Checkerboard" type="TextureRect" parent="."]
+material = SubResource("ShaderMaterial_y7eee")
+layout_mode = 2
+texture = ExtResource("2_10rcm")
+expand_mode = 1
+stretch_mode = 1
+
+[node name="TexturePreview" type="TextureRect" parent="Checkerboard"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("3_05elb")
+expand_mode = 2
+stretch_mode = 5

--- a/src/ui_parts/export_dialog.tscn
+++ b/src/ui_parts/export_dialog.tscn
@@ -1,15 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://c13dadqbljqlu"]
+[gd_scene load_steps=6 format=3 uid="uid://c13dadqbljqlu"]
 
 [ext_resource type="Script" path="res://src/ui_parts/export_dialog.gd" id="1_objnb"]
-[ext_resource type="Shader" path="res://src/shaders/zoom_shader.gdshader" id="2_6bte3"]
-[ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://visual/icons/backgrounds/Checkerboard.svg" id="3_q8p2p"]
+[ext_resource type="PackedScene" uid="uid://xh26qa68xed4" path="res://src/ui_elements/svg_preview.tscn" id="2_ewk0a"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="4_4t2iq"]
 [ext_resource type="PackedScene" uid="uid://dbu1lvajypafb" path="res://src/ui_elements/dropdown.tscn" id="5_y6ex0"]
 [ext_resource type="PackedScene" uid="uid://dad7fkhmsooc6" path="res://src/ui_elements/number_edit.tscn" id="6_w1sag"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_y7eee"]
-shader = ExtResource("2_6bte3")
-shader_parameter/uv_scale = 2.0
 
 [node name="ExportDialog" type="PanelContainer"]
 anchors_preset = 8
@@ -39,23 +34,9 @@ horizontal_alignment = 1
 layout_mode = 2
 theme_override_constants/separation = 12
 
-[node name="Checkerboard" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
-material = SubResource("ShaderMaterial_y7eee")
-custom_minimum_size = Vector2(128, 128)
-layout_mode = 2
-texture = ExtResource("3_q8p2p")
-stretch_mode = 1
-
-[node name="TexturePreview" type="TextureRect" parent="VBoxContainer/HBoxContainer/Checkerboard"]
+[node name="TexturePreview" parent="VBoxContainer/HBoxContainer" instance=ExtResource("2_ewk0a")]
 unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-expand_mode = 2
-stretch_mode = 5
+layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/HBoxContainer"]
 custom_minimum_size = Vector2(160, 0)
@@ -72,20 +53,28 @@ theme_override_constants/separation = 12
 [node name="DimensionsLabel" type="Label" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_fonts/font = ExtResource("4_4t2iq")
+theme_override_colors/font_color = Color(0.866667, 0.866667, 0.866667, 1)
+theme_override_font_sizes/font_size = 16
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer"]
+[node name="FallbackFormatLabel" type="Label" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_font_sizes/font_size = 14
+horizontal_alignment = 1
+
+[node name="FormatHBox" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 8
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer/FormatHBox"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 text = "Format"
 
-[node name="Dropdown" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer/HBoxContainer" instance=ExtResource("5_y6ex0")]
-unique_name_in_owner = true
+[node name="Dropdown" parent="VBoxContainer/HBoxContainer/MarginContainer/VBoxContainer/FormatHBox" instance=ExtResource("5_y6ex0")]
 layout_mode = 2
 values = Array[String](["svg", "png"])
 

--- a/src/ui_parts/import_warning_dialog.gd
+++ b/src/ui_parts/import_warning_dialog.gd
@@ -3,8 +3,7 @@ extends PanelContainer
 signal imported
 
 @onready var warnings_label: RichTextLabel = %WarningsLabel
-@onready var texture_preview: TextureRect = %TexturePreview
-@onready var checkerboard: TextureRect = %Checkerboard
+@onready var texture_preview: CenterContainer = %TexturePreview
 @onready var ok_button: Button = %ButtonContainer/OKButton
 @onready var margin_container: MarginContainer = %MarginContainer
 
@@ -18,15 +17,10 @@ func _ready() -> void:
 	var preview_parse_result := SVGParser.text_to_svg(preview_text)
 	var preview := preview_parse_result.svg
 	if preview != null:
-		var scaling_factor := texture_preview.size.x * 2 / maxf(preview.width, preview.height)
-		var img := Image.new()
-		img.load_svg_from_string(SVGParser.svg_to_text(preview), scaling_factor)
-		if not img.is_empty():
-			img.fix_alpha_edges()
-			texture_preview.texture = ImageTexture.create_from_image(img)
+		texture_preview.setup(SVGParser.svg_to_text(preview), preview.get_size())
 	
 	if imported_text_parse_result.error != SVGParser.ParseError.OK:
-		checkerboard.hide()
+		texture_preview.hide()
 		margin_container.custom_minimum_size.y = 48
 		size.y = 0
 		warnings_label.add_theme_color_override("default_color",

--- a/src/ui_parts/import_warning_dialog.tscn
+++ b/src/ui_parts/import_warning_dialog.tscn
@@ -1,13 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://bhskf8yrulqtj"]
+[gd_scene load_steps=4 format=3 uid="uid://bhskf8yrulqtj"]
 
 [ext_resource type="Script" path="res://src/ui_parts/import_warning_dialog.gd" id="1_1rv5w"]
-[ext_resource type="Shader" path="res://src/shaders/zoom_shader.gdshader" id="2_o24gk"]
-[ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://visual/icons/backgrounds/Checkerboard.svg" id="3_k3bec"]
+[ext_resource type="PackedScene" uid="uid://xh26qa68xed4" path="res://src/ui_elements/svg_preview.tscn" id="2_j1v8v"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="4_rpfrk"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_774g4"]
-shader = ExtResource("2_o24gk")
-shader_parameter/uv_scale = 2.0
 
 [node name="ImportWarningPanel" type="PanelContainer"]
 anchors_preset = 8
@@ -43,26 +38,9 @@ horizontal_alignment = 1
 layout_mode = 2
 theme_override_constants/separation = 12
 
-[node name="Checkerboard" type="TextureRect" parent="MarginContainer/VBoxContainer/TextureContainer"]
+[node name="TexturePreview" parent="MarginContainer/VBoxContainer/TextureContainer" instance=ExtResource("2_j1v8v")]
 unique_name_in_owner = true
-material = SubResource("ShaderMaterial_774g4")
-custom_minimum_size = Vector2(128, 128)
 layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-texture = ExtResource("3_k3bec")
-stretch_mode = 1
-
-[node name="TexturePreview" type="TextureRect" parent="MarginContainer/VBoxContainer/TextureContainer/Checkerboard"]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-expand_mode = 2
-stretch_mode = 5
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/VBoxContainer/TextureContainer"]
 unique_name_in_owner = true

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -196,6 +196,9 @@ msgstr ""
 msgid "Final size"
 msgstr ""
 
+msgid "Invalid"
+msgstr ""
+
 msgid "Export Configuration"
 msgstr ""
 

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -199,6 +199,9 @@ msgstr "Размер"
 msgid "Final size"
 msgstr "Краен размер"
 
+msgid "Invalid"
+msgstr "Невалиден"
+
 msgid "Export Configuration"
 msgstr "Конфигурация на експорта"
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -200,6 +200,9 @@ msgstr "Größe"
 msgid "Final size"
 msgstr "Endgültige Größe"
 
+msgid "Invalid"
+msgstr ""
+
 msgid "Export Configuration"
 msgstr "Export-Konfiguration"
 

--- a/translations/en.po
+++ b/translations/en.po
@@ -197,6 +197,9 @@ msgstr ""
 msgid "Final size"
 msgstr ""
 
+msgid "Invalid"
+msgstr ""
+
 msgid "Export Configuration"
 msgstr ""
 

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -202,6 +202,9 @@ msgstr "Размер"
 msgid "Final size"
 msgstr "Финальный размер"
 
+msgid "Invalid"
+msgstr ""
+
 msgid "Export Configuration"
 msgstr "Настройки экспорта"
 

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -203,6 +203,9 @@ msgstr "Розмір"
 msgid "Final size"
 msgstr "Фінальний розмір"
 
+msgid "Invalid"
+msgstr ""
+
 msgid "Export Configuration"
 msgstr "Налаштування експорту"
 


### PR DESCRIPTION
Fixes the checkerboards being square even in non-square SVGs. Handles improper sizes correctly.