### PR TITLE
Resync attribute fields when an ancestor element is changed

### DIFF
--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -47,6 +47,7 @@ func _on_element_attribute_changed(attribute_changed: String) -> void:
 func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:
 		setup_placeholder()
+		resync()
 
 # Redraw in case the gradient might have changed.
 func _on_svg_text_changed() -> void:

--- a/src/ui_widgets/enum_field.gd
+++ b/src/ui_widgets/enum_field.gd
@@ -40,6 +40,7 @@ func _on_element_attribute_changed(attribute_changed: String) -> void:
 func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:
 		setup_placeholder()
+		resync()
 
 
 func _on_pressed() -> void:

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -56,6 +56,7 @@ func _on_element_attribute_changed(attribute_changed: String) -> void:
 func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:
 		setup_placeholder()
+		resync()
 
 func _on_focus_entered() -> void:
 	remove_theme_color_override("font_color")

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -61,6 +61,7 @@ func _on_element_attribute_changed(attribute_changed: String) -> void:
 func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:
 		setup_placeholder()
+		resync()
 
 func _on_text_change_canceled() -> void:
 	set_value(element.get_attribute_value(attribute_name))


### PR DESCRIPTION
This is needed in order for warning colors to be reflected correctly.