### PR TITLE
Improve shortcut handling and add Find action

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -307,6 +307,11 @@ view_overlay_reference={
 "deadzone": 0.5,
 "events": []
 }
+find={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":102,"location":0,"echo":false,"script":null)
+]
+}
 
 [input_devices]
 

--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -90,6 +90,7 @@ const keybinds_dict = {
 		"move_up": true,
 		"move_down": true,
 		"delete": true,
+		"find": true,
 	},
 	"view": {
 		"zoom_in": true,

--- a/src/HandlerGUI.gd
+++ b/src/HandlerGUI.gd
@@ -192,15 +192,6 @@ func _input(event: InputEvent) -> void:
 			event.double_click = true
 			last_mouse_click_double = false
 	
-	if not overlay_stack.is_empty():
-		return
-	
-	if event.is_action_pressed("save"):
-		get_viewport().set_input_as_handled()
-		FileUtils.open_save_dialog("svg", FileUtils.native_file_save,
-				FileUtils.save_svg_to_file)
-
-func _unhandled_input(event: InputEvent) -> void:
 	# Stuff that should replace the existing overlays.
 	for action in ["about_info", "about_donate", "check_updates", "open_settings"]:
 		if event.is_action_pressed(action):
@@ -218,10 +209,9 @@ func _unhandled_input(event: InputEvent) -> void:
 	
 	# Stop stuff from propagating when there's overlays.
 	if not popup_overlay_stack.is_empty() or not overlay_stack.is_empty():
-		get_viewport().set_input_as_handled()
 		return
 	
-	for action in ["import", "export", "copy_svg_text", "clear_svg", "optimize",
+	for action in ["import", "export", "save", "copy_svg_text", "clear_svg", "optimize",
 	"clear_file_path", "reset_svg", "redo", "undo"]:
 		if event.is_action_pressed(action):
 			get_viewport().set_input_as_handled()

--- a/src/ShortcutUtils.gd
+++ b/src/ShortcutUtils.gd
@@ -6,6 +6,8 @@ static func fn_call(shortcut: String) -> void:
 # The methods that should be called if these shortcuts aren't handled.
 static func fn(shortcut: String) -> Callable:
 	match shortcut:
+		"save": return FileUtils.open_save_dialog.bind("svg",
+				FileUtils.native_file_save, FileUtils.save_svg_to_file)
 		"import": return FileUtils.open_import_dialog
 		"export": return FileUtils.open_export_dialog
 		"copy_svg_text": return DisplayServer.clipboard_set.bind(SVG.text)

--- a/src/ui_elements/ContextPopup.gd
+++ b/src/ui_elements/ContextPopup.gd
@@ -59,6 +59,13 @@ icon: Texture2D = null, shortcut := "") -> Button:
 				ret_button.add_child(internal_hbox)
 				ret_button.pressed.connect(press_action)
 				ret_button.pressed.connect(HandlerGUI.remove_popup_overlay)
+				
+				var shortcut_obj := Shortcut.new()
+				var action_obj := InputEventAction.new()
+				action_obj.action = shortcut
+				shortcut_obj.events.append(action_obj)
+				ret_button.shortcut = shortcut_obj
+				ret_button.shortcut_feedback = false
 				return ret_button
 	# Finish setting up the main button and return it if there's no shortcut.
 	main_button.theme_type_variation = "ContextButton"
@@ -120,7 +127,14 @@ start_pressed: bool, shortcut := "") -> CheckBox:
 				internal_hbox.add_child(label_margin)
 				ret_button.add_child(internal_hbox)
 				ret_button.pressed.connect(
-						func(): checkbox.button_pressed = !checkbox.button_pressed)
+						func(): checkbox.button_pressed = not checkbox.button_pressed)
+				
+				var shortcut_obj := Shortcut.new()
+				var action_obj := InputEventAction.new()
+				action_obj.action = shortcut
+				shortcut_obj.events.append(action_obj)
+				ret_button.shortcut = shortcut_obj
+				ret_button.shortcut_feedback = false
 				return ret_button
 	# Finish setting up the checkbox and return it if there's no shortcut.
 	checkbox.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND

--- a/src/ui_elements/color_popup.gd
+++ b/src/ui_elements/color_popup.gd
@@ -115,3 +115,8 @@ func _on_switch_mode_pressed() -> void:
 
 func _on_tree_exited() -> void:
 	color_picked.emit(current_value, true)
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("find"):
+		search_field.grab_focus()
+		accept_event()

--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -445,3 +445,8 @@ func get_drive_icon(path: String) -> Texture2D:
 
 func is_system_dir(path: String) -> bool:
 	return path in system_dir_paths.values()
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("find"):
+		search_button.button_pressed = true
+		accept_event()


### PR DESCRIPTION
Closes #800. Helps us work towards #369.

Allows context buttons to be activated with their input event actions.

Fixes issues where TextEdits and LineEdits would eat inputs instead of letting GodSVG handle them.