### PR TITLE
Apply NL translation

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -319,7 +319,7 @@ pointing/android/enable_pan_and_scale_gestures=true
 
 [internationalization]
 
-locale/translations=PackedStringArray("res://translations/bg.po", "res://translations/de.po", "res://translations/en.po", "res://translations/ru.po", "res://translations/uk.po", "res://translations/zh.po")
+locale/translations=PackedStringArray("res://translations/bg.po", "res://translations/de.po", "res://translations/en.po", "res://translations/nl.po", "res://translations/ru.po", "res://translations/uk.po", "res://translations/zh.po")
 
 [rendering]
 

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -13,7 +13,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 msgid "translation-credits"
-msgstr "vertaling-kredieten"
+msgstr "Racer911dash1"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Quit GodSVG"


### PR DESCRIPTION
Adds NL as an applicable translation and attributes it to Racerdash correctly.