### PR TITLE
Fix workflows running on wrong Godot version

### DIFF
--- a/.github/actions/set-up-godot/action.yml
+++ b/.github/actions/set-up-godot/action.yml
@@ -8,32 +8,32 @@ runs:
         # Set up folders for Godot editor and export templates.
         # This is done before the download step because this uses caching and doesn't always need to download.
         # The ~/godot directory is for the editor, so it can be added to PATH.
-        mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+        mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}
         mkdir -v -p ~/godot
     - name: Use cache
       id: godot-cache
       uses:
         actions/cache@v4
       with:
-        key: ${{ env.GODOT_VERSION }}-stable
+        key: ${{ env.GODOT_VERSION }}-${{ env.GODOT_RELEASE }}
         path: |
-          ~/.local/share/godot/export_templates/${{ env.GODOT_VERSION }}.stable
+          ~/.local/share/godot/export_templates/${{ env.GODOT_VERSION }}.${{ env.GODOT_RELEASE }}
           ~/godot
     - name: Download Godot
       if: ${{ steps.godot-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         # Download Godot editor and export templates from godot-builds repo.
-        wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_export_templates.tpz &
-        wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-stable/Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip &
+        wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_export_templates.tpz &
+        wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip &
         wait
         # Unpack the files.
-        unzip Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip -d ~ &
-        unzip Godot_v${GODOT_VERSION}-stable_export_templates.tpz -d ~ &
+        unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip -d ~ &
+        unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_export_templates.tpz -d ~ &
         wait
         # Move to correct places.
-        mv ~/templates/* ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
-        mv ~/Godot_v${GODOT_VERSION}-stable_linux.x86_64 ~/godot/godot
+        mv ~/templates/* ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}
+        mv ~/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64 ~/godot/godot
     - name: Add Godot to path
       shell: bash
       run: echo "~/godot" >> $GITHUB_PATH

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up WINE and rcedit for Windows export
         run: |
           # Download rcedit and install wine.
-          wget -q https://github.com/electron/rcedit/releases/download/v1.1.1/rcedit-x64.exe
+          wget -q https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe
           sudo apt update
           sudo apt install -y --fix-missing wine64
           # Move rcedit to different place.

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -41,8 +41,8 @@ jobs:
           # Run Godot to generate editor config file.
           godot --headless --quit
           # Add wine and rcedit paths to Godot config.
-          echo 'export/windows/wine = "/usr/bin/wine64"' >> ~/.config/godot/editor_settings-4.tres
-          echo 'export/windows/rcedit = "/home/runner/.local/share/rcedit/rcedit-x64.exe"' >> ~/.config/godot/editor_settings-4.tres
+          echo 'export/windows/wine = "/usr/bin/wine64"' >> ~/.config/godot/editor_settings-${GODOT_VERSION}.tres
+          echo 'export/windows/rcedit = "/home/runner/.local/share/rcedit/rcedit-x64.exe"' >> ~/.config/godot/editor_settings-${GODOT_VERSION}.tres
 
       - name: Export project
         uses: ./.github/actions/godot-export

--- a/.github/workflows/dev-desktop.yml
+++ b/.github/workflows/dev-desktop.yml
@@ -8,7 +8,8 @@ on:
     branches: [ main ]
 
 env:
-  GODOT_VERSION: 4.2.2
+  GODOT_VERSION: 4.3
+  GODOT_RELEASE: beta3
   PROJECT_NAME: GodSVG
 
 jobs:


### PR DESCRIPTION
Changed it back to use version and release separately.
Also had to update the way wine and rcedit get added to the editor settings because the file names changed to include godot version.
Also executable sizes even larger now 💀