### PR TITLE
Ensure decent performance of GoodFileDialog

### DIFF
--- a/src/Indications.gd
+++ b/src/Indications.gd
@@ -1,5 +1,5 @@
-## This singleton handles editor information like zoom level and selections.
 extends Node
+## This singleton handles editor information like zoom level and selections.
 
 const ContextPopup = preload("res://src/ui_elements/context_popup.tscn")
 const PathCommandPopup = preload("res://src/ui_elements/path_popup.tscn")

--- a/src/SVG.gd
+++ b/src/SVG.gd
@@ -1,6 +1,6 @@
+extends Node
 ## This singleton handles the two representations of the SVG:
 ## The SVG text, and the native [TagSVG] representation.
-extends Node
 
 
 signal parsing_finished(error_id: SVGParser.ParseError)

--- a/src/data_classes/Attribute.gd
+++ b/src/data_classes/Attribute.gd
@@ -1,5 +1,5 @@
-## Abstract class for an attribute inside a [Tag], i.e. <tag attribute="value"/>
 class_name Attribute extends RefCounted
+## Abstract class for an attribute inside a [Tag], i.e. <tag attribute="value"/>
 
 signal value_changed(new_value: String)
 signal propagate_value_changed(undo_redo: bool)

--- a/src/data_classes/AttributeColor.gd
+++ b/src/data_classes/AttributeColor.gd
@@ -1,5 +1,5 @@
-## An attribute representing a color string, or an url to an ID.
 class_name AttributeColor extends Attribute
+## An attribute representing a color string, or an url to an ID.
 
 # No direct color representation for this attribute type. There are too many quirks.
 

--- a/src/data_classes/AttributeEnum.gd
+++ b/src/data_classes/AttributeEnum.gd
@@ -1,5 +1,5 @@
-## An attribute with only a set of meaningful values.
 class_name AttributeEnum extends Attribute
+## An attribute with only a set of meaningful values.
 
 var possible_values: Array[String]
 

--- a/src/data_classes/AttributeList.gd
+++ b/src/data_classes/AttributeList.gd
@@ -1,5 +1,5 @@
-## An attribute representing a list of numbers.
 class_name AttributeList extends Attribute
+## An attribute representing a list of numbers.
 
 var _list: PackedFloat32Array
 

--- a/src/data_classes/AttributeNumeric.gd
+++ b/src/data_classes/AttributeNumeric.gd
@@ -1,5 +1,5 @@
-## An attribute representing a number.
 class_name AttributeNumeric extends Attribute
+## An attribute representing a number.
 
 var _number := NAN
 enum Mode {FLOAT, UFLOAT, NFLOAT}  # UFLOAT is positive-only, NFLOAT is in [0, 1].

--- a/src/data_classes/AttributePath.gd
+++ b/src/data_classes/AttributePath.gd
@@ -1,5 +1,5 @@
-## The "d" attribute of [TagPath].
 class_name AttributePath extends Attribute
+## The "d" attribute of [TagPath].
 
 var _commands: Array[PathCommand]
 

--- a/src/data_classes/AttributeTransform.gd
+++ b/src/data_classes/AttributeTransform.gd
@@ -1,5 +1,5 @@
-## An attribute representing a list of transforms.
 class_name AttributeTransform extends Attribute
+## An attribute representing a list of transforms.
 
 class Transform extends RefCounted:
 	func compute_transform() -> Transform2D:

--- a/src/data_classes/AttributeUnknown.gd
+++ b/src/data_classes/AttributeUnknown.gd
@@ -1,5 +1,5 @@
-## An attribute not recognized by GodSVG.
 class_name AttributeUnknown extends Attribute
+## An attribute not recognized by GodSVG.
 
 var name := ""
 

--- a/src/data_classes/ColorPalette.gd
+++ b/src/data_classes/ColorPalette.gd
@@ -1,4 +1,7 @@
 class_name ColorPalette extends Resource
+## A resource for the color palettes that are listed in the color picker.
+
+signal layout_changed
 
 @export var title: String  # Color palettes must be uniquely named.
 @export var colors: Array[String]  # Colors must be unique within a palette.
@@ -16,11 +19,13 @@ func add_color() -> void:
 	colors.append("none")
 	color_names.append("")
 	emit_changed()
+	layout_changed.emit()
 
 func remove_color(idx: int) -> void:
 	colors.remove_at(idx)
 	color_names.remove_at(idx)
 	emit_changed()
+	layout_changed.emit()
 
 func move_color(old_idx: int, new_idx: int) -> void:
 	if old_idx == new_idx:
@@ -32,6 +37,7 @@ func move_color(old_idx: int, new_idx: int) -> void:
 	colors.insert(new_idx, colors.pop_at(old_idx))
 	color_names.insert(new_idx, color_names.pop_at(old_idx))
 	emit_changed()
+	layout_changed.emit()
 
 func modify_title(new_title: String) -> void:
 	title = new_title

--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -1,5 +1,5 @@
-## A SVG tag, standalone ([code]<tag/>[/code]) or container ([code]<tag></tag>[/code]).
 class_name Tag extends RefCounted
+## A SVG tag, standalone ([code]<tag/>[/code]) or container ([code]<tag></tag>[/code]).
 
 var child_tags: Array[Tag]
 

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -1,5 +1,5 @@
-## An <ellipse/> tag.
 class_name TagEllipse extends Tag
+## An <ellipse/> tag.
 
 const name = "ellipse"
 const possible_conversions = ["circle", "rect", "path"]

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -1,5 +1,5 @@
-## A <line/> tag.
 class_name TagLine extends Tag
+## A <line/> tag.
 
 const name = "line"
 const possible_conversions = ["path"]

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -1,5 +1,5 @@
-## A <path/> tag.
 class_name TagPath extends Tag
+## A <path/> tag.
 
 const name = "path"
 const possible_conversions = []

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -1,5 +1,5 @@
-## A <rect/> tag.
 class_name TagRect extends Tag
+## A <rect/> tag.
 
 const name = "rect"
 const possible_conversions = ["circle", "ellipse", "path"]

--- a/src/data_classes/TagSVG.gd
+++ b/src/data_classes/TagSVG.gd
@@ -1,5 +1,5 @@
-## A <svg></svg> tag.
 class_name TagSVG extends Tag
+## A <svg></svg> tag.
 
 var width: float
 var height: float

--- a/src/data_classes/TagStop.gd
+++ b/src/data_classes/TagStop.gd
@@ -1,5 +1,5 @@
-## A <stop/> tag.
 class_name TagStop extends Tag
+## A <stop/> tag.
 
 const name = "stop"
 const possible_conversions = []

--- a/src/data_classes/TagUnknown.gd
+++ b/src/data_classes/TagUnknown.gd
@@ -1,5 +1,5 @@
-## A tag not recognized by GodSVG.
 class_name TagUnknown extends Tag
+## A tag not recognized by GodSVG.
 
 var name: String
 const possible_conversions = []

--- a/src/ui_elements/palette_config.gd
+++ b/src/ui_elements/palette_config.gd
@@ -20,7 +20,7 @@ var currently_edited_idx := -1
 # Used to setup a palette for this element.
 func assign_palette(palette: ColorPalette) -> void:
 	current_palette = palette
-	current_palette.changed.connect(rebuild_colors)
+	current_palette.layout_changed.connect(rebuild_colors)
 	rebuild_colors()
 
 # Rebuilds the content of the colors container.
@@ -232,8 +232,10 @@ func _drop_data(_at_position: Vector2, data: Variant) -> void:
 		return
 	
 	if data[0] == current_palette:
+		currently_edited_idx = -1
 		current_palette.move_color(data[1], proposed_drop_idx)
 	else:
+		currently_edited_idx = -1
 		current_palette.colors.insert(proposed_drop_idx, data[0].colors[data[1]])
 		current_palette.color_names.insert(proposed_drop_idx, data[0].color_names[data[1]])
 		current_palette.emit_changed()


### PR DESCRIPTION
- Only renders images in the fallback file dialog when they are in the visible area, ensuring performance remains always tolerable.
- Fixes some huge issues with editing color palettes.
- Fixes top doc comments in the wrong place.