### PR TITLE
Fix UndoRedo in TextEdit no longer usable

### DIFF
--- a/src/HandlerGUI.gd
+++ b/src/HandlerGUI.gd
@@ -43,6 +43,9 @@ func _on_files_dropped(files: PackedStringArray) -> void:
 
 
 func add_overlay(overlay_menu: Control) -> void:
+	# FIXME subpar workaround to drag & drop not able to be cancelled manually.
+	get_tree().root.propagate_notification(NOTIFICATION_DRAG_END)
+	
 	remove_all_popup_overlays()
 	
 	if not overlay_stack.is_empty():
@@ -207,12 +210,13 @@ func _input(event: InputEvent) -> void:
 			ShortcutUtils.fn_call(action)
 			return
 	
-	# Stop stuff from propagating when there's overlays.
+	# Stop the logic below from running if there's overlays.
 	if not popup_overlay_stack.is_empty() or not overlay_stack.is_empty():
 		return
 	
+	# Global actions that should happen regardless of the context.
 	for action in ["import", "export", "save", "copy_svg_text", "clear_svg", "optimize",
-	"clear_file_path", "reset_svg", "redo", "undo"]:
+	"clear_file_path", "reset_svg"]:
 		if event.is_action_pressed(action):
 			get_viewport().set_input_as_handled()
 			ShortcutUtils.fn_call(action)
@@ -222,8 +226,8 @@ func _unhandled_input(event: InputEvent) -> void:
 	get_viewport().gui_is_dragging():
 		return
 	
-	for action in ["ui_cancel", "delete", "move_up", "move_down", "duplicate",
-	"select_all"]:
+	for action in ["redo", "undo", "ui_cancel", "delete", "move_up", "move_down",
+	"duplicate", "select_all"]:
 		if event.is_action_pressed(action):
 			get_viewport().set_input_as_handled()
 			ShortcutUtils.fn_call(action)

--- a/src/Utils.gd
+++ b/src/Utils.gd
@@ -146,7 +146,7 @@ static func is_event_drag_end(event: InputEvent) -> bool:
 	return event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and\
 			event.is_released()
 
-static func is_event_cancel(event: InputEvent) -> bool:
+static func is_event_drag_cancel(event: InputEvent) -> bool:
 	return event.is_action_pressed("ui_cancel") or\
 			event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT
 

--- a/src/ui_elements/number_field_with_slider.gd
+++ b/src/ui_elements/number_field_with_slider.gd
@@ -152,7 +152,7 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 				set_num(final_slider_value, true)
 
 func _unhandled_input(event: InputEvent) -> void:
-	if slider_dragged and Utils.is_event_cancel(event):
+	if slider_dragged and Utils.is_event_drag_cancel(event):
 		slider_dragged = false
 		set_num(initial_slider_value)
 		accept_event()


### PR DESCRIPTION
Also partially addresses something of an unfixable bug with drag-and-drop.