### PR TITLE
Rework Reference Images

### DIFF
--- a/src/FileUtils.gd
+++ b/src/FileUtils.gd
@@ -115,7 +115,7 @@ static func open_reference_load_dialog() -> void:
 	if FileUtils._is_native_preferred():
 		DisplayServer.file_dialog_show(TranslationServer.translate("Load an image file"),
 				Utils.get_last_dir(), "", false, DisplayServer.FILE_DIALOG_MODE_OPEN_FILE,
-				PackedStringArray(["*.svg,*.png,*.jpeg,*.jpg,*.webp"]),
+				PackedStringArray(["*.png,*.jpeg,*.jpg,*.webp,*.svg"]),
 				native_reference_image_load)
 	# TODO: Add Web Support
 	#elif OS.has_feature("web"):
@@ -124,7 +124,7 @@ static func open_reference_load_dialog() -> void:
 		var image_import_dialog := GoodFileDialog.instantiate()
 		image_import_dialog.setup(Utils.get_last_dir(), "",
 				GoodFileDialogType.FileMode.SELECT,
-				PackedStringArray(["svg", "png", "jpeg", "jpg", "webp"]))
+				PackedStringArray(["png", "jpeg", "jpg", "webp", "svg"]))
 		HandlerGUI.add_overlay(image_import_dialog)
 		image_import_dialog.file_selected.connect(load_reference_image)
 
@@ -139,7 +139,9 @@ _filter_idx: int) -> void:
 		load_reference_image(files[0])
 
 static func load_reference_image(path: String) -> void:
-	GlobalSettings.modify_save_data("reference_path", path)
+	var img = Image.new()
+	img.load_from_file(path)
+	img.save_png("user://reference_image.png")
 	Indications.imported_reference.emit()
 
 static func apply_svg_from_path(path: String) -> int:

--- a/src/data_classes/SaveData.gd
+++ b/src/data_classes/SaveData.gd
@@ -4,7 +4,6 @@ class_name SaveData extends Resource
 const GoodColorPicker = preload("res://src/ui_elements/good_color_picker.gd")
 
 @export var svg_text := ""
-@export var reference_path := ""
 @export var viewbox_coupling := true
 @export var snap := -0.5  # Negative when disabled.
 @export var color_picker_slider_mode := GoodColorPicker.SliderMode.RGB

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -194,8 +194,7 @@ func toggle_reference_overlay() -> void:
 func load_reference_image() -> void:
 	FileUtils.open_reference_load_dialog()
 	await Indications.imported_reference
-	var ref_path = GlobalSettings.save_data.get("reference_path")
-	var img = Image.load_from_file(ref_path)
+	var img = Image.load_from_file("user://reference_image.png")
 	reference_texture.texture = ImageTexture.create_from_image(img)
 	reference_texture.show()
 

--- a/src/ui_parts/display.tscn
+++ b/src/ui_parts/display.tscn
@@ -188,8 +188,8 @@ mouse_filter = 2
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
 theme_override_constants/line_spacing = 0
+theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 14
 horizontal_alignment = 2
 
@@ -197,8 +197,8 @@ horizontal_alignment = 2
 layout_mode = 2
 theme_override_colors/font_color = Color(0.75, 0.75, 0.75, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 4
 theme_override_constants/line_spacing = 0
+theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 14
 horizontal_alignment = 2
 


### PR DESCRIPTION
- Now saves the selected reference image to "user://reference_image.png"
- Removed reference path from SaveData as it is not needed anymore

Only changes things in the backend, nothing is changed for the user. This should make implementing web support easier.