### PR TITLE
Streamline shortcuts

### DIFF
--- a/AppInfo.gd
+++ b/AppInfo.gd
@@ -30,8 +30,13 @@ const authors: Array[String] = [
 ]
 
 # GodSVG is a non-profit project developed by voluntary contributors.
-# Everyone who has generously sponsored the project is listed here.
+# Thousands of hours of work have gone into it so far.
+# Everyone who has generously sponsored this effort is listed here.
 
-const donors: Array[String] = [
+const donors: Array[String] = []
+
+const golden_donors: Array[String] = []
+
+const diamond_donors: Array[String] = [
 	"Aaron Franke (aaronfranke)",
 ]

--- a/src/ShortcutUtils.gd
+++ b/src/ShortcutUtils.gd
@@ -1,0 +1,32 @@
+class_name ShortcutUtils extends RefCounted
+
+static func fn_call(shortcut: String) -> void:
+	fn(shortcut).call()
+
+# The methods that should be called if these shortcuts aren't handled.
+static func fn(shortcut: String) -> Callable:
+	match shortcut:
+		"import": return FileUtils.open_import_dialog
+		"export": return FileUtils.open_export_dialog
+		"copy_svg_text": return DisplayServer.clipboard_set.bind(SVG.text)
+		"clear_svg": return SVG.apply_svg_text.bind(SVG.DEFAULT)
+		"optimize": return SVG.root_tag.optimize
+		"clear_file_path": return GlobalSettings.modify_save_data.bind(
+				"current_file_path", "")
+		"reset_svg": return FileUtils.apply_svg_from_path.bind(
+				GlobalSettings.save_data.current_file_path)
+		"redo": return SVG.redo
+		"undo": return SVG.undo
+		"ui_cancel": return Indications.clear_all_selections
+		"delete": return Indications.delete_selected
+		"move_up": return Indications.move_up_selected
+		"move_down": return Indications.move_down_selected
+		"duplicate": return Indications.duplicate_selected
+		"select_all": return Indications.select_all
+		"about_info": return HandlerGUI.open_about
+		"about_donate": return HandlerGUI.open_donate
+		"about_repo": return OS.shell_open.bind("https://github.com/MewPurPur/GodSVG")
+		"about_website": return OS.shell_open.bind("https://godsvg.com")
+		"check_updates": return HandlerGUI.open_update_checker
+		"open_settings": return HandlerGUI.open_settings
+		_: return Callable()

--- a/src/ui_elements/BetterLineEdit.gd
+++ b/src/ui_elements/BetterLineEdit.gd
@@ -41,6 +41,7 @@ func _on_base_class_focus_exited() -> void:
 		text = text_before_focus
 		text_change_canceled.emit()
 	elif not Input.is_action_pressed("ui_accept"):
+		# If ui_accept is pressed, text_submitted gets emitted anyway.
 		text_submitted.emit(text)
 
 func _on_base_class_mouse_exited() -> void:

--- a/src/ui_elements/BetterTextEdit.gd
+++ b/src/ui_elements/BetterTextEdit.gd
@@ -25,6 +25,8 @@ func _ready() -> void:
 	get_v_scroll_bar().value_changed.connect(queue_redraw_caret.unbind(1))
 	get_h_scroll_bar().value_changed.connect(queue_redraw_caret.unbind(1))
 	mouse_exited.connect(_on_base_class_mouse_exited)
+	focus_entered.connect(_on_base_class_focus_entered)
+	focus_exited.connect(_on_base_class_focus_exited)
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(_surface)
@@ -83,10 +85,10 @@ func blink() -> void:
 	blonk = not blonk
 	RenderingServer.canvas_item_set_visible(_surface, blonk)
 
-func _on_focus_entered() -> void:
+func _on_base_class_focus_entered() -> void:
 	_timer.start(0.6)
 
-func _on_focus_exited() -> void:
+func _on_base_class_focus_exited() -> void:
 	_timer.stop()
 	RenderingServer.canvas_item_clear(_surface)
 

--- a/src/ui_parts/about_menu.gd
+++ b/src/ui_parts/about_menu.gd
@@ -1,11 +1,15 @@
 extends PanelContainer
 
+@onready var version_label: Label = %VersionLabel
+@onready var close_button: Button = $VBoxContainer/CloseButton
+
 @onready var project_founder_list: PanelGrid = %ProjectFounder/List
 @onready var authors_list: PanelGrid = %Developers/List
 @onready var translations_list: PanelGrid = %Translations/List
-@onready var donors_list: PanelGrid = %DonorsList
-@onready var version_label: Label = %VersionLabel
-@onready var close_button: Button = $VBoxContainer/CloseButton
+
+@onready var donors_list: PanelGrid = %Donors/List
+@onready var golden_donors_list: PanelGrid = %GoldenDonors/List
+@onready var diamond_donors_list: PanelGrid = %DiamondDonors/List
 
 func _notification(what: int) -> void:
 	if what == Utils.CustomNotification.LANGUAGE_CHANGED:
@@ -15,6 +19,9 @@ func update_translation() -> void:
 	%ProjectFounder/Label.text = TranslationServer.translate("Project Founder and Manager")
 	%Developers/Label.text = TranslationServer.translate("Developers")
 	%Translations/Label.text = TranslationServer.translate("Translators")
+	%Donors/Label.text = TranslationServer.translate("Donors")
+	%GoldenDonors/Label.text = TranslationServer.translate("Golden donors")
+	%DiamondDonors/Label.text = TranslationServer.translate("Diamond donors")
 	$VBoxContainer/TabContainer.set_tab_title(0, TranslationServer.translate("Authors"))
 	$VBoxContainer/TabContainer.set_tab_title(1, TranslationServer.translate("Donors"))
 	$VBoxContainer/TabContainer.set_tab_title(2, TranslationServer.translate("License"))
@@ -30,6 +37,10 @@ func _ready() -> void:
 	authors_list.setup()
 	donors_list.items = AppInfo.donors
 	donors_list.setup()
+	golden_donors_list.items = AppInfo.golden_donors
+	golden_donors_list.setup()
+	diamond_donors_list.items = AppInfo.diamond_donors
+	diamond_donors_list.setup()
 	var translation_items: Array[String] = []
 	for lang in TranslationServer.get_loaded_locales():
 		var credits := TranslationServer.get_translation_object(lang).get_message(

--- a/src/ui_parts/about_menu.tscn
+++ b/src/ui_parts/about_menu.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=8 format=3 uid="uid://mhfp37lr7q4f"]
 
 [ext_resource type="Script" path="res://src/ui_parts/about_menu.gd" id="1_xxltt"]
-[ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://godot_only/source_assets/icon.svg" id="2_y5kl0"]
+[ext_resource type="Texture2D" uid="uid://v7hej5yexkvl" path="res://visual/icon.png" id="2_5uakw"]
 [ext_resource type="FontFile" uid="uid://dtb4wkus51hxs" path="res://visual/fonts/FontMono.ttf" id="3_e8i1t"]
 [ext_resource type="FontFile" uid="uid://dc0w4sx0h0fui" path="res://visual/fonts/FontBold.ttf" id="4_n6gp0"]
 [ext_resource type="Texture2D" uid="uid://cgxpm1e3v0i3v" path="res://visual/icons/Link.svg" id="6_hbk78"]
@@ -46,7 +46,7 @@ theme_override_constants/separation = 8
 
 [node name="TextureRect" type="TextureRect" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
-texture = ExtResource("2_y5kl0")
+texture = ExtResource("2_5uakw")
 expand_mode = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
@@ -133,7 +133,60 @@ stylebox = SubResource("StyleBoxFlat_jtvwe")
 visible = false
 layout_mode = 2
 
-[node name="DonorsList" type="GridContainer" parent="VBoxContainer/TabContainer/Donors"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Donors"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 8
+
+[node name="Donors" type="VBoxContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 6
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/Donors"]
+layout_mode = 2
+horizontal_alignment = 1
+
+[node name="List" type="GridContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/Donors"]
+layout_mode = 2
+theme_override_constants/h_separation = -1
+theme_override_constants/v_separation = -1
+columns = 2
+script = ExtResource("7_nvctb")
+stylebox = SubResource("StyleBoxFlat_jtvwe")
+
+[node name="GoldenDonors" type="VBoxContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 6
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/GoldenDonors"]
+layout_mode = 2
+horizontal_alignment = 1
+
+[node name="List" type="GridContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/GoldenDonors"]
+layout_mode = 2
+theme_override_constants/h_separation = -1
+theme_override_constants/v_separation = -1
+columns = 2
+script = ExtResource("7_nvctb")
+stylebox = SubResource("StyleBoxFlat_jtvwe")
+
+[node name="DiamondDonors" type="VBoxContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 6
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/DiamondDonors"]
+layout_mode = 2
+horizontal_alignment = 1
+
+[node name="List" type="GridContainer" parent="VBoxContainer/TabContainer/Donors/VBoxContainer/DiamondDonors"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/h_separation = -1

--- a/src/ui_parts/code_editor.tscn
+++ b/src/ui_parts/code_editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://cr1fdlmbknnko"]
+[gd_scene load_steps=11 format=3 uid="uid://cr1fdlmbknnko"]
 
 [ext_resource type="Script" path="res://src/ui_parts/code_editor.gd" id="1_nffk0"]
 [ext_resource type="Texture2D" uid="uid://c5kgvxffw35gi" path="res://visual/icons/Compress.svg" id="2_33tgq"]
@@ -31,18 +31,6 @@ corner_radius_top_left = 3
 corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
-
-[sub_resource type="InputEventAction" id="InputEventAction_7f3rx"]
-action = &"import"
-
-[sub_resource type="Shortcut" id="Shortcut_2nqbo"]
-events = [SubResource("InputEventAction_7f3rx")]
-
-[sub_resource type="InputEventAction" id="InputEventAction_oqold"]
-action = &"export"
-
-[sub_resource type="Shortcut" id="Shortcut_6w18e"]
-events = [SubResource("InputEventAction_oqold")]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_k0een"]
 content_margin_left = 10.0
@@ -101,6 +89,7 @@ theme_type_variation = &"FlatButton"
 text_overrun_behavior = 3
 
 [node name="MetaActions" type="HBoxContainer" parent="PanelContainer/CodeButtons"]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
 
@@ -119,8 +108,6 @@ tooltip_text = "Import"
 focus_mode = 0
 mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
-shortcut = SubResource("Shortcut_2nqbo")
-shortcut_in_tooltip = false
 icon = ExtResource("4_cuhac")
 
 [node name="ExportButton" type="Button" parent="PanelContainer/CodeButtons/MetaActions"]
@@ -129,8 +116,6 @@ tooltip_text = "Export"
 focus_mode = 0
 mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
-shortcut = SubResource("Shortcut_6w18e")
-shortcut_in_tooltip = false
 icon = ExtResource("5_pgurh")
 
 [node name="ScriptEditor" type="VBoxContainer" parent="."]
@@ -158,14 +143,9 @@ theme_override_fonts/normal_font = ExtResource("2_p4nol")
 theme_override_font_sizes/normal_font_size = 14
 fit_content = true
 
-[connection signal="pressed" from="PanelContainer/CodeButtons/OptimizeButton" to="." method="_on_optimize_button_pressed"]
 [connection signal="pressed" from="PanelContainer/CodeButtons/MarginContainer/FileButton" to="." method="_on_file_button_pressed"]
 [connection signal="pressed" from="PanelContainer/CodeButtons/MetaActions/OptionsButton" to="." method="_on_options_button_pressed"]
-[connection signal="pressed" from="PanelContainer/CodeButtons/MetaActions/ImportButton" to="." method="_on_import_button_pressed"]
-[connection signal="pressed" from="PanelContainer/CodeButtons/MetaActions/ExportButton" to="." method="_on_export_button_pressed"]
 [connection signal="caret_changed" from="ScriptEditor/SVGCodeEdit" to="ScriptEditor/SVGCodeEdit" method="redraw_caret"]
 [connection signal="focus_entered" from="ScriptEditor/SVGCodeEdit" to="." method="_on_svg_code_edit_focus_entered"]
-[connection signal="focus_entered" from="ScriptEditor/SVGCodeEdit" to="ScriptEditor/SVGCodeEdit" method="_on_focus_entered"]
 [connection signal="focus_exited" from="ScriptEditor/SVGCodeEdit" to="." method="_on_svg_code_edit_focus_exited"]
-[connection signal="focus_exited" from="ScriptEditor/SVGCodeEdit" to="ScriptEditor/SVGCodeEdit" method="_on_focus_exited"]
-[connection signal="text_changed" from="ScriptEditor/SVGCodeEdit" to="." method="_on_code_edit_text_changed"]
+[connection signal="text_changed" from="ScriptEditor/SVGCodeEdit" to="." method="_on_svg_code_edit_text_changed"]

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -4,11 +4,6 @@ extends VBoxContainer
 signal view_settings_updated(show_grid: bool, show_handles: bool, rasterized_svg: bool)
 signal snap_settings_updated(snap_enabled: bool, snap_amount: float)
 
-const settings_menu = preload("settings_menu.tscn")
-const about_menu = preload("about_menu.tscn")
-const donate_menu = preload("res://src/ui_parts/donate_menu.tscn")
-const update_menu = preload("res://src/ui_parts/update_menu.tscn")
-
 const NumberEditType = preload("res://src/ui_elements/number_edit.gd")
 const BetterToggleButtonType = preload("res://src/ui_elements/BetterToggleButton.gd")
 
@@ -37,8 +32,6 @@ func _notification(what: int) -> void:
 		update_translations()
 	elif what == Utils.CustomNotification.NUMBER_PRECISION_CHANGED:
 		update_snap_config()
-	elif what == NOTIFICATION_WM_ABOUT:
-		open_about.call_deferred()
 	elif what ==  Utils.CustomNotification.THEME_CHANGED:
 		update_theme()
 
@@ -64,8 +57,6 @@ func _unhandled_input(input_event: InputEvent) -> void:
 			input_debug_label.text = ""
 	elif input_event.is_action_pressed("load_reference"):
 		load_reference_image()
-	elif input_event.is_action_pressed("open_settings"):
-		_on_settings_pressed()
 	elif input_event.is_action_pressed("view_show_grid"):
 		toggle_grid_visuals()
 	elif input_event.is_action_pressed("view_show_handles"):
@@ -78,16 +69,6 @@ func _unhandled_input(input_event: InputEvent) -> void:
 		toggle_reference_overlay()
 	elif input_event.is_action_pressed("snap_toggle"):
 		toggle_snap()
-	elif input_event.is_action_pressed("about_repo"):
-		open_godsvg_repo()
-	elif input_event.is_action_pressed("about_website"):
-		open_godsvg_website()
-	elif input_event.is_action_pressed("about_info"):
-		open_about()
-	elif input_event.is_action_pressed("about_donate"):
-		open_sponsor()
-	elif input_event.is_action_pressed("check_updates"):
-		open_update_checker()
 
 
 func update_translations() -> void:
@@ -122,8 +103,7 @@ func update_snap_config() -> void:
 
 
 func _on_settings_pressed() -> void:
-	var settings_menu_instance := settings_menu.instantiate()
-	HandlerGUI.add_overlay(settings_menu_instance)
+	ShortcutUtils.fn_call("open_settings")
 
 
 func _on_reference_pressed() -> void:
@@ -158,20 +138,23 @@ func _on_visuals_button_pressed() -> void:
 
 func _on_more_options_pressed() -> void:
 	var about_btn := ContextPopup.create_button(TranslationServer.translate("About…"),
-			open_about, false, load("res://visual/icon.png"), "about_info")
+			ShortcutUtils.fn("about_info"), false, load("res://visual/icon.png"),
+			"about_info")
 	about_btn.expand_icon = true
 	var buttons_arr: Array[Button] = [
 		about_btn,
 		ContextPopup.create_button(TranslationServer.translate("Donate…"),
-				open_sponsor, false, load("res://visual/icons/Heart.svg"), "about_donate"),
+				ShortcutUtils.fn("about_donate"), false, load("res://visual/icons/Heart.svg"),
+				"about_donate"),
 		ContextPopup.create_button(TranslationServer.translate("GodSVG repository"),
-				open_godsvg_repo, false, load("res://visual/icons/Link.svg"), "about_repo"),
+				ShortcutUtils.fn("about_repo"), false, load("res://visual/icons/Link.svg"),
+				"about_repo"),
 		ContextPopup.create_button(TranslationServer.translate("GodSVG website"),
-				open_godsvg_website, false, load("res://visual/icons/Link.svg"),
+				ShortcutUtils.fn("about_website"), false, load("res://visual/icons/Link.svg"),
 				"about_website"),
 		ContextPopup.create_button(TranslationServer.translate("Check for updates"),
-				open_update_checker, false, load("res://visual/icons/Reload.svg"),
-				"check_updates")]
+				ShortcutUtils.fn("check_updates"), false,
+				load("res://visual/icons/Reload.svg"), "check_updates")]
 	var separator_indices: Array[int] = [2, 4]
 	
 	var more_popup := ContextPopup.new()
@@ -179,44 +162,21 @@ func _on_more_options_pressed() -> void:
 	HandlerGUI.popup_under_rect_center(more_popup, more_button.get_global_rect(),
 			get_viewport())
 
-func open_godsvg_repo() -> void:
-	OS.shell_open("https://github.com/MewPurPur/GodSVG")
-
-func open_godsvg_website() -> void:
-	OS.shell_open("https://godsvg.com")
-
-func open_about() -> void:
-	var about_menu_instance := about_menu.instantiate()
-	HandlerGUI.add_overlay(about_menu_instance)
-
-func open_sponsor() -> void:
-	var donate_menu_instance := donate_menu.instantiate()
-	HandlerGUI.add_overlay(donate_menu_instance)
-
-func open_update_checker() -> void:
-	var confirmation_dialog := ConfirmDialog.instantiate()
-	HandlerGUI.add_overlay(confirmation_dialog)
-	confirmation_dialog.setup(TranslationServer.translate("Check for updates?"),
-			TranslationServer.translate("This requires GodSVG to connect to the internet."),
-			TranslationServer.translate("OK"), _list_updates)
-
-func _list_updates() -> void:
-	HandlerGUI.remove_all_overlays()
-	var update_menu_instance := update_menu.instantiate()
-	HandlerGUI.add_overlay(update_menu_instance)
-
 
 func toggle_grid_visuals() -> void:
 	grid_visuals.visible = not grid_visuals.visible
-	view_settings_updated.emit(grid_visuals.visible, controls.visible, viewport.display_texture.rasterized)
+	view_settings_updated.emit(grid_visuals.visible, controls.visible,
+			viewport.display_texture.rasterized)
 
 func toggle_handles_visuals() -> void:
 	controls.visible = not controls.visible
-	view_settings_updated.emit(grid_visuals.visible, controls.visible, viewport.display_texture.rasterized)
+	view_settings_updated.emit(grid_visuals.visible, controls.visible,
+			viewport.display_texture.rasterized)
 
 func toggle_rasterization() -> void:
 	viewport.display_texture.rasterized = not viewport.display_texture.rasterized
-	view_settings_updated.emit(grid_visuals.visible, controls.visible, viewport.display_texture.rasterized)
+	view_settings_updated.emit(grid_visuals.visible, controls.visible,
+			viewport.display_texture.rasterized)
 
 
 func toggle_reference_image() -> void:


### PR DESCRIPTION
Makes the shortcuts logic a bit cleaner IMO. Fixes #775.

Sets up the About menu to accommodate donor tiers in the future.

Adds TODO to remove a workaround for the bug that will be fixed by https://github.com/godotengine/godot/pull/92582 as it's unnecessary overhead.