### PR TITLE
Add an "Auto UI scale" feature

### DIFF
--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -70,13 +70,17 @@ func setup_setting_labels() -> void:
 	use_native_file_dialog.label.text = tr("Use native file dialog")
 	use_native_file_dialog.tooltip_text = tr("If turned on, uses your operating system's native file dialog. If turned off, uses GodSVG's built-in file dialog.")
 	
-	var handles_size := %ContentContainer/Other/OtherSettings/Misc/HandleSize
+	var handles_size := %Misc/HandleSize
 	handles_size.label.text = tr("Handles size")
 	handles_size.tooltip_text = tr("Increases the visual size and grabbing area of handles.")
 	
-	var ui_scale := %ContentContainer/Other/OtherSettings/Misc/UIScale
+	var ui_scale := %Misc/UIScale
 	ui_scale.label.text = tr("UI scale")
 	ui_scale.tooltip_text = tr("Changes the scale of the visual user interface.")
+	
+	var auto_ui_scale := %Misc/AutoUIScale
+	auto_ui_scale.label.text = tr("Auto UI scale")
+	auto_ui_scale.tooltip_text = tr("Scale the user interface based on the window size.")
 	
 	%GeneralVBox/NumberPrecision.label.text = tr("Number precision digits")
 	%GeneralVBox/AnglePrecision.label.text = tr("Angle precision digits")

--- a/src/ui_parts/settings_menu.tscn
+++ b/src/ui_parts/settings_menu.tscn
@@ -509,6 +509,7 @@ section_name = "other"
 setting_name = "use_ctrl_for_zoom"
 
 [node name="Misc" type="VBoxContainer" parent="VBoxContainer/HBoxContainer/MainPanel/ContentContainer/Other/OtherSettings"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -543,6 +544,11 @@ type = 3
 restricted = false
 number_min = 0.5
 number_max = 2.5
+
+[node name="AutoUIScale" parent="VBoxContainer/HBoxContainer/MainPanel/ContentContainer/Other/OtherSettings/Misc" instance=ExtResource("4_2qeh2")]
+layout_mode = 2
+section_name = "other"
+setting_name = "auto_ui_scale"
 
 [node name="CloseButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2


### PR DESCRIPTION
As of #115, the default UI scale is unusable on macOS:
<img width="1900" alt="Screenshot 2024-04-17 at 7 25 07 PM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/182fb1c2-aa9c-4a00-acca-34ff84b9e9f0">

This PR adds a new feature, enabled by default, that will automatically increase the UI scale. I added a new checkbox to the settings menu. When unchecked, the UI scale number directly sets the UI scale. When checked, the UI scale number acts as a multiplier, and the actual scale is calculated from this number and the window size.
<img width="420" alt="Screenshot 2024-04-17 at 7 26 49 PM" src="https://github.com/MewPurPur/GodSVG/assets/1646875/7aa08b3f-e523-44a2-b8a5-9cbd1fb13985">
