### PR TITLE
Switch auto UI scale to use screen DPI

### DIFF
--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -246,8 +246,9 @@ func get_validity_color(error_condition: bool, warning_condition := false) -> Co
 
 
 func update_ui_scale() -> void:
-	await get_tree().process_frame
 	var window := get_window()
+	if not window.is_node_ready():
+		await window.ready
 	
 	var usable_screen_size := Vector2(
 		DisplayServer.screen_get_usable_rect(DisplayServer.window_get_current_screen()).size

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -293,7 +293,7 @@ func _calculate_auto_scale() -> float:
 			return 1.0
 		elif dpi <= 120:
 			return 1.25
-		elif dpi <=160:
+		elif dpi <= 160:
 			return 1.5
 		elif dpi <= 200:
 			return 2.0

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -257,8 +257,7 @@ func update_ui_scale() -> void:
 	
 	# How much can window content size be multiplied by before it extends over the usable screen size.
 	var diff :=  usable_screen_size / window.get_contents_minimum_size()
-	var max_scale := floorf(minf(diff.x, diff.y)*4.0)/4.0
-	
+	var max_scale := floorf(minf(diff.x, diff.y) * 4.0) / 4.0
 	var desired_scale: float = ui_scale * _calculate_auto_scale()
 	
 	if not desired_scale > max_scale:

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -191,6 +191,7 @@ func _enter_tree() -> void:
 		default_input_events[action] = InputMap.action_get_events(action)
 	load_settings()
 	load_user_data()
+	get_window().dpi_changed.connect(update_ui_scale)
 	update_ui_scale()
 	ThemeGenerator.generate_theme()
 
@@ -290,14 +291,20 @@ func _calculate_auto_scale() -> float:
 			return 0.75
 		elif dpi <= 96:
 			return 1.0
-		elif dpi <=160:
+		elif dpi <= 120:
 			return 1.25
-		elif dpi <= 240:
+		elif dpi <=160:
 			return 1.5
-		elif dpi <= 480:
-			return 1.75
-		elif dpi > 480:
+		elif dpi <= 200:
 			return 2.0
+		elif dpi <= 240:
+			return 2.5
+		elif dpi <= 320:
+			return 3.0
+		elif dpi <= 480:
+			return 4.0
+		else:  # dpi > 480
+			return 5.0
 	elif smallest_dimension >= 1700:
 		# Likely a hiDPI display, but we aren't certain due to the returned DPI.
 		# Use an intermediate scale to handle this situation.

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -80,7 +80,7 @@ func setup_setting_labels() -> void:
 	
 	var auto_ui_scale := %Misc/AutoUIScale
 	auto_ui_scale.label.text = tr("Auto UI scale")
-	auto_ui_scale.tooltip_text = tr("Scale the user interface based on the screen size.")
+	auto_ui_scale.tooltip_text = tr("Scales the user interface based on the screen size.")
 	
 	%GeneralVBox/NumberPrecision.label.text = tr("Number precision digits")
 	%GeneralVBox/AnglePrecision.label.text = tr("Angle precision digits")

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -80,7 +80,7 @@ func setup_setting_labels() -> void:
 	
 	var auto_ui_scale := %Misc/AutoUIScale
 	auto_ui_scale.label.text = tr("Auto UI scale")
-	auto_ui_scale.tooltip_text = tr("Scale the user interface based on the window size.")
+	auto_ui_scale.tooltip_text = tr("Scale the user interface based on the screen size.")
 	
 	%GeneralVBox/NumberPrecision.label.text = tr("Number precision digits")
 	%GeneralVBox/AnglePrecision.label.text = tr("Angle precision digits")

--- a/src/ui_parts/settings_menu.tscn
+++ b/src/ui_parts/settings_menu.tscn
@@ -539,11 +539,11 @@ number_max = 2.5
 layout_mode = 2
 section_name = "other"
 setting_name = "ui_scale"
-values = Array[String](["0.75", "1.0", "1.25", "1.5", "1.75", "2.0"])
+values = Array[String](["0.75", "1.0", "1.25", "1.5", "1.75", "2.0", "2.5", "3.0", "4.0"])
 type = 3
 restricted = false
 number_min = 0.5
-number_max = 2.5
+number_max = 10.0
 
 [node name="AutoUIScale" parent="VBoxContainer/HBoxContainer/MainPanel/ContentContainer/Other/OtherSettings/Misc" instance=ExtResource("4_2qeh2")]
 layout_mode = 2

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -44,11 +44,18 @@ msgstr ""
 msgid ""
 "If turned on, scrolling will pan the view. To zoom, hold CTRL while "
 "scrolling."
+msgstr ""
 
 msgid "UI scale"
 msgstr ""
 
 msgid "Changes the scale of the visual user interface."
+msgstr ""
+
+msgid "Auto UI scale"
+msgstr ""
+
+msgid "Scales the user interface based on the screen size."
 msgstr ""
 
 msgid "Input"

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -56,6 +56,13 @@ msgstr "Мащаб"
 msgid "Changes the scale of the visual user interface."
 msgstr ""
 
+#, fuzzy
+msgid "Auto UI scale"
+msgstr "Мащаб"
+
+msgid "Scales the user interface based on the screen size."
+msgstr ""
+
 msgid "Input"
 msgstr "Входни сигнали"
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -57,6 +57,13 @@ msgstr "Skalieren"
 msgid "Changes the scale of the visual user interface."
 msgstr ""
 
+#, fuzzy
+msgid "Auto UI scale"
+msgstr "Skalieren"
+
+msgid "Scales the user interface based on the screen size."
+msgstr ""
+
 msgid "Input"
 msgstr "Eingabe"
 

--- a/translations/en.po
+++ b/translations/en.po
@@ -53,6 +53,12 @@ msgstr ""
 msgid "Changes the scale of the visual user interface."
 msgstr ""
 
+msgid "Auto UI scale"
+msgstr ""
+
+msgid "Scales the user interface based on the screen size."
+msgstr ""
+
 msgid "Input"
 msgstr ""
 

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -59,6 +59,13 @@ msgstr "Масштаб"
 msgid "Changes the scale of the visual user interface."
 msgstr ""
 
+#, fuzzy
+msgid "Auto UI scale"
+msgstr "Масштаб"
+
+msgid "Scales the user interface based on the screen size."
+msgstr ""
+
 msgid "Input"
 msgstr "Устройства ввода"
 

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -60,6 +60,13 @@ msgstr "Масштаб"
 msgid "Changes the scale of the visual user interface."
 msgstr ""
 
+#, fuzzy
+msgid "Auto UI scale"
+msgstr "Масштаб"
+
+msgid "Scales the user interface based on the screen size."
+msgstr ""
+
 msgid "Input"
 msgstr "Пристрої вводу"
 


### PR DESCRIPTION
- This makes auto scaling use screen DPI.
- Limits scale to a calculated max scale to avoid glitches when min size would be bigger than usable screen size.

This has to be tested on more devices. @aaronfranke
I only tested this on my phone and laptop, which both have low resolution screens. Different DPI though so it's tested a little bit and seems to work.

Previously it was making the default experience on phone even worse, because it made UI even smaller than it already was without automatic scale. I know phones arent really supported anyways, but I hope this fix also makes it better on desktop.

Edit: I did some testing on my laptop (1366x768,  DPI 96). Previous implementation would make UI too small on it. New one seems to work well. Also tested with the AMD virtual resulution to set it to higher resolutions (FHD, DPI 120), and it still works well.