### PR TITLE
Implements navigation using tab and shift+tab

### DIFF
--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	focus_entered.connect(_on_focus_entered)
 	focus_exited.connect(_on_focus_exited)
 	mouse_exited.connect(_on_mouse_exited)
-	text_submitted.connect(_on_text_submitted.unbind(1))
+	text_submitted.connect(_on_text_submitted)
 
 func _input(event: InputEvent) -> void:
 	if has_focus():

--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	focus_entered.connect(_on_focus_entered)
 	focus_exited.connect(_on_focus_exited)
 	mouse_exited.connect(_on_mouse_exited)
-	text_submitted.connect(func(): if not Input.is_action_just_pressed("ui_focus_next"): release_focus.unbind(1))
+	text_submitted.connect(_on_text_submitted.unbind(1))
 
 func _input(event: InputEvent) -> void:
 	if has_focus():
@@ -35,7 +35,7 @@ func _input(event: InputEvent) -> void:
 		elif first_click:
 			first_click = false
 			select_all()
-		elif event.is_action_pressed("ui_focus_next"):
+		elif event.is_action_pressed("ui_focus_next") || event.is_action_pressed("ui_focus_next"):
 			text_submitted.emit(text)
 
 var tree_was_paused_before := false
@@ -58,6 +58,10 @@ func _on_focus_exited() -> void:
 	if Input.is_action_pressed("ui_cancel"):
 		text = text_before_focus
 		text_change_canceled.emit()
+
+func _on_text_submitted(_submitted_text: String) -> void:
+	if not Input.is_action_just_pressed("ui_focus_next") && not Input.is_action_just_pressed("ui_focus_prev"):
+		release_focus()
 
 
 func _on_mouse_exited() -> void:

--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	focus_entered.connect(_on_focus_entered)
 	focus_exited.connect(_on_focus_exited)
 	mouse_exited.connect(_on_mouse_exited)
-	text_submitted.connect(release_focus.unbind(1))
+	text_submitted.connect(func(): if not Input.is_action_just_pressed("ui_focus_next"): release_focus.unbind(1))
 
 func _input(event: InputEvent) -> void:
 	if has_focus():
@@ -35,6 +35,8 @@ func _input(event: InputEvent) -> void:
 		elif first_click:
 			first_click = false
 			select_all()
+		elif event.is_action_pressed("ui_focus_next"):
+			text_submitted.emit(text)
 
 var tree_was_paused_before := false
 var first_click := false

--- a/src/ui_elements/color_edit.tscn
+++ b/src/ui_elements/color_edit.tscn
@@ -27,6 +27,5 @@ theme_type_variation = &"LeftConnectedButtonTransparent"
 
 [connection signal="text_change_canceled" from="LineEdit" to="." method="_on_text_change_canceled"]
 [connection signal="text_changed" from="LineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]
 [connection signal="resized" from="Button" to="." method="_on_button_resized"]

--- a/src/ui_elements/color_field.gd
+++ b/src/ui_elements/color_field.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 
 signal focused
 var attribute: AttributeColor
+var previous_focusable: Control
 
 const ColorPopup = preload("res://src/ui_elements/color_popup.tscn")
 const checkerboard = preload("res://visual/icons/backgrounds/ColorButtonBG.svg")
@@ -40,6 +41,10 @@ func _ready() -> void:
 	color_button.resized.connect(queue_redraw)
 	attribute.value_changed.connect(set_value)
 	color_edit.text_submitted.connect(set_value)
+	if previous_focusable:
+		previous_focusable.focus_next = previous_focusable.get_path_to(color_edit)
+		color_edit.focus_previous = color_edit.get_path_to(previous_focusable)
+	previous_focusable = color_edit
 
 
 func _on_button_pressed() -> void:

--- a/src/ui_elements/enum_field.gd
+++ b/src/ui_elements/enum_field.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 
 signal focused
 var attribute: AttributeEnum
+var previous_focusable: Control
 
 const bold_font = preload("res://visual/fonts/FontBold.ttf")
 const reload_icon = preload("res://visual/icons/Reload.svg")
@@ -26,6 +27,10 @@ func _ready() -> void:
 	set_value(attribute.get_value())
 	indicator.tooltip_text = attribute.name
 	indicator.placeholder_text = attribute.get_default()
+	if previous_focusable:
+		previous_focusable.focus_next = previous_focusable.get_path_to(indicator)
+		indicator.focus_previous = indicator.get_path_to(previous_focusable)
+	previous_focusable = indicator
 
 func _on_button_pressed() -> void:
 	var btn_arr: Array[Button] = []

--- a/src/ui_elements/enum_field.tscn
+++ b/src/ui_elements/enum_field.tscn
@@ -33,6 +33,5 @@ expand_icon = true
 [connection signal="focus_entered" from="LineEdit" to="." method="_on_focus_entered"]
 [connection signal="text_change_canceled" from="LineEdit" to="." method="_on_text_change_canceled"]
 [connection signal="text_changed" from="LineEdit" to="." method="_on_text_changed"]
-[connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
 [connection signal="gui_input" from="Button" to="." method="_on_button_gui_input"]
 [connection signal="pressed" from="Button" to="." method="_on_button_pressed"]

--- a/src/ui_elements/flag_field.tscn
+++ b/src/ui_elements/flag_field.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=6 format=3 uid="uid://br8g7w38jguh4"]
 
-[ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="1_p8s8y"]
+[ext_resource type="FontFile" uid="uid://c4wm102ulqhb5" path="res://visual/fonts/FontMono.ttf" id="1_p8s8y"]
 [ext_resource type="Script" path="res://src/ui_elements/flag_field.gd" id="2_0bhg4"]
 
 [sub_resource type="FontVariation" id="FontVariation_46ud6"]

--- a/src/ui_elements/mini_number_field.gd
+++ b/src/ui_elements/mini_number_field.gd
@@ -23,6 +23,7 @@ func get_value() -> float:
 
 func _on_text_submitted(submitted_text: String) -> void:
 	set_value(evaluate_after_input(submitted_text))
+	super(submitted_text)
 
 func evaluate_after_input(eval_text: String) -> float:
 	var num := NumberParser.evaluate(eval_text)

--- a/src/ui_elements/mini_number_field.tscn
+++ b/src/ui_elements/mini_number_field.tscn
@@ -10,5 +10,3 @@ mouse_filter = 1
 theme_type_variation = &"MiniLineEdit"
 script = ExtResource("1_ggi5v")
 code_font_tooltip = true
-
-[connection signal="text_submitted" from="." to="." method="_on_text_submitted"]

--- a/src/ui_elements/number_edit.gd
+++ b/src/ui_elements/number_edit.gd
@@ -39,6 +39,7 @@ func _ready() -> void:
 
 func _on_text_submitted(submitted_text: String) -> void:
 	set_value(NumberParser.evaluate(submitted_text))
+	super(submitted_text)
 
 func sync_text() -> void:
 	text = String.num(_value, GlobalSettings.general_number_precision)

--- a/src/ui_elements/number_edit.tscn
+++ b/src/ui_elements/number_edit.tscn
@@ -8,5 +8,3 @@ offset_right = 35.8125
 offset_bottom = 21.0
 focus_mode = 1
 script = ExtResource("1_dywrg")
-
-[connection signal="text_submitted" from="." to="." method="_on_text_submitted"]

--- a/src/ui_elements/number_field.gd
+++ b/src/ui_elements/number_field.gd
@@ -3,6 +3,7 @@ extends BetterLineEdit
 
 signal focused
 var attribute: AttributeNumeric
+var previous_focusable: Control
 
 var min_value := 0.0
 var max_value := 1.0
@@ -45,6 +46,10 @@ func _ready() -> void:
 	tooltip_text = attribute.name
 	placeholder_text = attribute.get_default()
 	text_submitted.connect(set_value)
+	if previous_focusable:
+		previous_focusable.focus_next = previous_focusable.get_path_to(self)
+		self.focus_previous = get_path_to(previous_focusable)
+	previous_focusable = self
 
 func _on_focus_entered() -> void:
 	remove_theme_color_override("font_color")

--- a/src/ui_elements/number_field_with_slider.gd
+++ b/src/ui_elements/number_field_with_slider.gd
@@ -21,7 +21,7 @@ func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> vo
 		if !is_finite(numeric_value):
 			sync(attribute.get_value())
 			return
-
+		
 		if not allow_higher and numeric_value > max_value:
 			numeric_value = max_value
 			new_value = NumberParser.num_to_text(numeric_value)
@@ -129,7 +129,7 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 		Utils.throw_mouse_motion_event(get_viewport())
 	else:
 		slider.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)
-
+	
 	if not slider_dragged:
 		if event is InputEventMouseMotion and event.button_mask == 0:
 			slider_hovered = true

--- a/src/ui_elements/number_field_with_slider.gd
+++ b/src/ui_elements/number_field_with_slider.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 
 signal focused
 var attribute: AttributeNumeric
+var previous_focusable: Control
 
 @onready var num_edit: LineEdit = $LineEdit
 @onready var slider: Button = $Slider
@@ -20,17 +21,17 @@ func set_value(new_value: String, update_type := Utils.UpdateType.REGULAR) -> vo
 		if !is_finite(numeric_value):
 			sync(attribute.get_value())
 			return
-		
+
 		if not allow_higher and numeric_value > max_value:
 			numeric_value = max_value
 			new_value = NumberParser.num_to_text(numeric_value)
 		elif not allow_lower and numeric_value < min_value:
 			numeric_value = min_value
 			new_value = NumberParser.num_to_text(numeric_value)
-		
+
 		new_value = NumberParser.num_to_text(numeric_value)
 		sync(attribute.format(new_value))
-	
+
 	sync(attribute.format(new_value))
 	# Update the attribute.
 	if new_value != attribute.get_value() or update_type == Utils.UpdateType.FINAL:
@@ -53,6 +54,10 @@ func _ready() -> void:
 	num_edit.placeholder_text = attribute.get_default()
 	slider.resized.connect(queue_redraw)  # Whyyyyy are their sizes wrong at first...
 	num_edit.text_submitted.connect(set_value)
+	if previous_focusable:
+		previous_focusable.focus_next = previous_focusable.get_path_to(num_edit)
+		num_edit.focus_previous = num_edit.get_path_to(previous_focusable)
+	previous_focusable = num_edit
 
 func _on_focus_entered() -> void:
 	num_edit.remove_theme_color_override("font_color")
@@ -124,7 +129,7 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 		Utils.throw_mouse_motion_event(get_viewport())
 	else:
 		slider.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)
-	
+
 	if not slider_dragged:
 		if event is InputEventMouseMotion and event.button_mask == 0:
 			slider_hovered = true

--- a/src/ui_elements/number_field_with_slider.tscn
+++ b/src/ui_elements/number_field_with_slider.tscn
@@ -31,6 +31,5 @@ keep_pressed_outside = true
 
 [connection signal="focus_entered" from="LineEdit" to="." method="_on_focus_entered"]
 [connection signal="text_change_canceled" from="LineEdit" to="." method="_on_text_change_canceled"]
-[connection signal="text_submitted" from="LineEdit" to="." method="_on_text_submitted"]
 [connection signal="gui_input" from="Slider" to="." method="_on_slider_gui_input"]
 [connection signal="mouse_exited" from="Slider" to="." method="_on_slider_mouse_exited"]

--- a/src/ui_elements/pathdata_field.gd
+++ b/src/ui_elements/pathdata_field.gd
@@ -17,6 +17,7 @@ const COMMAND_HEIGHT = 22.0
 
 signal focused
 var attribute: AttributePath
+var previous_focusable: Control
 var tid: PackedInt32Array  # The path field has inner selectables, so it needs this.
 
 const MiniNumberField = preload("mini_number_field.tscn")

--- a/src/ui_elements/tag_content_path.gd
+++ b/src/ui_elements/tag_content_path.gd
@@ -11,6 +11,7 @@ const EnumField = preload("res://src/ui_elements/enum_field.tscn")
 
 var tag: Tag
 var tid: PackedInt32Array
+var previous_focusable: Control
 
 func _ready() -> void:
 	path_field.set_attribute(tag.attributes.d)
@@ -43,4 +44,6 @@ func _ready() -> void:
 			input_field = EnumField.instantiate()
 		input_field.attribute = attribute
 		input_field.focused.connect(Indications.normal_select.bind(tid))
+		input_field.previous_focusable = previous_focusable
 		attribute_container.add_child(input_field)
+		previous_focusable = input_field.previous_focusable

--- a/src/ui_elements/tag_content_unknown.gd
+++ b/src/ui_elements/tag_content_unknown.gd
@@ -10,6 +10,7 @@ const EnumField = preload("res://src/ui_elements/enum_field.tscn")
 
 var tag: Tag
 var tid: PackedInt32Array
+var previous_focusable: Control
 
 func _ready() -> void:
 	# Continue with supported attributes.
@@ -39,4 +40,6 @@ func _ready() -> void:
 			input_field = EnumField.instantiate()
 		input_field.attribute = attribute
 		input_field.focused.connect(Indications.normal_select.bind(tid))
+		input_field.previous_focusable = previous_focusable
 		attribute_container.add_child(input_field)
+		previous_focusable = input_field.previous_focusable

--- a/src/ui_elements/transform_field.gd
+++ b/src/ui_elements/transform_field.gd
@@ -3,6 +3,7 @@ extends HBoxContainer
 
 signal focused
 var attribute: AttributeTransform
+var previous_focusable: Control
 
 const TransformPopup = preload("res://src/ui_elements/transform_popup.tscn")
 
@@ -31,6 +32,10 @@ func _ready() -> void:
 	line_edit.tooltip_text = attribute.name
 	line_edit.text_submitted.connect(set_value)
 	update_translation()
+	if previous_focusable:
+		previous_focusable.focus_next = previous_focusable.get_path_to(line_edit)
+		line_edit.focus_previous = line_edit.get_path_to(previous_focusable)
+	previous_focusable = line_edit
 
 
 func update_translation() -> void:

--- a/src/ui_elements/unknown_field.gd
+++ b/src/ui_elements/unknown_field.gd
@@ -37,6 +37,7 @@ func _on_focus_entered() -> void:
 
 func _on_text_submitted(new_text: String) -> void:
 	set_value(new_text)
+	super(new_text)
 
 
 func sync(new_value: String) -> void:

--- a/src/ui_elements/unknown_field.tscn
+++ b/src/ui_elements/unknown_field.tscn
@@ -11,5 +11,3 @@ focus_mode = 1
 right_icon = ExtResource("1_sd7sr")
 script = ExtResource("1_decfb")
 code_font_tooltip = true
-
-[connection signal="text_submitted" from="." to="." method="_on_text_submitted"]

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -5,6 +5,7 @@ const TagFrame = preload("tag_frame.tscn")
 @onready var tags_container: VBoxContainer = %Tags
 @onready var add_button: Button = $AddButton
 
+var previous_focusable: Control
 
 func _notification(what: int) -> void:
 	if what == Utils.CustomNotification.LANGUAGE_CHANGED:
@@ -24,12 +25,15 @@ func update_translation() -> void:
 func full_rebuild() -> void:
 	for node in tags_container.get_children():
 		node.queue_free()
+	previous_focusable = null
 	# Only add the first level of tags, they will automatically add their children.
 	for tag_idx in SVG.root_tag.get_child_count():
 		var tag_editor := TagFrame.instantiate()
+		tag_editor.previous_focusable = previous_focusable
 		tag_editor.tag = SVG.root_tag.child_tags[tag_idx]
 		tag_editor.tid = PackedInt32Array([tag_idx])
 		tags_container.add_child(tag_editor)
+		previous_focusable = tag_editor.previous_focusable
 
 func add_tag(tag_name: String) -> void:
 	var new_tid := PackedInt32Array([SVG.root_tag.get_child_count()])

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -49,6 +49,7 @@ script = ExtResource("4_i4hc2")
 [node name="ScrollContainer" type="ScrollContainer" parent="TagContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+follow_focus = true
 horizontal_scroll_mode = 0
 
 [node name="MarginContainer" type="MarginContainer" parent="TagContainer/ScrollContainer"]

--- a/src/ui_parts/tag_frame.gd
+++ b/src/ui_parts/tag_frame.gd
@@ -34,7 +34,7 @@ func _ready() -> void:
 	Indications.proposed_drop_changed.connect(queue_redraw)
 	determine_selection_highlight()
 	title_bar.queue_redraw()
-
+	
 	# If there are unknown attributes, they would always be on top.
 	if not tag.unknown_attributes.is_empty():
 		var unknown_container := HFlowContainer.new()


### PR DESCRIPTION
Allows using tab and shift+tab to move forwards and backwards through standard and unknown tag attributes.

Also makes tab count as submitting text, closing #715 

Note that this PR does not touch Path commands; that's a whole complex system that I do not fully understand yet, and it's not clear to me how to go about implementing this in there.