### PR TITLE
Add native global menu support (macOS)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -35,6 +35,11 @@ SVG="*res://src/SVG.gd"
 Indications="*res://src/Indications.gd"
 HandlerGUI="*res://src/HandlerGUI.gd"
 
+[debug]
+
+gdscript/warnings/int_as_enum_without_cast=0
+gdscript/warnings/int_as_enum_without_match=0
+
 [display]
 
 window/size/viewport_width=1024
@@ -309,7 +314,8 @@ view_overlay_reference={
 }
 find={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":true,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -1,6 +1,9 @@
 # This singleton handles session data and settings.
 extends Node
 
+
+signal keybinds_changed
+
 # Session data
 var save_data := SaveData.new()
 const save_path = "user://save.tres"
@@ -228,6 +231,7 @@ func save_palettes() -> void:
 func save_keybind(action: String) -> void:
 	config.set_value("keybinds", action, InputMap.action_get_events(action))
 	config.save(config_path)
+	keybinds_changed.emit()
 
 
 func modify_save_data(property: String, new_value: Variant) -> void:

--- a/src/TranslationUtils.gd
+++ b/src/TranslationUtils.gd
@@ -2,9 +2,9 @@ class_name TranslationUtils extends RefCounted
 
 static func get_shortcut_description(action_name: String) -> String:
 	match action_name:
-		"export": return TranslationServer.translate("Export")
-		"import": return TranslationServer.translate("Import")
-		"save": return TranslationServer.translate("Save SVG")
+		"export": return TranslationServer.translate("Export Image")
+		"import": return TranslationServer.translate("Import SVG")
+		"save": return TranslationServer.translate("Export SVG")
 		"optimize": return TranslationServer.translate("Optimize")
 		"copy_svg_text": return TranslationServer.translate("Copy all text")
 		"reset_svg": return TranslationServer.translate("Reset SVG")
@@ -17,12 +17,14 @@ static func get_shortcut_description(action_name: String) -> String:
 		"delete": return TranslationServer.translate("Delete the selection")
 		"move_up": return TranslationServer.translate("Move the selected elements up")
 		"move_down": return TranslationServer.translate("Move the selected elements down")
+		"find": return TranslationServer.translate("Find")
 		"zoom_in": return TranslationServer.translate("Zoom in")
 		"zoom_out": return TranslationServer.translate("Zoom out")
 		"zoom_reset": return TranslationServer.translate("Zoom reset")
 		"view_show_grid": return TranslationServer.translate("Show grid")
 		"view_show_handles": return TranslationServer.translate("Show handles")
 		"view_rasterized_svg": return TranslationServer.translate("Show rasterized SVG")
+		"snap_toggle": return TranslationServer.translate("Enable snap")
 		"load_reference": return TranslationServer.translate("Load reference image")
 		"view_show_reference": return TranslationServer.translate("Show reference image")
 		"view_overlay_reference": return TranslationServer.translate("Overlay reference image")

--- a/src/ui_parts/global_menu.gd
+++ b/src/ui_parts/global_menu.gd
@@ -1,0 +1,223 @@
+extends Node
+
+
+var global_rid: RID
+var appl_rid: RID
+var help_rid: RID
+
+var file_rid: RID
+var file_index: int
+var file_clear_svg_index: int
+var file_optimize_index: int
+var file_clear_assoc_index: int
+var file_reset_svg_index: int
+
+var edit_rid: RID
+var edit_index: int
+var tool_rid: RID
+var tool_index: int
+
+var view_rid: RID
+var view_index: int
+var view_show_grid_index: int
+var view_show_handles_index: int
+var view_rasterized_svg_index: int
+
+var snap_rid: RID
+var snap_index: int
+var snap_enable_index: int
+var snap_0125_index: int
+var snap_025_index: int
+var snap_05_index: int
+var snap_1_index: int
+var snap_2_index: int
+var snap_4_index: int
+
+
+func _enter_tree() -> void:
+	if not DisplayServer.has_feature(DisplayServer.FEATURE_GLOBAL_MENU):
+		queue_free()
+		return
+	# Included menus.
+	global_rid = NativeMenu.get_system_menu(NativeMenu.MAIN_MENU_ID)
+	appl_rid = NativeMenu.get_system_menu(NativeMenu.APPLICATION_MENU_ID)
+	help_rid = NativeMenu.get_system_menu(NativeMenu.HELP_MENU_ID)
+	# Custom menus.
+	_generate_main_menus()
+	_setup_menu_items()
+	GlobalSettings.keybinds_changed.connect(_reset_menu_items)
+	SVG.text_changed.connect(_on_svg_text_changed)
+
+
+func _notification(what: int) -> void:
+	if what == Utils.CustomNotification.LANGUAGE_CHANGED:
+		_clear_menu_items()
+		NativeMenu.remove_item(global_rid, snap_index)
+		NativeMenu.remove_item(global_rid, view_index)
+		NativeMenu.remove_item(global_rid, tool_index)
+		NativeMenu.remove_item(global_rid, edit_index)
+		NativeMenu.remove_item(global_rid, file_index)
+		NativeMenu.free_menu(file_rid)
+		NativeMenu.free_menu(edit_rid)
+		NativeMenu.free_menu(tool_rid)
+		NativeMenu.free_menu(view_rid)
+		NativeMenu.free_menu(snap_rid)
+		_generate_main_menus()
+		_setup_menu_items()
+
+
+func _generate_main_menus() -> void:
+	file_rid = NativeMenu.create_menu()
+	edit_rid = NativeMenu.create_menu()
+	tool_rid = NativeMenu.create_menu()
+	view_rid = NativeMenu.create_menu()
+	snap_rid = NativeMenu.create_menu()
+	file_index = NativeMenu.add_submenu_item(global_rid, TranslationServer.translate("File"), file_rid)
+	edit_index = NativeMenu.add_submenu_item(global_rid, TranslationServer.translate("Edit"), edit_rid)
+	tool_index = NativeMenu.add_submenu_item(global_rid, TranslationServer.translate("Tool"), tool_rid)
+	view_index = NativeMenu.add_submenu_item(global_rid, TranslationServer.translate("View"), view_rid)
+	snap_index = NativeMenu.add_submenu_item(global_rid, TranslationServer.translate("Snap"), snap_rid)
+
+
+func _reset_menu_items() -> void:
+	_setup_menu_items()
+
+
+func _clear_menu_items() -> void:
+	NativeMenu.clear(appl_rid)
+	NativeMenu.clear(help_rid)
+	NativeMenu.clear(file_rid)
+	NativeMenu.clear(edit_rid)
+	NativeMenu.clear(tool_rid)
+	NativeMenu.clear(view_rid)
+	NativeMenu.clear(snap_rid)
+
+
+func _setup_menu_items() -> void:
+	# Included App and Help menus.
+	_add_action(appl_rid, "open_settings")
+	_add_icon_item(help_rid, "open_settings", load("res://visual/icons/Gear.svg"))
+	_add_icon_item(help_rid, "about_repo", load("res://visual/icons/Link.svg"))
+	_add_icon_item(help_rid, "about_info", load("res://visual/icon.svg"))
+	_add_icon_item(help_rid, "about_donate", load("res://visual/icons/Heart.svg"))
+	_add_icon_item(help_rid, "about_website", load("res://visual/icons/Link.svg"))
+	_add_icon_item(help_rid, "check_updates", load("res://visual/icons/Reload.svg"))
+	# File menu.
+	_add_action(file_rid, "import")
+	_add_action(file_rid, "export")
+	_add_action(file_rid, "save")
+	NativeMenu.add_separator(file_rid)
+	_add_action(file_rid, "copy_svg_text")
+	file_clear_svg_index = _add_action(file_rid, "clear_svg")
+	file_optimize_index = _add_action(file_rid, "optimize")
+	NativeMenu.add_separator(file_rid)
+	file_clear_assoc_index = _add_action(file_rid, "clear_file_path")
+	file_reset_svg_index = _add_action(file_rid, "reset_svg")
+	_on_svg_text_changed()
+	# Edit and Tool menus.
+	_add_many_actions(edit_rid, GlobalSettings.keybinds_dict["edit"].keys())
+	_add_many_actions(tool_rid, GlobalSettings.keybinds_dict["tool"].keys())
+	# View menu.
+	view_show_grid_index = _add_check_item(view_rid, "view_show_grid")
+	view_show_handles_index = _add_check_item(view_rid, "view_show_handles")
+	view_rasterized_svg_index = _add_check_item(view_rid, "view_rasterized_svg")
+	_on_display_view_settings_updated(true, true, false)
+	NativeMenu.add_separator(view_rid)
+	_add_action(view_rid, "zoom_in")
+	_add_action(view_rid, "zoom_out")
+	_add_action(view_rid, "zoom_reset")
+	# Snap menu.
+	snap_enable_index = _add_check_item(snap_rid, "snap_toggle")
+	NativeMenu.add_separator(snap_rid)
+	snap_0125_index = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
+	snap_025_index = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)
+	snap_05_index = NativeMenu.add_radio_check_item(snap_rid, "0.5", _set_snap, _set_snap, 0.5)
+	snap_1_index = NativeMenu.add_radio_check_item(snap_rid, "1", _set_snap, _set_snap, 1)
+	snap_2_index = NativeMenu.add_radio_check_item(snap_rid, "2", _set_snap, _set_snap, 2)
+	snap_4_index = NativeMenu.add_radio_check_item(snap_rid, "4", _set_snap, _set_snap, 4)
+
+
+func _add_many_actions(menu_rid: RID, actions: Array) -> void:
+	for action in actions:
+		_add_action(menu_rid, action)
+
+
+func _add_action(menu_rid: RID, action_name: StringName) -> int:
+	var display_name = _get_action_display_name(action_name)
+	var key = _get_keycode_for_events(InputMap.action_get_events(action_name))
+	return NativeMenu.add_item(menu_rid, display_name, _action_call, _action_call, action_name, key)
+
+
+func _add_check_item(menu_rid: RID, action_name: StringName) -> int:
+	var display_name = _get_action_display_name(action_name)
+	return NativeMenu.add_check_item(menu_rid, display_name, _action_call, _action_call, action_name)
+
+
+func _add_icon_item(menu_rid: RID, action_name: StringName, icon: Texture2D) -> int:
+	var display_name = _get_action_display_name(action_name)
+	return NativeMenu.add_icon_item(menu_rid, icon, display_name, _action_call, _action_call, action_name)
+
+
+func _get_action_display_name(action_name: StringName) -> String:
+	var display_name = TranslationUtils.get_shortcut_description(action_name)
+	if display_name.is_empty():
+		display_name = action_name.capitalize().replace("Svg", "SVG")
+	return display_name
+
+
+func _get_keycode_for_events(input_events: Array[InputEvent]) -> Key:
+	for input_event in input_events:
+		if input_event is InputEventKey:
+			var key = input_event.get_keycode_with_modifiers()
+			if key != KEY_NONE:
+				return key
+			key = input_event.get_physical_keycode_with_modifiers()
+			if key != KEY_NONE:
+				return key
+	return KEY_NONE
+
+
+func _on_svg_text_changed() -> void:
+	NativeMenu.set_item_disabled(file_rid, file_clear_svg_index, SVG.text == SVG.DEFAULT)
+	var empty_path: bool = GlobalSettings.save_data.current_file_path.is_empty()
+	NativeMenu.set_item_disabled(file_rid, file_clear_assoc_index, empty_path)
+	NativeMenu.set_item_disabled(file_rid, file_reset_svg_index, empty_path)
+
+
+func _on_display_view_settings_updated(show_grid: bool, show_handles: bool, rasterized_svg: bool) -> void:
+	NativeMenu.set_item_checked(view_rid, view_show_grid_index, show_grid)
+	NativeMenu.set_item_checked(view_rid, view_show_handles_index, show_handles)
+	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_index, rasterized_svg)
+
+
+func _on_display_snap_settings_updated(snap_enabled: bool, snap_amount: float) -> void:
+	NativeMenu.set_item_checked(snap_rid, snap_enable_index, snap_enabled)
+	NativeMenu.set_item_checked(snap_rid, snap_0125_index, false)
+	NativeMenu.set_item_checked(snap_rid, snap_025_index, false)
+	NativeMenu.set_item_checked(snap_rid, snap_05_index, false)
+	NativeMenu.set_item_checked(snap_rid, snap_1_index, false)
+	NativeMenu.set_item_checked(snap_rid, snap_2_index, false)
+	NativeMenu.set_item_checked(snap_rid, snap_4_index, false)
+	if is_equal_approx(snap_amount, 0.125):
+		NativeMenu.set_item_checked(snap_rid, snap_0125_index, true)
+	elif is_equal_approx(snap_amount, 0.25):
+		NativeMenu.set_item_checked(snap_rid, snap_025_index, true)
+	elif is_equal_approx(snap_amount, 0.5):
+		NativeMenu.set_item_checked(snap_rid, snap_05_index, true)
+	elif is_equal_approx(snap_amount, 1):
+		NativeMenu.set_item_checked(snap_rid, snap_1_index, true)
+	elif is_equal_approx(snap_amount, 2):
+		NativeMenu.set_item_checked(snap_rid, snap_2_index, true)
+	elif is_equal_approx(snap_amount, 4):
+		NativeMenu.set_item_checked(snap_rid, snap_4_index, true)
+
+
+func _set_snap(tag: float) -> void:
+	%Display.set_snap_amount(tag)
+
+
+func _action_call(tag: StringName) -> void:
+	var a = InputEventAction.new()
+	a.action = tag
+	a.pressed = true
+	Input.parse_input_event(a)

--- a/src/ui_parts/main_scene.tscn
+++ b/src/ui_parts/main_scene.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://ce6j54x27pom"]
+[gd_scene load_steps=7 format=3 uid="uid://ce6j54x27pom"]
 
 [ext_resource type="PackedScene" uid="uid://cr1fdlmbknnko" path="res://src/ui_parts/code_editor.tscn" id="1_0jgh3"]
 [ext_resource type="Texture2D" uid="uid://co75w07yqmcro" path="res://visual/icons/theme/SplitGrabber2.svg" id="1_7y812"]
 [ext_resource type="PackedScene" uid="uid://ccynisiuyn5qn" path="res://src/ui_parts/inspector.tscn" id="1_afxvd"]
 [ext_resource type="Script" path="res://src/ui_parts/main_scene.gd" id="1_c0fkj"]
 [ext_resource type="PackedScene" uid="uid://bvrncl7e6yn5b" path="res://src/ui_parts/display.tscn" id="3_qbqbs"]
+[ext_resource type="Script" path="res://src/ui_parts/global_menu.gd" id="5_wda5e"]
 
 [node name="MainScene" type="HBoxContainer"]
 anchors_preset = 15
@@ -42,3 +43,9 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="GlobalMenu" type="Node" parent="."]
+script = ExtResource("5_wda5e")
+
+[connection signal="snap_settings_updated" from="HSplitContainer/Display" to="GlobalMenu" method="_on_display_snap_settings_updated"]
+[connection signal="view_settings_updated" from="HSplitContainer/Display" to="GlobalMenu" method="_on_display_view_settings_updated"]

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -222,7 +222,6 @@ msgid "OK"
 msgstr ""
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr ""
 
@@ -343,12 +342,32 @@ msgstr ""
 msgid "Scale"
 msgstr ""
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr ""
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd
+msgid "Snap"
 msgstr ""
 
 #: src/ui_parts/good_file_dialog.gd
@@ -590,22 +609,6 @@ msgid "Language"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr ""
 
@@ -811,7 +814,15 @@ msgid "Convert To"
 msgstr ""
 
 #: src/TranslationUtils.gd
-msgid "Import"
+msgid "Export Image"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Import SVG"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Export SVG"
 msgstr ""
 
 #: src/TranslationUtils.gd
@@ -832,6 +843,10 @@ msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Move the selected elements down"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Find"
 msgstr ""
 
 #: src/TranslationUtils.gd
@@ -856,6 +871,10 @@ msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Enable snap"
 msgstr ""
 
 #: src/TranslationUtils.gd

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -222,7 +222,6 @@ msgid "OK"
 msgstr "Добре"
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr "Запиши SVG-то"
 
@@ -343,13 +342,34 @@ msgstr "Качество"
 msgid "Scale"
 msgstr "Мащаб"
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr "Експортирай"
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
 msgstr "Краен размер"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr "Файл"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr "Промени"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr "Инструмент"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr "Гледка"
+
+#: src/ui_parts/global_menu.gd
+#, fuzzy
+msgid "Snap"
+msgstr "Размер на захващането"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
@@ -592,22 +612,6 @@ msgid "Language"
 msgstr "Език"
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr "Файл"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr "Промени"
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr "Гледка"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr "Инструмент"
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr "Помощ"
 
@@ -823,8 +827,19 @@ msgid "Convert To"
 msgstr "Превърни в"
 
 #: src/TranslationUtils.gd
-msgid "Import"
+#, fuzzy
+msgid "Export Image"
+msgstr "Експортирай"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Import SVG"
 msgstr "Импортирай"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Export SVG"
+msgstr "Експортирай"
 
 #: src/TranslationUtils.gd
 msgid "Select all elements"
@@ -845,6 +860,10 @@ msgstr "Премести избраните елементи нагоре"
 #: src/TranslationUtils.gd
 msgid "Move the selected elements down"
 msgstr "Премести избраните елементи надолу"
+
+#: src/TranslationUtils.gd
+msgid "Find"
+msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Zoom in"
@@ -869,6 +888,11 @@ msgstr "Покажи дръжките"
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
 msgstr "Покажи растеризиран SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Enable snap"
+msgstr "Включи захващането"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"

--- a/translations/de.po
+++ b/translations/de.po
@@ -225,7 +225,6 @@ msgid "OK"
 msgstr "OK"
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 #, fuzzy
 msgid "Save SVG"
 msgstr "Speichern"
@@ -353,13 +352,34 @@ msgstr ""
 msgid "Scale"
 msgstr "Skalieren"
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr "Exportieren"
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
 msgstr "Endgültige Größe"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd
+#, fuzzy
+msgid "Snap"
+msgstr "Einrastgröße"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
@@ -624,22 +644,6 @@ msgid "Language"
 msgstr "Sprache"
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr ""
 
@@ -856,8 +860,19 @@ msgid "Convert To"
 msgstr "Konvertieren zu"
 
 #: src/TranslationUtils.gd
-msgid "Import"
+#, fuzzy
+msgid "Export Image"
+msgstr "Exportieren"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Import SVG"
 msgstr "Importieren"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Export SVG"
+msgstr "Exportieren"
 
 #: src/TranslationUtils.gd
 #, fuzzy
@@ -882,6 +897,10 @@ msgstr "Ausgewählte Tags nach oben verschieben"
 #, fuzzy
 msgid "Move the selected elements down"
 msgstr "Ausgewählte Tags nach unten verschieben"
+
+#: src/TranslationUtils.gd
+msgid "Find"
+msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Zoom in"
@@ -909,6 +928,11 @@ msgstr "Griffe anzeigen"
 #, fuzzy
 msgid "Show rasterized SVG"
 msgstr "SVG rasterisieren"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Enable snap"
+msgstr "Einrasten aktivieren"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"

--- a/translations/en.po
+++ b/translations/en.po
@@ -222,7 +222,6 @@ msgid "OK"
 msgstr ""
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr ""
 
@@ -343,12 +342,32 @@ msgstr ""
 msgid "Scale"
 msgstr ""
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr ""
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr ""
+
+#: src/ui_parts/global_menu.gd
+msgid "Snap"
 msgstr ""
 
 #: src/ui_parts/good_file_dialog.gd
@@ -590,22 +609,6 @@ msgid "Language"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr ""
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr ""
 
@@ -811,7 +814,15 @@ msgid "Convert To"
 msgstr ""
 
 #: src/TranslationUtils.gd
-msgid "Import"
+msgid "Export Image"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Import SVG"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Export SVG"
 msgstr ""
 
 #: src/TranslationUtils.gd
@@ -832,6 +843,10 @@ msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Move the selected elements down"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Find"
 msgstr ""
 
 #: src/TranslationUtils.gd
@@ -856,6 +871,10 @@ msgstr ""
 
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
+msgstr ""
+
+#: src/TranslationUtils.gd
+msgid "Enable snap"
 msgstr ""
 
 #: src/TranslationUtils.gd

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -224,7 +224,6 @@ msgid "OK"
 msgstr "Хорошо"
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr "Сохранить SVG"
 
@@ -345,13 +344,34 @@ msgstr "Качество"
 msgid "Scale"
 msgstr "Масштаб"
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr "Экспортовать"
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
 msgstr "Финальный размер"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr "Файл"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr "Редактировать"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr "Инструмент"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr "Просмотр"
+
+#: src/ui_parts/global_menu.gd
+#, fuzzy
+msgid "Snap"
+msgstr "Размер привязки"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
@@ -600,22 +620,6 @@ msgid "Language"
 msgstr "Язык"
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr "Файл"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr "Редактировать"
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr "Просмотр"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr "Инструмент"
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr "Помощь"
 
@@ -835,8 +839,18 @@ msgid "Convert To"
 msgstr "Конвертировать в"
 
 #: src/TranslationUtils.gd
-msgid "Import"
-msgstr "Импортировать"
+#, fuzzy
+msgid "Export Image"
+msgstr "Экспортовать"
+
+#: src/TranslationUtils.gd
+msgid "Import SVG"
+msgstr "Импортировать SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Export SVG"
+msgstr "Импортировать SVG"
 
 #: src/TranslationUtils.gd
 #, fuzzy
@@ -863,6 +877,10 @@ msgid "Move the selected elements down"
 msgstr "Подвинуть вниз все выбранные теги"
 
 #: src/TranslationUtils.gd
+msgid "Find"
+msgstr ""
+
+#: src/TranslationUtils.gd
 msgid "Zoom in"
 msgstr "Приблизить масштаб"
 
@@ -885,6 +903,11 @@ msgstr "Показать ручки редактирования"
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
 msgstr "Показать растеризованый SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Enable snap"
+msgstr "Включить привязку"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"
@@ -962,6 +985,9 @@ msgstr "Кубическая Безье до"
 msgid "Shorthand Cubic Bezier to"
 msgstr "Сокращенная кубическая Безье до"
 
+#~ msgid "Import"
+#~ msgstr "Импортировать"
+
 #~ msgid "Tag color"
 #~ msgstr "Цвет тега"
 
@@ -1013,6 +1039,3 @@ msgstr "Сокращенная кубическая Безье до"
 #, fuzzy
 #~ msgid "Clear association"
 #~ msgstr "Удалить"
-
-#~ msgid "Import SVG"
-#~ msgstr "Импортировать SVG"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -223,7 +223,6 @@ msgid "OK"
 msgstr "Добре"
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr "Зберегти SVG"
 
@@ -344,13 +343,34 @@ msgstr "Якість"
 msgid "Scale"
 msgstr "Масштаб"
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr "Експортувати"
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
 msgstr "Фінальний розмір"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr "Файл"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr "Редагування"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr "Інструмент"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr "Перегляд"
+
+#: src/ui_parts/global_menu.gd
+#, fuzzy
+msgid "Snap"
+msgstr "Розмір прилипання"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
@@ -600,22 +620,6 @@ msgid "Language"
 msgstr "Мова"
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr "Файл"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr "Редагування"
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr "Перегляд"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr "Інструмент"
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr "Допомога"
 
@@ -839,8 +843,18 @@ msgid "Convert To"
 msgstr "Конвертувати в"
 
 #: src/TranslationUtils.gd
-msgid "Import"
-msgstr "Імпортувати"
+#, fuzzy
+msgid "Export Image"
+msgstr "Експортувати"
+
+#: src/TranslationUtils.gd
+msgid "Import SVG"
+msgstr "Імпортувати SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Export SVG"
+msgstr "Імпортувати SVG"
 
 #: src/TranslationUtils.gd
 #, fuzzy
@@ -867,6 +881,10 @@ msgid "Move the selected elements down"
 msgstr "Пересунути усі обрані теги вниз"
 
 #: src/TranslationUtils.gd
+msgid "Find"
+msgstr ""
+
+#: src/TranslationUtils.gd
 msgid "Zoom in"
 msgstr "Збільшити масштаб"
 
@@ -889,6 +907,11 @@ msgstr "Показати ручки редагування"
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
 msgstr "Показати растеризуваний SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Enable snap"
+msgstr "Активувати прилипання"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"
@@ -966,6 +989,9 @@ msgstr "Кубічна Безьє до"
 msgid "Shorthand Cubic Bezier to"
 msgstr "Скорочена кубічна Безьє до"
 
+#~ msgid "Import"
+#~ msgstr "Імпортувати"
+
 #~ msgid "Tag color"
 #~ msgstr "Колір тегу"
 
@@ -1005,6 +1031,3 @@ msgstr "Скорочена кубічна Безьє до"
 #, fuzzy
 #~ msgid "Clear association"
 #~ msgstr "Видалити асоціацію"
-
-#~ msgid "Import SVG"
-#~ msgstr "Імпортувати SVG"

--- a/translations/zh.po
+++ b/translations/zh.po
@@ -222,7 +222,6 @@ msgid "OK"
 msgstr "确定"
 
 #: src/ui_parts/code_editor.gd src/ui_parts/good_file_dialog.gd
-#: src/TranslationUtils.gd
 msgid "Save SVG"
 msgstr "保存 SVG"
 
@@ -343,13 +342,34 @@ msgstr "质量"
 msgid "Scale"
 msgstr "缩放"
 
-#: src/ui_parts/export_dialog.gd src/TranslationUtils.gd
+#: src/ui_parts/export_dialog.gd
 msgid "Export"
 msgstr "导出"
 
 #: src/ui_parts/export_dialog.gd
 msgid "Final size"
 msgstr "最终大小"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "File"
+msgstr "文件"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Edit"
+msgstr "编辑"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "Tool"
+msgstr "工具"
+
+#: src/ui_parts/global_menu.gd src/ui_parts/settings_menu.gd
+msgid "View"
+msgstr "视图"
+
+#: src/ui_parts/global_menu.gd
+#, fuzzy
+msgid "Snap"
+msgstr "吸附大小"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
@@ -597,22 +617,6 @@ msgid "Language"
 msgstr "语言"
 
 #: src/ui_parts/settings_menu.gd
-msgid "File"
-msgstr "文件"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Edit"
-msgstr "编辑"
-
-#: src/ui_parts/settings_menu.gd
-msgid "View"
-msgstr "视图"
-
-#: src/ui_parts/settings_menu.gd
-msgid "Tool"
-msgstr "工具"
-
-#: src/ui_parts/settings_menu.gd
 msgid "Help"
 msgstr "帮助"
 
@@ -830,8 +834,19 @@ msgid "Convert To"
 msgstr "转换为"
 
 #: src/TranslationUtils.gd
-msgid "Import"
+#, fuzzy
+msgid "Export Image"
+msgstr "导出"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Import SVG"
 msgstr "导入"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Export SVG"
+msgstr "导出"
 
 #: src/TranslationUtils.gd
 #, fuzzy
@@ -858,6 +873,10 @@ msgid "Move the selected elements down"
 msgstr "将选中的元素下移"
 
 #: src/TranslationUtils.gd
+msgid "Find"
+msgstr ""
+
+#: src/TranslationUtils.gd
 msgid "Zoom in"
 msgstr "放大"
 
@@ -880,6 +899,11 @@ msgstr "显示拖拽框"
 #: src/TranslationUtils.gd
 msgid "Show rasterized SVG"
 msgstr "显示光栅化 SVG"
+
+#: src/TranslationUtils.gd
+#, fuzzy
+msgid "Enable snap"
+msgstr "启用吸附"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"

--- a/visual/fonts/Font.ttf.import
+++ b/visual/fonts/Font.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/Font.ttf-ab23156a8f74313018e59a9482cc956b.fon
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/visual/fonts/FontBold.ttf.import
+++ b/visual/fonts/FontBold.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/FontBold.ttf-1e1f4e9653596be23836f0f07c44b39f
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/visual/fonts/FontMono.ttf.import
+++ b/visual/fonts/FontMono.ttf.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/FontMono.ttf-a376ecc2a480b8f7f1be2af334133b0b
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48


### PR DESCRIPTION
Draft because I used the new Godot 4.3+ API so this will only work with Godot 4.3+. Follow-up to #643.

<img width="800" alt="Screenshot 2024-04-09 at 4 33 47 AM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/80b939c1-f610-4984-9274-797f9e67db86">
<img width="800" alt="Screenshot 2024-04-09 at 4 34 07 AM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/257e169b-2364-4713-ac15-3bba04c16183">
<img width="800" alt="Screenshot 2024-04-09 at 4 34 17 AM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/36fb9103-0303-41d4-b848-32f22ce1a285">
<img width="800" alt="Screenshot 2024-04-09 at 4 34 29 AM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/0ea7c3c0-1604-4ecd-8410-c3e058fd6f79">

This is not just about clicking buttons in the menu, it also provides convenient documentation for the user of what actions are available and which have keys available to press.
<img width="800" alt="Screenshot 2024-04-09 at 4 33 14 AM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/36b8e111-2e9b-47b8-bb96-41fd4f9dd9f9">
