### PR TITLE
Show orange color for MoveTo operations if the parent isn't valid

### DIFF
--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -23,7 +23,7 @@ var svg: ElementSVG:
 		_svg = weakref(new_value)
 
 var _root: WeakRef = null
-var root: ElementSVG:
+var root: ElementRoot:
 	get():
 		if _root != null:
 			return _root.get_ref()

--- a/src/ui_parts/element_frame.gd
+++ b/src/ui_parts/element_frame.gd
@@ -282,15 +282,23 @@ func _draw() -> void:
 			return
 	
 	var parent_xid := Utils.get_parent_xid(element.xid)
-	# Draw the yellow indicator of drag and drop actions.
+	# Draw the indicator of drag and drop actions.
 	var drop_sb := StyleBoxFlat.new()
-	var proposed_drop_xid := Indications.proposed_drop_xid
-	drop_sb.border_color = Color.GREEN
-	if proposed_drop_xid == parent_xid + PackedInt32Array([element.xid[-1]]):
+	var drop_xid := Indications.proposed_drop_xid
+	
+	var drop_tag := element.root.get_element(Utils.get_parent_xid(drop_xid))
+	var are_all_children_valid := true
+	for xid in Indications.selected_xids:
+		if !DB.is_child_element_valid(drop_tag.name, element.root.get_element(xid).name):
+			are_all_children_valid = false
+			break
+	
+	drop_sb.border_color = Color.GREEN if are_all_children_valid else Color.ORANGE
+	if drop_xid == parent_xid + PackedInt32Array([element.xid[-1]]):
 		drop_sb.border_width_top = 2
-	elif proposed_drop_xid == parent_xid + PackedInt32Array([element.xid[-1] + 1]):
+	elif drop_xid == parent_xid + PackedInt32Array([element.xid[-1] + 1]):
 		drop_sb.border_width_bottom = 2
-	elif proposed_drop_xid == element.xid + PackedInt32Array([0]):
+	elif drop_xid == element.xid + PackedInt32Array([0]):
 		drop_sb.set_border_width_all(2)
 		if is_instance_valid(child_elements_container):
 			drop_sb.border_color = Color(Color.GREEN, 0.4)


### PR DESCRIPTION
When one of the tags isn't a valid child of the to-be-parent, the indicator is orange instead of green.