### PR TITLE
Fix a few bugs and tweak eyedropper colors

### DIFF
--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -81,6 +81,10 @@ func get_child_count() -> int:
 func replace_child(idx: int, new_element: Element) -> void:
 	var old_element := get_child(idx)
 	_child_elements[idx] = new_element
+	for grandchild_element in new_element.get_children():
+		grandchild_element.parent = new_element
+		if new_element is ElementSVG:
+			grandchild_element.svg = new_element
 	new_element.xid = old_element.xid
 	new_element.parent = old_element.parent
 	new_element.svg = old_element.svg

--- a/src/parsers/NumberParser.gd
+++ b/src/parsers/NumberParser.gd
@@ -43,8 +43,7 @@ static func format_text(text: String) -> String:
 	if text == "-0":
 		text = "0"
 	
-	if leading_decimal_point or\
-	(GlobalSettings.number_remove_leading_zero and "." in text):
+	if leading_decimal_point or (GlobalSettings.number_remove_leading_zero and "." in text):
 		if text.begins_with("0"):
 			text = text.right(-1)
 		if text.begins_with("-0") or text.begins_with("+0"):

--- a/src/ui_parts/eyedropper_popup.gd
+++ b/src/ui_parts/eyedropper_popup.gd
@@ -45,11 +45,13 @@ func _draw() -> void:
 				draw_rect(Rect2(pos + Vector2(x, y) * 7 - Vector2(3, 3), Vector2(7, 7)),
 						texture_image.get_pixelv(pos + Vector2(x, y)))
 	
+	var theme_color := Color(0.9, 0.9, 0.9)
+	
 	for i in range(-45, 50, 7):
 		var offset := sqrt(2604 - i * i)
 		draw_line(pos + Vector2(i, -offset), pos + Vector2(i, offset), grid_color)
 		draw_line(pos + Vector2(-offset, i), pos + Vector2(offset, i), grid_color)
-	draw_circle(pos, 52, Color.WHITE, false, 6.0, true)
+	draw_circle(pos, 52, theme_color, false, 6.0, true)
 	draw_rect(Rect2(pos - Vector2(3, 3), Vector2(7, 7)), Color.WHITE, false, 1.0)
 	draw_rect(Rect2(pos - Vector2(4, 4), Vector2(9, 9)), Color.BLACK, false, 1.0)
 	
@@ -57,15 +59,14 @@ func _draw() -> void:
 			pos.y + (50 if (pos.y + 75 <= viewport_height) else -75))
 	var stylebox := StyleBoxFlat.new()
 	stylebox.set_corner_radius_all(4)
-	stylebox.bg_color = Color.WHITE
+	stylebox.bg_color = theme_color
 	stylebox.draw(ci, Rect2(stylebox_corner, Vector2(103, 25)))
 	
 	color = texture_image.get_pixelv(pos)
-	code_font.draw_string(ci, stylebox_corner + Vector2(25, 19), "#" + color.to_html(false),
+	code_font.draw_string(ci, stylebox_corner + Vector2(26, 19), "#" + color.to_html(false),
 			HORIZONTAL_ALIGNMENT_LEFT, -1, 16, Color.BLACK)
+	draw_rect(Rect2(stylebox_corner + Vector2(5, 5), Vector2(15, 15)), color)
+	var border := Color.WHITE
 	if color.get_luminance() > 0.455:
-		draw_rect(Rect2(stylebox_corner + Vector2(5, 5), Vector2(15, 15)), color)
-		draw_rect(Rect2(stylebox_corner + Vector2(5, 5), Vector2(16, 16)), Color.BLACK,
-				false, 1.0)
-	else:
-		draw_rect(Rect2(stylebox_corner + Vector2(4, 4), Vector2(17, 17)), color)
+		border = Color.BLACK
+	draw_rect(Rect2(stylebox_corner + Vector2(5, 5), Vector2(16, 16)), border, false, 1.0)

--- a/src/ui_parts/move_to_overlay.gd
+++ b/src/ui_parts/move_to_overlay.gd
@@ -14,3 +14,4 @@ func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 func _drop_data(_at_position: Vector2, data: Variant) -> void:
 	if data is Array[PackedInt32Array]:
 		SVG.root_element.move_elements_to(data, Indications.proposed_drop_xid)
+		SVG.queue_save()


### PR DESCRIPTION
Eyedropper now uses 90% gray instead of pure white, which was a bit of an eyesore.

Fixes issue where moving tags doesn't generate UndoRedo.

Fixes issue where converting shape tags with invalid children makes the children no longer show their config warnings.