### PR TITLE
Small improvements and fixes

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -59,12 +59,13 @@ optimize={
 }
 open_settings={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":44,"physical_keycode":0,"key_label":0,"unicode":44,"echo":false,"script":null)
+]
 }
 import={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":79,"physical_keycode":0,"key_label":0,"unicode":111,"echo":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":73,"physical_keycode":0,"key_label":0,"unicode":105,"echo":false,"script":null)
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":73,"physical_keycode":0,"key_label":0,"unicode":105,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":79,"physical_keycode":0,"key_label":0,"unicode":111,"echo":false,"script":null)
 ]
 }
 export={

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -184,7 +184,6 @@ func load_user_data() -> void:
 		save_data = ResourceLoader.load(save_path)
 
 func _exit_tree() -> void:
-	save_data.window_mode = DisplayServer.window_get_mode()
 	ResourceSaver.save(save_data, save_path)
 
 func _enter_tree() -> void:
@@ -192,7 +191,6 @@ func _enter_tree() -> void:
 		default_input_events[action] = InputMap.action_get_events(action)
 	load_settings()
 	load_user_data()
-	DisplayServer.window_set_mode(save_data.window_mode)
 	get_window().wrap_controls = true  # Prevents the main window from getting too small.
 	update_ui_scale()
 	get_window().size_changed.connect(update_ui_scale)

--- a/src/HandlerGUI.gd
+++ b/src/HandlerGUI.gd
@@ -165,13 +165,16 @@ func _input(event: InputEvent) -> void:
 
 func _unhandled_input(event: InputEvent) -> void:
 	# Clear popups or overlays.
-	if event.is_action_pressed("ui_cancel"):
-		if not popup_overlay_stack.is_empty():
-			get_viewport().set_input_as_handled()
+	if not popup_overlay_stack.is_empty():
+		get_viewport().set_input_as_handled()
+		if event.is_action_pressed("ui_cancel"):
 			remove_popup_overlay()
-		elif not overlay_stack.is_empty():
-			get_viewport().set_input_as_handled()
+		return
+	elif not overlay_stack.is_empty():
+		get_viewport().set_input_as_handled()
+		if event.is_action_pressed("ui_cancel"):
 			remove_overlay()
+		return
 	
 	if event.is_action_pressed("redo"):
 		get_viewport().set_input_as_handled()

--- a/src/data_classes/SaveData.gd
+++ b/src/data_classes/SaveData.gd
@@ -3,7 +3,6 @@ class_name SaveData extends Resource
 
 const GoodColorPicker = preload("res://src/ui_elements/good_color_picker.gd")
 
-@export var window_mode := DisplayServer.WINDOW_MODE_MAXIMIZED
 @export var svg_text := ""
 @export var viewbox_coupling := true
 @export var snap := -0.5  # Negative when disabled.

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -119,11 +119,6 @@ func setup_setting_labels() -> void:
 	%BasicColorsVBox/ErrorColor.label.text = tr("Error color")
 	%BasicColorsVBox/WarningColor.label.text = tr("Warning color")
 
-func _on_window_mode_pressed() -> void:
-	GlobalSettings.save_window_mode = not GlobalSettings.save_window_mode
-
-func _on_svg_pressed() -> void:
-	GlobalSettings.save_svg = not GlobalSettings.save_svg
 
 func _on_language_pressed() -> void:
 	var btn_arr: Array[Button] = []
@@ -206,8 +201,7 @@ func _on_number_precision_changed() -> void:
 		GlobalSettings.save_data.snap = quanta
 		if not snapping_on:
 			GlobalSettings.save_data.snap *= -1
-	get_tree().get_root().propagate_notification(
-			Utils.CustomNotification.NUMBER_PRECISION_CHANGED)
+	custom_notify(Utils.CustomNotification.NUMBER_PRECISION_CHANGED)
 
 func disable_autoformat_checkboxes() -> void:
 	var is_autoformatting_numbers := GlobalSettings.number_enable_autoformatting


### PR DESCRIPTION
Adds `Ctrl+,` as a shortcut to open settings.

Fixes bug where inputs weren't input when overlays were active.

Small cleanup.

Removes window mode from SaveData.