### PR TITLE
Fix attributes getting wrongly added

### DIFF
--- a/src/data_classes/Tag.gd
+++ b/src/data_classes/Tag.gd
@@ -17,6 +17,10 @@ func _init() -> void:
 	for attribute: Attribute in attributes.values():
 		attribute.propagate_value_changed.connect(emit_attribute_changed)
 
+func user_setup(_what = null) -> void:
+	printerr("Unimplemented function")
+	breakpoint
+
 func set_unknown_attributes(attribs: Array[Attribute]) -> void:
 	unknown_attributes = attribs.duplicate()
 	for attribute in unknown_attributes:

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -3,9 +3,11 @@ class_name TagCircle extends Tag
 
 const name = "circle"
 const possible_conversions = ["ellipse", "rect", "path"]
-const known_attributes = ["transform", "cx", "cy", "r", "opacity", "fill",
-		"fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 const icon = preload("res://visual/icons/tag/circle.svg")
+
+const known_attributes = ["transform", "opacity", "fill", "fill-opacity",
+		"stroke", "stroke-opacity", "stroke-width", "cx", "cy", "r"]
+		
 
 func _init() -> void:
 	for attrib_name in known_attributes:

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -15,7 +15,7 @@ func _init() -> void:
 	super()
 
 func user_setup(pos := Vector2.ZERO) -> void:
-	attributes.r = DB.attribute("r", "1")
+	attributes.r.set_num(1.0)
 	if pos != Vector2.ZERO:
 		attributes.cx.set_num(pos.x)
 		attributes.cy.set_num(pos.y)

--- a/src/data_classes/TagCircle.gd
+++ b/src/data_classes/TagCircle.gd
@@ -7,16 +7,16 @@ const known_attributes = ["transform", "cx", "cy", "r", "opacity", "fill",
 		"fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 const icon = preload("res://visual/icons/tag/circle.svg")
 
-func _init(pos := Vector2.ZERO) -> void:
-	for attrib_name in ["transform", "cx", "cy", "opacity", "fill", "fill-opacity",
-	"stroke", "stroke-opacity", "stroke-width"]:
+func _init() -> void:
+	for attrib_name in known_attributes:
 		attributes[attrib_name] = DB.attribute(attrib_name)
+	super()
+
+func user_setup(pos := Vector2.ZERO) -> void:
 	attributes.r = DB.attribute("r", "1")
 	if pos != Vector2.ZERO:
 		attributes.cx.set_num(pos.x)
 		attributes.cy.set_num(pos.y)
-	super()
-
 
 func can_replace(new_tag: String) -> bool:
 	return new_tag in ["ellipse", "rect", "path"]

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -14,8 +14,8 @@ func _init() -> void:
 	super()
 
 func user_setup(pos := Vector2.ZERO) -> void:
-	attributes.rx = DB.attribute("rx", "1")
-	attributes.ry = DB.attribute("ry", "1")
+	attributes.rx.set_num(1.0)
+	attributes.ry.set_num(1.0)
 	if pos != Vector2.ZERO:
 		attributes.cx.set_num(pos.x)
 		attributes.cy.set_num(pos.y)

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -5,8 +5,8 @@ const name = "ellipse"
 const possible_conversions = ["circle", "rect", "path"]
 const icon = preload("res://visual/icons/tag/ellipse.svg")
 
-const known_attributes = ["cx", "cy", "rx", "ry", "transform", "opacity",
-		"fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
+const known_attributes = ["transform", "opacity", "fill", "fill-opacity",
+		"stroke", "stroke-opacity", "stroke-width", "cx", "cy", "rx", "ry"]
 
 func _init() -> void:
 	for attrib_name in known_attributes:

--- a/src/data_classes/TagEllipse.gd
+++ b/src/data_classes/TagEllipse.gd
@@ -8,17 +8,17 @@ const icon = preload("res://visual/icons/tag/ellipse.svg")
 const known_attributes = ["cx", "cy", "rx", "ry", "transform", "opacity",
 		"fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width"]
 
-func _init(pos := Vector2.ZERO) -> void:
-	for attrib_name in ["transform", "cx", "cy", "opacity", "fill", "fill-opacity",
-	"stroke", "stroke-opacity", "stroke-width"]:
+func _init() -> void:
+	for attrib_name in known_attributes:
 		attributes[attrib_name] = DB.attribute(attrib_name)
+	super()
+
+func user_setup(pos := Vector2.ZERO) -> void:
 	attributes.rx = DB.attribute("rx", "1")
 	attributes.ry = DB.attribute("ry", "1")
 	if pos != Vector2.ZERO:
 		attributes.cx.set_num(pos.x)
 		attributes.cy.set_num(pos.y)
-	super()
-
 
 func can_replace(new_tag: String) -> bool:
 	if new_tag == "circle":

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -9,16 +9,17 @@ const known_attributes = ["x1", "y1", "x2", "y2", "transform", "opacity", "strok
 		"stroke-opacity", "stroke-width", "stroke-linecap"]
 
 func _init(pos := Vector2.ZERO) -> void:
-	for attrib_name in ["transform", "opacity", "stroke", "stroke-opacity",
-	"stroke-width", "stroke-linecap"]:
+	for attrib_name in known_attributes:
 		attributes[attrib_name] = DB.attribute(attrib_name)
+	super()
+
+func user_setup(pos := Vector2.ZERO) -> void:
 	if pos != Vector2.ZERO:
 		attributes.x1.set_num(pos.x)
 		attributes.y1.set_num(pos.y)
 		attributes.x2.set_num(pos.x + 1)
 		attributes.y2.set_num(pos.y)
-	super()
-
+	attributes.stroke.set_value("black")
 
 func can_replace(new_tag: String) -> bool:
 	return new_tag == "path"

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -17,8 +17,8 @@ func user_setup(pos := Vector2.ZERO) -> void:
 	if pos != Vector2.ZERO:
 		attributes.x1.set_num(pos.x)
 		attributes.y1.set_num(pos.y)
-		attributes.x2.set_num(pos.x + 1)
 		attributes.y2.set_num(pos.y)
+	attributes.x2.set_num(pos.x + 1)
 	attributes.stroke.set_value("black")
 
 func can_replace(new_tag: String) -> bool:

--- a/src/data_classes/TagLine.gd
+++ b/src/data_classes/TagLine.gd
@@ -5,8 +5,8 @@ const name = "line"
 const possible_conversions = ["path"]
 const icon = preload("res://visual/icons/tag/line.svg")
 
-const known_attributes = ["x1", "y1", "x2", "y2", "transform", "opacity", "stroke",
-		"stroke-opacity", "stroke-width", "stroke-linecap"]
+const known_attributes = ["transform", "opacity", "stroke", "stroke-opacity",
+		"stroke-width", "stroke-linecap", "x1", "y1", "x2", "y2", ]
 
 func _init(pos := Vector2.ZERO) -> void:
 	for attrib_name in known_attributes:

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -15,9 +15,10 @@ func _init() -> void:
 	super()
 
 func user_setup(pos := Vector2.ZERO) -> void:
-	attributes.d.insert_command(0, "M")
-	attributes.d.set_command_property(0, "x", pos.x)
-	attributes.d.set_command_property(0, "y", pos.y)
+	if pos != Vector2.ZERO:
+		attributes.d.insert_command(0, "M")
+		attributes.d.set_command_property(0, "x", pos.x)
+		attributes.d.set_command_property(0, "y", pos.y)
 
 func can_replace(_new_tag: String) -> bool:
 	return false

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -5,8 +5,9 @@ const name = "path"
 const possible_conversions = []
 const icon = preload("res://visual/icons/tag/path.svg")
 
-const known_attributes = ["d", "transform", "opacity", "fill", "fill-opacity",
-		"stroke", "stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin"]
+const known_attributes = ["transform", "opacity", "fill", "fill-opacity",
+		"stroke", "stroke-opacity", "stroke-width", "stroke-linecap",
+		"stroke-linejoin", "d"]
 
 func _init() -> void:
 	for attrib_name in known_attributes:

--- a/src/data_classes/TagPath.gd
+++ b/src/data_classes/TagPath.gd
@@ -8,14 +8,15 @@ const icon = preload("res://visual/icons/tag/path.svg")
 const known_attributes = ["d", "transform", "opacity", "fill", "fill-opacity",
 		"stroke", "stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin"]
 
-func _init(pos := Vector2.ZERO) -> void:
-	for attrib_name in ["transform", "d", "opacity", "fill", "fill-opacity",
-	"stroke", "stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin"]:
+func _init() -> void:
+	for attrib_name in known_attributes:
 		attributes[attrib_name] = DB.attribute(attrib_name)
+	super()
+
+func user_setup(pos := Vector2.ZERO) -> void:
 	attributes.d.insert_command(0, "M")
 	attributes.d.set_command_property(0, "x", pos.x)
 	attributes.d.set_command_property(0, "y", pos.y)
-	super()
 
 func can_replace(_new_tag: String) -> bool:
 	return false

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -5,9 +5,9 @@ const name = "rect"
 const possible_conversions = ["circle", "ellipse", "path"]
 const icon = preload("res://visual/icons/tag/rect.svg")
 
-const known_attributes = ["x", "y", "width", "height", "rx", "ry", "transform",
-		"opacity", "fill", "fill-opacity", "stroke", "stroke-opacity", "stroke-width",
-		"stroke-linejoin"]
+const known_attributes = ["transform", "opacity", "fill", "fill-opacity",
+		"stroke", "stroke-opacity", "stroke-width", "stroke-linejoin", 
+		"x", "y", "width", "height", "rx", "ry",]
 
 func _init(pos := Vector2.ZERO) -> void:
 	for attrib_name in known_attributes:

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -15,8 +15,8 @@ func _init(pos := Vector2.ZERO) -> void:
 	super()
 
 func user_setup(pos := Vector2.ZERO) -> void:
-	attributes.width = DB.attribute("width", "1")
-	attributes.height = DB.attribute("height", "1")
+	attributes.width.set_num(1.0)
+	attributes.height.set_num(1.0)
 	if pos != Vector2.ZERO:
 		attributes.x.set_num(pos.x)
 		attributes.y.set_num(pos.y)

--- a/src/data_classes/TagRect.gd
+++ b/src/data_classes/TagRect.gd
@@ -10,16 +10,16 @@ const known_attributes = ["x", "y", "width", "height", "rx", "ry", "transform",
 		"stroke-linejoin"]
 
 func _init(pos := Vector2.ZERO) -> void:
-	for attrib_name in ["transform", "x", "y", "rx", "ry", "opacity", "fill",
-	"fill-opacity", "stroke", "stroke-opacity", "stroke-width", "stroke-linejoin"]:
+	for attrib_name in known_attributes:
 		attributes[attrib_name] = DB.attribute(attrib_name)
+	super()
+
+func user_setup(pos := Vector2.ZERO) -> void:
 	attributes.width = DB.attribute("width", "1")
 	attributes.height = DB.attribute("height", "1")
 	if pos != Vector2.ZERO:
 		attributes.x.set_num(pos.x)
 		attributes.y.set_num(pos.y)
-	super()
-
 
 func can_replace(new_tag: String) -> bool:
 	if new_tag == "ellipse":

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -774,9 +774,10 @@ func create_tag_context(pos: Vector2) -> ContextPopup:
 func add_tag_at_pos(tag_name: String, pos: Vector2) -> void:
 	var tag: Tag
 	match tag_name:
-		"path": tag = TagPath.new(pos)
-		"circle": tag = TagCircle.new(pos)
-		"ellipse": tag = TagEllipse.new(pos)
-		"rect": tag = TagRect.new(pos)
-		"line": tag = TagLine.new(pos)
+		"path": tag = TagPath.new()
+		"circle": tag = TagCircle.new()
+		"ellipse": tag = TagEllipse.new()
+		"rect": tag = TagRect.new()
+		"line": tag = TagLine.new()
+	tag.user_setup(pos)
 	SVG.root_tag.add_tag(tag, PackedInt32Array([SVG.root_tag.get_child_count()]))

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -40,6 +40,7 @@ func add_tag(tag_name: String) -> void:
 		"rect": new_tag = TagRect.new()
 		"path": new_tag = TagPath.new()
 		"line": new_tag = TagLine.new()
+	new_tag.user_setup()
 	SVG.root_tag.add_tag(new_tag, new_tid)
 
 

--- a/src/ui_parts/tag_container.gd
+++ b/src/ui_parts/tag_container.gd
@@ -107,12 +107,15 @@ func _gui_input(event: InputEvent) -> void:
 			HandlerGUI.popup_under_pos(add_popup, vp.get_mouse_position(), vp)
 
 func add_tag(tag_name: String, tag_location: int) -> void:
+	var tag: Tag
 	match tag_name:
-		"path": SVG.root_tag.add_tag(TagPath.new(), PackedInt32Array([tag_location]))
-		"circle": SVG.root_tag.add_tag(TagCircle.new(), PackedInt32Array([tag_location]))
-		"ellipse": SVG.root_tag.add_tag(TagEllipse.new(), PackedInt32Array([tag_location]))
-		"rect": SVG.root_tag.add_tag(TagRect.new(), PackedInt32Array([tag_location]))
-		"line": SVG.root_tag.add_tag(TagLine.new(), PackedInt32Array([tag_location]))
+		"path": tag = TagPath.new()
+		"circle": tag = TagCircle.new()
+		"ellipse": tag = TagEllipse.new()
+		"rect": tag = TagRect.new()
+		"line": tag = TagLine.new()
+	tag.user_setup()
+	SVG.root_tag.add_tag(tag, PackedInt32Array([tag_location]))
 
 # This function assumes there exists a tag editor for the corresponding TID.
 func get_tag_editor_rect(tid: PackedInt32Array) -> Rect2:


### PR DESCRIPTION
I separated setting up tag specific defaults in to method `user_setup()` so it doesn't add new attributes to tags that don't have any. The attribute values now only get changed when adding new tags with the UI actions.
Fix #729

I also changed the initialization of attributes to fix some not being initialized. This might change the order of attributes in the UI, but that can be easily fixed.
Fix #726 