### PR TITLE
russian translation cleanup

### DIFF
--- a/translations/ru.po
+++ b/translations/ru.po
@@ -1,27 +1,26 @@
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: GodSVG\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: \n"
-"Last-Translator: volkov <volkovissocool@gmail.com>\n"
-"Language-Team: \n"
+"PO-Revision-Date: 2024-05-31 11:16+0300\n"
+"Last-Translator: Gallifreyan <gallifreyan@protonmail.ch>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.2\n"
+"X-Generator: Lokalize 24.05.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "translation-credits"
 msgstr "volkov <volkovissocool@gmail.com>"
 
 #: src/parsers/SVGParser.gd
 msgid "Doesn’t describe an SVG."
-msgstr "Не есть описанием SVG."
+msgstr "Не является описанием SVG."
 
 #: src/parsers/SVGParser.gd
 msgid "Improper nesting."
-msgstr "Не правильное вкладывание."
+msgstr "Неправильное вложение."
 
 #: src/ui_elements/BetterLineEdit.gd src/ui_elements/BetterTextEdit.gd
 #: src/TranslationUtils.gd
@@ -87,7 +86,7 @@ msgstr "Подвинуть вниз"
 
 #: src/ui_elements/palette_config.gd
 msgid "Copy as XML"
-msgstr "Скопировать как XML"
+msgstr "Скопировать XML"
 
 #: src/ui_elements/palette_config.gd
 msgid "Paste XML"
@@ -129,7 +128,7 @@ msgstr "Добавить сочетание клавиш"
 
 #: src/ui_elements/setting_shortcut.gd
 msgid "Edit"
-msgstr "Редактирование"
+msgstr "Редактировать"
 
 #: src/ui_elements/setting_shortcut.gd
 msgid "Remove"
@@ -137,7 +136,7 @@ msgstr "Удалить"
 
 #: src/ui_elements/setting_shortcut.gd
 msgid "Press keys…"
-msgstr "Нажмите копки…"
+msgstr "Нажмите клавиши…"
 
 #: src/ui_elements/transform_field.gd
 msgid "No transforms"
@@ -177,7 +176,7 @@ msgstr "Переводчики"
 
 #: src/ui_parts/about_menu.gd
 msgid "Authors"
-msgstr "Автори"
+msgstr "Авторы"
 
 #: src/ui_parts/about_menu.gd
 msgid "Donors"
@@ -239,27 +238,27 @@ msgstr "Внешний вид"
 
 #: src/ui_parts/display.gd src/TranslationUtils.gd
 msgid "Load reference image"
-msgstr ""
+msgstr "Загрузить "
 
 #: src/ui_parts/display.gd
 msgid "Show reference"
-msgstr ""
+msgstr "Показать референс-изображение"
 
 #: src/ui_parts/display.gd
 msgid "Overlay reference"
-msgstr ""
+msgstr "Наложить референс-изображение"
 
 #: src/ui_parts/display.gd
 msgid "Import Reference Image"
-msgstr ""
+msgstr "Импортировать референс-изображение"
 
 #: src/ui_parts/display.gd
 msgid "Show Reference Image"
-msgstr ""
+msgstr "Показать референс-изображение"
 
 #: src/ui_parts/display.gd
 msgid "Overlay Reference Image"
-msgstr ""
+msgstr "Наложить референс-изображение"
 
 #: src/ui_parts/display.gd
 msgid "Show Grid"
@@ -294,13 +293,12 @@ msgid "Check for updates"
 msgstr "Проверить обновления"
 
 #: src/ui_parts/display.gd
-#, fuzzy
 msgid "Check for updates?"
-msgstr "Проверить обновления"
+msgstr "Проверить обновления?"
 
 #: src/ui_parts/display.gd
 msgid "This requires GodSVG to connect to the internet."
-msgstr ""
+msgstr "Для этого необходимо подключение к Интернету"
 
 #: src/ui_parts/display.gd
 msgid "Enable snapping"
@@ -375,9 +373,8 @@ msgid "Select an SVG"
 msgstr "Выбрать SVG"
 
 #: src/ui_parts/good_file_dialog.gd
-#, fuzzy
 msgid "Select an image"
-msgstr "Выбрать все теги"
+msgstr "Выбрать изображение"
 
 #: src/ui_parts/good_file_dialog.gd src/ui_parts/update_menu.gd
 msgid "Close"
@@ -485,7 +482,7 @@ msgstr "Разное"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Any changes will apply immediately."
-msgstr "Любые изменения будут применены моментально."
+msgstr "Любые изменения будут применены немедленно."
 
 #: src/ui_parts/settings_menu.gd
 msgid "Formatting"
@@ -538,7 +535,7 @@ msgstr "Поменяет местами увеличение и уменьшен
 #: src/ui_parts/settings_menu.gd
 msgid "Wraps the mouse cursor around when panning the viewport."
 msgstr ""
-"Миша будет телепортироваться от одного края до противположного при "
+"Курсор будет телепортироваться от одного до противоположного края при "
 "передвижении окна просмотра."
 
 #: src/ui_parts/settings_menu.gd
@@ -547,11 +544,11 @@ msgid ""
 "scrolling."
 msgstr ""
 "Если включено, прокрутка будет перемещать окно просмотра. Чтобы "
-"масштабировать Зажмите CTRL когда прокручиваете."
+"масштабировать зажмите CTRL при прокручивании."
 
 #: src/ui_parts/settings_menu.gd
 msgid "Use native file dialog"
-msgstr "Использовать родной файловый диалог"
+msgstr "Использовать родной файловый диалог системы"
 
 #: src/ui_parts/settings_menu.gd
 msgid ""
@@ -564,7 +561,7 @@ msgstr ""
 
 #: src/ui_parts/settings_menu.gd
 msgid "Increases the visual size and grabbing area of handles."
-msgstr "Увеличить визуальную и область захвата ручек редактирования."
+msgstr "Увеличить вид и область захвата ручек редактирования."
 
 #: src/ui_parts/settings_menu.gd
 msgid "Changes the scale of the visual user interface."
@@ -572,15 +569,15 @@ msgstr "Изменить масштаб пользовательского ин�
 
 #: src/ui_parts/settings_menu.gd
 msgid "Scales the user interface based on the screen size."
-msgstr "Маштабировать интерфейс пользователя в зависимости от размера экрана."
+msgstr "Масштабировать интерфейс пользователя в зависимости от размера экрана."
 
 #: src/ui_parts/settings_menu.gd
 msgid "Number precision digits"
-msgstr "Количество цифр точности углов"
+msgstr "Значащие цифры углов"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Angle precision digits"
-msgstr "Количество цифр точности чисел"
+msgstr "Значащие цифры чисел"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Add trailing newline"
@@ -624,11 +621,11 @@ msgstr "Сжать цифры"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Minimize spacing"
-msgstr "Минимизировать размеры"
+msgstr "Минимизировать интервалы"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Remove spacing after flags"
-msgstr "Удалить расстояние после флагов"
+msgstr "Удалить интервалы после флагов"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Remove consecutive commands"
@@ -636,7 +633,7 @@ msgstr "Удалить последовательные команды"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Remove unnecessary parameters"
-msgstr "Удалить не нужные параметры"
+msgstr "Удалить ненужные параметры"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Symbol color"
@@ -691,9 +688,8 @@ msgid "Hovered selected color"
 msgstr "Цвет выделенного-наведенного"
 
 #: src/ui_parts/settings_menu.gd
-#, fuzzy
 msgid "Background color"
-msgstr "Базовый цвет"
+msgstr "Цвет фона"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Valid color"
@@ -705,28 +701,27 @@ msgstr "Цвет предупреждения"
 
 #: src/ui_parts/update_menu.gd
 msgid "Include prereleases"
-msgstr ""
+msgstr "Включить пре-релизы"
 
 #: src/ui_parts/update_menu.gd
 msgid "Current Version"
-msgstr ""
+msgstr "Текущая версия"
 
 #: src/ui_parts/update_menu.gd
-#, fuzzy
 msgid "Retrieving information..."
-msgstr "Просмотреть информацию для отладки"
+msgstr "Загрузка информации..."
 
 #: src/ui_parts/update_menu.gd
 msgid "Update check failed"
-msgstr ""
+msgstr "Не удалось проверит обновления"
 
 #: src/ui_parts/update_menu.gd
 msgid "GodSVG is up-to-date."
-msgstr ""
+msgstr "Установлена последняя версия GodSVG"
 
 #: src/ui_parts/update_menu.gd
 msgid "New versions"
-msgstr ""
+msgstr "Новые версии"
 
 #: src/FileUtils.gd
 msgid "Save the .\"{extension}\" file"
@@ -738,18 +733,18 @@ msgstr "Импортировать .svg файл"
 
 #: src/FileUtils.gd
 msgid "Load an image file"
-msgstr ""
+msgstr "Загрузить изображение"
 
 #: src/FileUtils.gd src/HandlerGUI.gd
 msgid "The file extension is empty. Only \"svg\" files are supported."
-msgstr "Расширение файла пустрое. Поддерживается только «svg» файлы."
+msgstr "Расширение файла пустое. Поддерживается только «svg» файлы."
 
 #: src/FileUtils.gd src/HandlerGUI.gd
 msgid ""
 "\"{passed_extension}\" is a unsupported file extension. Only \"svg\" files "
 "are supported."
 msgstr ""
-"\"{passed_extension}\" это расширение файла которое не поддерживается. "
+"Расширение \"{passed_extension}\" поддерживается. "
 "Поддерживается только «svg»."
 
 #: src/FileUtils.gd
@@ -759,7 +754,7 @@ msgid ""
 "different file."
 msgstr ""
 "Невозможно открыть этот файл.\n"
-"Попробуйте проверить путь до файла, убедитесь что файл не удален або "
+"Попробуйте проверить путь до файла, убедитесь что файл не удален или "
 "выберите другой файл."
 
 #: src/HandlerGUI.gd
@@ -792,7 +787,7 @@ msgstr "Импортировать"
 
 #: src/TranslationUtils.gd
 msgid "Load Reference Image"
-msgstr ""
+msgstr "Загрузить референс-изображение"
 
 #: src/TranslationUtils.gd
 msgid "Optimize"
@@ -844,11 +839,11 @@ msgstr "Показать растеризованый SVG"
 
 #: src/TranslationUtils.gd
 msgid "Show reference image"
-msgstr ""
+msgstr "Показать референс-изображение"
 
 #: src/TranslationUtils.gd
 msgid "Overlay reference image"
-msgstr ""
+msgstr "Наложить референс-изображение"
 
 #: src/TranslationUtils.gd
 msgid "View debug information"
@@ -912,7 +907,7 @@ msgstr "Сокращенная квадратичная Безье до"
 
 #: src/TranslationUtils.gd
 msgid "Cubic Bezier to"
-msgstr "Кибическая Безье до"
+msgstr "Кубическая Безье до"
 
 #: src/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
@@ -951,3 +946,4 @@ msgstr "Сокращенная кубическая Безье до"
 
 #~ msgid "Import SVG"
 #~ msgstr "Импортировать SVG"
+

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -1,3 +1,4 @@
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: GodSVG\n"
@@ -12,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "translation-credits"
-msgstr "volkov <volkovissocool@gmail.com>"
+msgstr "volkov <volkovissocool@gmail.com>, Gallifreyan <gallifreyan@protonmail.ch>"
 
 #: src/parsers/SVGParser.gd
 msgid "Doesn’t describe an SVG."
@@ -86,7 +87,7 @@ msgstr "Подвинуть вниз"
 
 #: src/ui_elements/palette_config.gd
 msgid "Copy as XML"
-msgstr "Скопировать XML"
+msgstr "Скопировать как XML"
 
 #: src/ui_elements/palette_config.gd
 msgid "Paste XML"
@@ -238,7 +239,7 @@ msgstr "Внешний вид"
 
 #: src/ui_parts/display.gd src/TranslationUtils.gd
 msgid "Load reference image"
-msgstr "Загрузить "
+msgstr "Загрузить референс"
 
 #: src/ui_parts/display.gd
 msgid "Show reference"


### PR DESCRIPTION
Fixed a few errors in the existing translation and added a few to items that were previously not translated. 

There are still things that are not translated, e.g. the "width" and "height" fields, some buttons in the keyboard shortcut submenu, the right-click menu, etc.