### PR TITLE
Fix Ctrl + Middle mouse drag zooming

### DIFF
--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -135,7 +135,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		set_view(view.position + move_vec * factor / Indications.zoom * 32)
 	
 	else:
-		_zoom_to = Vector2.ZERO  # Reset Ctrl + MMB zoom position if released.
+		if not event.is_echo():
+			_zoom_to = Vector2.ZERO  # Reset Ctrl + MMB zoom position if released.
 
 
 func _on_zoom_changed(new_zoom_level: float, offset: Vector2) -> void:


### PR DESCRIPTION
Due to a hardware difference i was not aware of this earlier. On my laptop the keyboard probably doesn't spam input when holding a key down.