### PR TITLE
Fix some issues around settings

### DIFF
--- a/src/GlobalSettings.gd
+++ b/src/GlobalSettings.gd
@@ -19,61 +19,67 @@ const save_path = "user://save.tres"
 var config := ConfigFile.new()
 const config_path = "user://config.tres"
 
+func get_default(section: String, setting: String) -> Variant:
+	return defaults[section][setting][0]
+
+func get_signal(section: String, setting: String) -> Signal:
+	return defaults[section][setting][1]
+
 # Don't have the language setting here, so it's not reset.
-const default_config = {
+var defaults = {
 	"formatting": {
-		"general_number_precision": 3,
-		"general_angle_precision": 1,
-		"xml_add_trailing_newline": false,
-		"xml_shorthand_tags": true,
-		"xml_pretty_formatting": false,
-		"number_enable_autoformatting": false,
-		"number_remove_zero_padding": false,
-		"number_remove_leading_zero": true,
-		"number_remove_plus_sign": false,
-		"color_enable_autoformatting": false,
-		"color_convert_rgb_to_hex": false,
-		"color_convert_named_to_hex": true,
-		"color_use_shorthand_hex_code": true,
-		"color_use_short_named_colors": false,
-		"pathdata_enable_autoformatting": true,
-		"pathdata_compress_numbers": true,
-		"pathdata_minimize_spacing": true,
-		"pathdata_remove_spacing_after_flags": false,
-		"pathdata_remove_consecutive_commands": true,
-		"transform_list_enable_autoformatting": true,
-		"transform_list_compress_numbers": true,
-		"transform_list_minimize_spacing": true,
-		"transform_list_remove_unnecessary_params": true,
+		"general_number_precision": [3, number_precision_changed],
+		"general_angle_precision": [1, number_precision_changed],
+		"xml_add_trailing_newline": [false, Signal()],
+		"xml_shorthand_tags": [true, Signal()],
+		"xml_pretty_formatting": [false, Signal()],
+		"number_enable_autoformatting": [false, Signal()],
+		"number_remove_zero_padding": [false, Signal()],
+		"number_remove_leading_zero": [true, Signal()],
+		"number_remove_plus_sign": [false, Signal()],
+		"color_enable_autoformatting": [false, Signal()],
+		"color_convert_rgb_to_hex": [false, Signal()],
+		"color_convert_named_to_hex": [true, Signal()],
+		"color_use_shorthand_hex_code": [true, Signal()],
+		"color_use_short_named_colors": [false, Signal()],
+		"pathdata_enable_autoformatting": [true, Signal()],
+		"pathdata_compress_numbers": [true, Signal()],
+		"pathdata_minimize_spacing": [true, Signal()],
+		"pathdata_remove_spacing_after_flags": [false, Signal()],
+		"pathdata_remove_consecutive_commands": [true, Signal()],
+		"transform_list_enable_autoformatting": [true, Signal()],
+		"transform_list_compress_numbers": [true, Signal()],
+		"transform_list_minimize_spacing": [true, Signal()],
+		"transform_list_remove_unnecessary_params": [true, Signal()],
 	},
 	"theming": {
-		"highlighting_symbol_color": Color("abc9ff"),
-		"highlighting_element_color": Color("ff8ccc"),
-		"highlighting_attribute_color": Color("bce0ff"),
-		"highlighting_string_color": Color("a1ffe0"),
-		"highlighting_comment_color": Color("cdcfd280"),
-		"highlighting_text_color": Color("cdcfeaac"),
-		"highlighting_cdata_color": Color("ffeda1ac"),
-		"highlighting_error_color": Color("ff866b"),
-		"handle_inside_color": Color("fff"),
-		"handle_color": Color("#111"),
-		"handle_hovered_color": Color("#aaa"),
-		"handle_selected_color": Color("#46f"),
-		"handle_hovered_selected_color": Color("#f44"),
-		"background_color": Color(0.12, 0.132, 0.2, 1),
-		"basic_color_valid": Color("9f9"),
-		"basic_color_error": Color("f99"),
-		"basic_color_warning": Color("ee5"),
+		"highlighting_symbol_color": [Color("abc9ff"), highlight_colors_changed],
+		"highlighting_element_color": [Color("ff8ccc"), highlight_colors_changed],
+		"highlighting_attribute_color": [Color("bce0ff"), highlight_colors_changed],
+		"highlighting_string_color": [Color("a1ffe0"), highlight_colors_changed],
+		"highlighting_comment_color": [Color("cdcfd280"), highlight_colors_changed],
+		"highlighting_text_color": [Color("cdcfeaac"), highlight_colors_changed],
+		"highlighting_cdata_color": [Color("ffeda1ac"), highlight_colors_changed],
+		"highlighting_error_color": [Color("ff866b"), highlight_colors_changed],
+		"handle_inside_color": [Color("fff"), handle_visuals_changed],
+		"handle_color": [Color("#111"), handle_visuals_changed],
+		"handle_hovered_color": [Color("#aaa"), handle_visuals_changed],
+		"handle_selected_color": [Color("#46f"), handle_visuals_changed],
+		"handle_hovered_selected_color": [Color("#f44"), handle_visuals_changed],
+		"background_color": [Color("1f2233"), Signal()],
+		"basic_color_valid": [Color("9f9"), basic_colors_changed],
+		"basic_color_error": [Color("f99"), basic_colors_changed],
+		"basic_color_warning": [Color("ee5"), basic_colors_changed],
 	},
 	"other": {
-		"invert_zoom": false,
-		"wrap_mouse": false,
-		"use_ctrl_for_zoom": true,
-		"use_native_file_dialog": true,
-		"use_current_filename_for_window_title": true,
-		"handle_size": 1.0,
-		"ui_scale": 1.0,
-		"auto_ui_scale": true,
+		"invert_zoom": [false, Signal()],
+		"wrap_mouse": [false, Signal()],
+		"use_ctrl_for_zoom": [true, Signal()],
+		"use_native_file_dialog": [true, Signal()],
+		"use_current_filename_for_window_title": [true, window_title_scheme_changed],
+		"handle_size": [1.0, handle_visuals_changed],
+		"ui_scale": [1.0, ui_scale_changed],
+		"auto_ui_scale": [true, ui_scale_changed],
 	},
 }
 
@@ -150,9 +156,11 @@ const keybinds_dict = {
 
 var language: String:
 	set(new_value):
-		language = new_value
-		TranslationServer.set_locale(new_value)
-		save_setting("localization", "language")
+		if language != new_value:
+			language = new_value
+			TranslationServer.set_locale(new_value)
+			save_setting("localization", "language")
+			language_changed.emit()
 
 var palettes: Array[ColorPalette] = []
 
@@ -218,14 +226,19 @@ func toggle_bool_setting(section: String, setting: String) -> void:
 	save_setting(section, setting)
 
 func modify_setting(section: String, setting: String, new_value: Variant) -> void:
-	set(setting, new_value)
-	save_setting(section, setting)
+	if get(setting) != new_value:
+		set(setting, new_value)
+		save_setting(section, setting)
+		var related_signal := get_signal(section, setting)
+		if not related_signal.is_null():
+			related_signal.emit()
 
 func modify_keybind(action: String, new_events: Array[InputEvent]) -> void:
 	InputMap.action_erase_events(action)
 	for event in new_events:
 		InputMap.action_add_event(action, event)
 	save_keybind(action)
+	shortcuts_changed.emit()
 
 func save_setting(section: String, setting: String) -> void:
 	config.set_value(section, setting, get(setting))
@@ -285,13 +298,13 @@ func load_settings() -> void:
 					save_setting(section, setting)
 
 func reset_settings() -> void:
-	for section in default_config.keys():
-		for setting in default_config[section].keys():
-			set(setting, default_config[section][setting])
+	for section in defaults.keys():
+		for setting in defaults[section].keys():
+			set(setting, get_default(section, setting))
 			save_setting(section, setting)
 
 func reset_setting(section: String, setting: String) -> void:
-	set(setting, default_config[section][setting])
+	set(setting, get_default(section, setting))
 	save_setting(section, setting)
 
 func reset_keybinds() -> void:

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -23,6 +23,8 @@ const SettingColor = preload("res://src/ui_widgets/setting_color.gd")
 var focused_content := 0
 
 func _ready() -> void:
+	GlobalSettings.language_changed.connect(setup_setting_labels)
+	GlobalSettings.theme_changed.connect(setup_theming)
 	update_language_button()
 	setup_setting_labels()
 	for i in tabs.get_child_count():
@@ -37,10 +39,7 @@ func update_focused_content(idx: int) -> void:
 		content_container.get_child(i).visible = (focused_content == i)
 	tabs.get_child(focused_content).button_pressed = true
 
-
 func setup_theming() -> void:
-	GlobalSettings.language_changed.connect(setup_setting_labels)
-	GlobalSettings.theme_changed.connect(setup_theming)
 	var stylebox := get_theme_stylebox("panel").duplicate()
 	stylebox.content_margin_top += 4.0
 	add_theme_stylebox_override("panel", stylebox)
@@ -242,7 +241,6 @@ func _on_language_pressed() -> void:
 
 func _on_language_chosen(locale: String) -> void:
 	GlobalSettings.language = locale
-	GlobalSettings.language_changed.emit()
 	update_language_button()
 
 func update_language_button() -> void:
@@ -312,7 +310,6 @@ func _on_number_precision_changed() -> void:
 		GlobalSettings.save_data.snap = quanta
 		if not snapping_on:
 			GlobalSettings.save_data.snap *= -1
-	GlobalSettings.number_precision_changed.emit()
 
 func disable_format_checkboxes() -> void:
 	var is_autoformatting_numbers := GlobalSettings.number_enable_autoformatting
@@ -364,18 +361,6 @@ func show_keybinds(category: String):
 			keybind_config.label.text = TranslationUtils.get_shortcut_description(action)
 			keybind_config.setup(action)
 
-
-func setup_theming_tab() -> void:
-	for child in %HighlighterVBox.get_children():
-		if child is SettingColor:
-			child.value_changed.connect(GlobalSettings.highlight_colors_changed.emit)
-	for child in %HandleColors.get_children():
-		if child is SettingColor:
-			child.value_changed.connect(GlobalSettings.handle_visuals_changed.emit)
-	for child in %BasicColorsVBox.get_children():
-		if child is SettingColor:
-			child.value_changed.connect(GlobalSettings.basic_colors_changed.emit)
-
 func _on_theme_settings_changed() -> void:
 	ThemeGenerator.generate_theme()
 
@@ -407,16 +392,10 @@ func _on_shortcuts_tab_toggled(toggled_on: bool) -> void:
 
 func _on_theme_tab_toggled(toggled_on: bool) -> void:
 	if toggled_on and not generated_content.theming:
-		setup_theming_tab()
 		generated_content.theming = true
 
 func _on_other_tab_toggled(toggled_on: bool) -> void:
 	if toggled_on and not generated_content.other:
-		%Misc/HandleSize.value_changed.connect(GlobalSettings.handle_visuals_changed.emit)
-		%Misc/UIScale.value_changed.connect(GlobalSettings.ui_scale_changed.emit)
-		%Misc/AutoUIScale.pressed.connect(GlobalSettings.ui_scale_changed.emit)
-		%Misc/UseCurrentFilenameForWindowTitle.pressed.connect(
-				GlobalSettings.window_title_scheme_changed.emit)
 		# Disable mouse wrap if not available.
 		if not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE_WARP):
 			wrap_mouse.checkbox.set_pressed_no_signal(false)

--- a/src/ui_widgets/LineEditButton.gd
+++ b/src/ui_widgets/LineEditButton.gd
@@ -14,7 +14,7 @@ signal pressed
 signal text_change_canceled
 signal text_changed
 signal text_submitted
-signal button_gui_input
+signal button_gui_input(event: InputEvent)
 
 var _should_stay_active_outside := false
 var _is_mouse_outside := true

--- a/src/ui_widgets/color_edit.gd
+++ b/src/ui_widgets/color_edit.gd
@@ -25,6 +25,9 @@ var value: String:
 
 
 func _ready() -> void:
+	text_submitted.connect(set.bind("value"))
+	text_change_canceled.connect(sync.bind(value))
+	button_gui_input.connect(queue_redraw.unbind(1))
 	if enable_alpha:
 		custom_minimum_size.x += 14.0
 	sync(value)
@@ -50,6 +53,9 @@ func _on_pressed() -> void:
 	HandlerGUI.popup_under_rect(color_picker, get_global_rect(), get_viewport())
 	color_picker.color_picked.connect(_on_color_picked)
 
+func _on_text_changed(new_text: String) -> void:
+	font_color = GlobalSettings.get_validity_color(!is_color_valid_non_url(new_text))
+
 func _draw() -> void:
 	super()
 	var stylebox := StyleBoxFlat.new()
@@ -67,22 +73,7 @@ func _draw() -> void:
 	else:
 		draw_button_border("normal")
 
-
-func _on_text_submitted(new_text: String) -> void:
-	value = new_text
-
-func _on_text_change_canceled() -> void:
-	sync(value)
-
 func _on_color_picked(new_color: String, close_picker: bool) -> void:
 	value = new_color
 	if close_picker:
 		color_picker.queue_free()
-
-
-func _on_text_changed(new_text: String) -> void:
-	font_color = GlobalSettings.get_validity_color(!is_color_valid_non_url(new_text))
-
-
-func _on_button_gui_input(_event: InputEvent) -> void:
-	queue_redraw()

--- a/src/ui_widgets/color_edit.tscn
+++ b/src/ui_widgets/color_edit.tscn
@@ -10,8 +10,5 @@ offset_right = 68.0
 script = ExtResource("1_1uexr")
 button_visuals = false
 
-[connection signal="button_gui_input" from="." to="." method="_on_button_gui_input"]
 [connection signal="pressed" from="." to="." method="_on_pressed"]
-[connection signal="text_change_canceled" from="." to="." method="_on_text_change_canceled"]
 [connection signal="text_changed" from="." to="." method="_on_text_changed"]
-[connection signal="text_submitted" from="." to="." method="_on_text_submitted"]

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -28,7 +28,7 @@ func setup_placeholder() -> void:
 
 
 func _ready() -> void:
-	GlobalSettings.basic_colors_changed.connect(sync.bind(text))
+	GlobalSettings.basic_colors_changed.connect(resync)
 	set_value(element.get_attribute_value(attribute_name, true))
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	if attribute_name in DB.propagated_attributes:
@@ -124,6 +124,9 @@ func is_valid(color_text: String) -> bool:
 
 func _on_text_changed(new_text: String) -> void:
 	font_color = GlobalSettings.get_validity_color(!is_valid(new_text))
+
+func resync() -> void:
+	sync(text)
 
 func sync(new_value: String) -> void:
 	reset_font_color()

--- a/src/ui_widgets/enum_field.gd
+++ b/src/ui_widgets/enum_field.gd
@@ -18,7 +18,7 @@ func setup_placeholder() -> void:
 
 
 func _ready() -> void:
-	GlobalSettings.basic_colors_changed.connect(sync.bind(text))
+	GlobalSettings.basic_colors_changed.connect(resync)
 	set_value(element.get_attribute_value(attribute_name, true))
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	if attribute_name in DB.propagated_attributes:
@@ -75,6 +75,9 @@ func _on_text_change_canceled() -> void:
 func _on_text_changed(new_text: String) -> void:
 	font_color = GlobalSettings.get_validity_color(
 			not new_text in DB.attribute_enum_values[attribute_name])
+
+func resync() -> void:
+	sync(text)
 
 func sync(new_value: String) -> void:
 	text = new_value

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -13,7 +13,7 @@ func set_value(new_value: String, save := false) -> void:
 
 
 func _ready() -> void:
-	GlobalSettings.basic_colors_changed.connect(sync.bind(text))
+	GlobalSettings.basic_colors_changed.connect(resync)
 	set_value(element.get_attribute_value(attribute_name, true))
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	text_changed.connect(_on_text_changed)
@@ -38,6 +38,9 @@ func _on_text_changed(new_text: String) -> void:
 			validity_level == IDParser.ValidityLevel.INVALID,
 			validity_level == IDParser.ValidityLevel.INVALID_XML_NAMETOKEN)
 	add_theme_color_override("font_color", font_color)
+
+func resync() -> void:
+	sync(text)
 
 func sync(new_value: String) -> void:
 	text = new_value

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -37,7 +37,7 @@ func setup_placeholder() -> void:
 
 
 func _ready() -> void:
-	GlobalSettings.basic_colors_changed.connect(sync.bind(text))
+	GlobalSettings.basic_colors_changed.connect(resync)
 	set_value(element.get_attribute_value(attribute_name, true))
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	if attribute_name in DB.propagated_attributes:
@@ -62,6 +62,9 @@ func _on_focus_entered() -> void:
 
 func _on_text_change_canceled() -> void:
 	sync(element.get_attribute_value(attribute_name))
+
+func resync() -> void:
+	sync(text)
 
 func sync(new_value: String) -> void:
 	text = new_value

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -43,7 +43,7 @@ func setup_placeholder() -> void:
 
 
 func _ready() -> void:
-	GlobalSettings.basic_colors_changed.connect(sync.bind(text))
+	GlobalSettings.basic_colors_changed.connect(resync)
 	set_value(element.get_attribute_value(attribute_name, true))
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	if attribute_name in DB.propagated_attributes:
@@ -64,6 +64,9 @@ func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 
 func _on_text_change_canceled() -> void:
 	set_value(element.get_attribute_value(attribute_name))
+
+func resync() -> void:
+	sync(text)
 
 func sync(new_value: String) -> void:
 	text = new_value

--- a/src/ui_widgets/setting_check_box.gd
+++ b/src/ui_widgets/setting_check_box.gd
@@ -23,7 +23,7 @@ func update_widgets() -> void:
 	var setting_value: bool = GlobalSettings.get(setting_name)
 	checkbox.text = "On" if setting_value else "Off"
 	reset_button.visible = not checkbox.disabled and (setting_value !=\
-			GlobalSettings.default_config[section_name][setting_name])
+			GlobalSettings.get_default(section_name, setting_name))
 	if checkbox.disabled:
 		label.add_theme_color_override("font_color",
 				ThemeGenerator.common_subtle_text_color)

--- a/src/ui_widgets/setting_color.gd
+++ b/src/ui_widgets/setting_color.gd
@@ -30,5 +30,5 @@ func update_widgets() -> void:
 	var show_alpha := enable_alpha and setting_value.a != 1.0
 	var setting_str: String = setting_value.to_html(show_alpha)
 	color_edit.value = setting_str
-	var default_value: Color = GlobalSettings.default_config[section_name][setting_name]
+	var default_value: Color = GlobalSettings.get_default(section_name, setting_name)
 	reset_button.visible = (setting_str != default_value.to_html(default_value.a != 1.0))

--- a/src/ui_widgets/setting_dropdown.gd
+++ b/src/ui_widgets/setting_dropdown.gd
@@ -44,4 +44,4 @@ func update_widgets() -> void:
 	var setting_value: Variant = GlobalSettings.get(setting_name)
 	dropdown_widget.value = var_to_str(setting_value)
 	reset_button.visible = (setting_value !=\
-			GlobalSettings.default_config[section_name][setting_name])
+			GlobalSettings.get_default(section_name, setting_name))


### PR DESCRIPTION
Tweaks GlobalSettings to hold the signals that should be emitted when each setting changes. No need to guess anymore. Defaults and signal triggers are kept in the old default_config dictionary, which was repurposed to hold these arrays. I'm using arrays because I don't think we need a whole class for this right now.

Also resolves an issue that caused some fields' text to be wiped when you opened the settings.