### PR TITLE
Use more reasonable precision when dragging handles

### DIFF
--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -122,9 +122,9 @@ func _on_reference_pressed() -> void:
 
 func _on_visuals_button_pressed() -> void:
 	var btn_arr: Array[Button] = [
-		ContextPopup.create_checkbox(TranslationServer.translate("Show Grid"),
+		ContextPopup.create_checkbox(TranslationServer.translate("Show grid"),
 				toggle_grid_visuals, grid_visuals.visible, "view_show_grid"),
-		ContextPopup.create_checkbox(TranslationServer.translate("Show Handles"),
+		ContextPopup.create_checkbox(TranslationServer.translate("Show handles"),
 				toggle_handles_visuals, controls.visible, "view_show_handles"),
 		ContextPopup.create_checkbox(TranslationServer.translate("Rasterized SVG"),
 				toggle_rasterization, viewport.display_texture.rasterized,

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -235,12 +235,12 @@ msgstr ""
 msgid "Overlay reference"
 msgstr ""
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr ""
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr ""
 
 #: src/ui_parts/display.gd
@@ -895,14 +895,6 @@ msgstr ""
 
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
-msgstr ""
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr ""
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -237,12 +237,12 @@ msgstr "Покажни справочното изображение"
 msgid "Overlay reference"
 msgstr "Насложи справочното изображение"
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "Покажи решетката"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "Покажи дръжките"
 
 #: src/ui_parts/display.gd
@@ -910,14 +910,6 @@ msgstr "Намали"
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
 msgstr "Рестартирай мащаба"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "Покажи решетката"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "Покажи дръжките"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"

--- a/translations/de.po
+++ b/translations/de.po
@@ -238,12 +238,12 @@ msgstr "Referenz anzeigen"
 msgid "Overlay reference"
 msgstr "Referenz überblenden"
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "Raster anzeigen"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "Griffe anzeigen"
 
 #: src/ui_parts/display.gd
@@ -913,14 +913,6 @@ msgid "Zoom reset"
 msgstr "Zoom zurücksetzen"
 
 #: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "Raster anzeigen"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "Griffe anzeigen"
-
-#: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"
 msgstr "Rasterisiertes SVG anzeigen"
 
@@ -1003,9 +995,6 @@ msgstr "Kubischer Bezier to"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "Kurzhand-Kubischer Bezier to"
-
-#~ msgid "No id attribute defined."
-#~ msgstr "Kein id Attribut definiert."
 
 #~ msgid "General"
 #~ msgstr "Allgemein"

--- a/translations/en.po
+++ b/translations/en.po
@@ -235,12 +235,12 @@ msgstr ""
 msgid "Overlay reference"
 msgstr ""
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr ""
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr ""
 
 #: src/ui_parts/display.gd
@@ -895,14 +895,6 @@ msgstr ""
 
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
-msgstr ""
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr ""
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -123,8 +123,9 @@ msgid "This group has only one element."
 msgstr "Deze groep heeft alleen een element."
 
 #: src/data_classes/ElementLinearGradient.gd
-msgid "No id attribute defined."
-msgstr "Geen id attribuut gedefinieert."
+#: src/data_classes/ElementRadialGradient.gd
+msgid "No \"id\" attribute defined."
+msgstr "Geen \"id\" attribuut gedefineerd."
 
 #: src/data_classes/ElementLinearGradient.gd
 #: src/data_classes/ElementRadialGradient.gd
@@ -135,10 +136,6 @@ msgstr "Geen <stop> elementen onder deze kleurovergang."
 #: src/data_classes/ElementRadialGradient.gd
 msgid "This gradient is a solid color."
 msgstr "Deze kleurovergang is een vaste kleur."
-
-#: src/data_classes/ElementRadialGradient.gd
-msgid "No \"id\" attribute defined."
-msgstr "Geen \"id\" attribuut gedefineerd."
 
 #: src/data_classes/SVGParser.gd
 msgid "Doesn’t describe an SVG."
@@ -241,12 +238,12 @@ msgstr "Referentie weergeven"
 msgid "Overlay reference"
 msgstr "Referentie overlappen"
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "Rooster weergeven"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "Hendelgrepen weergeven"
 
 #: src/ui_parts/display.gd
@@ -913,14 +910,6 @@ msgstr "Uitzoomen"
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
 msgstr "Zoom opnieuw zetten"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "Rooster weergeven"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "Hendelgrepen weergeven"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -241,12 +241,12 @@ msgstr "Показать референс-изображение"
 msgid "Overlay reference"
 msgstr "Наложить референс-изображение"
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "Показать сетку"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "Показать ручки редактирования"
 
 #: src/ui_parts/display.gd
@@ -932,14 +932,6 @@ msgstr "Отдалить масштаб"
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
 msgstr "Сбросить масштаб"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "Показать сетку"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "Показать ручки редактирования"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -241,12 +241,12 @@ msgstr ""
 msgid "Overlay reference"
 msgstr ""
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "Показати ґратку"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "Показати ручки редагування"
 
 #: src/ui_parts/display.gd
@@ -936,14 +936,6 @@ msgstr "Зменшити масштаб"
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
 msgstr "Скинути масштаб"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "Показати ґратку"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "Показати ручки редагування"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"

--- a/translations/zh.po
+++ b/translations/zh.po
@@ -237,12 +237,12 @@ msgstr "显示参考"
 msgid "Overlay reference"
 msgstr "置顶参考"
 
-#: src/ui_parts/display.gd
-msgid "Show Grid"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show grid"
 msgstr "显示网格"
 
-#: src/ui_parts/display.gd
-msgid "Show Handles"
+#: src/ui_parts/display.gd src/utils/TranslationUtils.gd
+msgid "Show handles"
 msgstr "显示拖拽框"
 
 #: src/ui_parts/display.gd
@@ -924,14 +924,6 @@ msgstr "缩小"
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
 msgstr "重置缩放"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show grid"
-msgstr "显示网格"
-
-#: src/utils/TranslationUtils.gd
-msgid "Show handles"
-msgstr "显示拖拽框"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"


### PR DESCRIPTION
Maths a precision based on your current zoom level instead of the crazy precision you'd get before when dragging handles. Also removes some duplicate strings with just different capitalization.