### PR TITLE
Add attribute field build

### DIFF
--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -7,9 +7,9 @@ static func add_hash_if_hex(color: String) -> String:
 		color = "#" + color
 	return color
 
-static func is_valid(color: String) -> bool:
+static func is_valid(color: String, allow_url := true) -> bool:
 	return is_valid_hex(color) or is_valid_rgb(color) or is_valid_named(color) or\
-			is_valid_url(color)
+			(allow_url and is_valid_url(color))
 
 static func is_valid_hex(color: String) -> bool:
 	color = color.strip_edges()

--- a/src/data_classes/DB.gd
+++ b/src/data_classes/DB.gd
@@ -2,6 +2,7 @@ class_name DB extends RefCounted
 
 enum AttributeType {NUMERIC, COLOR, LIST, PATHDATA, ENUM, TRANSFORM_LIST, ID, UNKNOWN}
 enum PercentageHandling {FRACTION, HORIZONTAL, VERTICAL, NORMALIZED}
+enum NumberRange {ARBITRARY, POSITIVE, UNIT}
 
 
 const recognized_elements = ["svg", "g", "circle", "ellipse", "rect", "path", "line",
@@ -103,27 +104,29 @@ const attribute_enum_values = {
 	"spreadMethod": ["pad", "reflect", "repeat"],
 }
 
-const attribute_numeric_bounds = {
-	"width": Vector2(0, INF),
-	"height": Vector2(0, INF),
-	"x": Vector2(-INF, INF),
-	"y": Vector2(-INF, INF),
-	"x1": Vector2(-INF, INF),
-	"y1": Vector2(-INF, INF),
-	"x2": Vector2(-INF, INF),
-	"y2": Vector2(-INF, INF),
-	"cx": Vector2(-INF, INF),
-	"cy": Vector2(-INF, INF),
-	"r": Vector2(0, INF),
-	"rx": Vector2(0, INF),
-	"ry": Vector2(0, INF),
-	"opacity": Vector2(0, 1),
-	"fill-opacity": Vector2(0, 1),
-	"stroke-opacity": Vector2(0, 1),
-	"stroke-width": Vector2(0, INF),
-	"offset": Vector2(0, 1),
-	"stop-opacity": Vector2(0, 1),
+const attribute_number_range = {
+	"width": NumberRange.POSITIVE,
+	"height": NumberRange.POSITIVE,
+	"x": NumberRange.ARBITRARY,
+	"y": NumberRange.ARBITRARY,
+	"x1": NumberRange.ARBITRARY,
+	"y1": NumberRange.ARBITRARY,
+	"x2": NumberRange.ARBITRARY,
+	"y2": NumberRange.ARBITRARY,
+	"cx": NumberRange.ARBITRARY,
+	"cy": NumberRange.ARBITRARY,
+	"r": NumberRange.POSITIVE,
+	"rx": NumberRange.POSITIVE,
+	"ry": NumberRange.POSITIVE,
+	"opacity": NumberRange.UNIT,
+	"fill-opacity": NumberRange.UNIT,
+	"stroke-opacity": NumberRange.UNIT,
+	"stroke-width": NumberRange.POSITIVE,
+	"offset": NumberRange.UNIT,
+	"stop-opacity": NumberRange.UNIT,
 }
+
+const attribute_color_url_allowed = ["fill", "stroke"]
 
 
 static func is_attribute_recognized(element_name: String, attribute_name: String) -> bool:

--- a/src/ui_parts/element_frame.gd
+++ b/src/ui_parts/element_frame.gd
@@ -66,40 +66,7 @@ func _ready() -> void:
 			unknown_container = HFlowContainer.new()
 			main_container.add_child(unknown_container)
 			main_container.move_child(unknown_container, 0)
-		
-		var input_field: Control
-		match DB.get_attribute_type(attribute.name):
-			DB.AttributeType.COLOR:
-				input_field = ColorField.instantiate()
-				input_field.attribute_name = attribute.name
-			DB.AttributeType.ENUM:
-				input_field = EnumField.instantiate()
-				input_field.attribute_name = attribute.name
-			DB.AttributeType.TRANSFORM_LIST:
-				input_field = TransformField.instantiate()
-				input_field.attribute_name = attribute.name
-			DB.AttributeType.ID: input_field = IDField.instantiate()
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute.name].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute.name].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-				input_field.attribute_name = attribute.name
-			_:
-				input_field = UnrecognizedField.instantiate()
-				input_field.attribute_name = attribute.name
-		input_field.element = element
-		unknown_container.add_child(input_field)
+		unknown_container.add_child(AttributeFieldBuilder.create(attribute.name, element))
 	
 	var element_content: Control
 	if element.name in element_content_types:

--- a/src/ui_parts/root_element_editor.gd
+++ b/src/ui_parts/root_element_editor.gd
@@ -65,36 +65,7 @@ func update_attributes() -> void:
 				add_child(unknown_container)
 				move_child(unknown_container, 0)
 			
-			var input_field: Control
-			match DB.get_attribute_type(attribute.name):
-				DB.AttributeType.COLOR:
-					input_field = ColorField.instantiate()
-					input_field.attribute_name = attribute.name
-				DB.AttributeType.ENUM:
-					input_field = EnumField.instantiate()
-					input_field.attribute_name = attribute.name
-				DB.AttributeType.TRANSFORM_LIST:
-					input_field = TransformField.instantiate()
-					input_field.attribute_name = attribute.name
-				DB.AttributeType.ID:
-					input_field = IDField.instantiate()
-				DB.AttributeType.NUMERIC:
-					var min_value: float = DB.attribute_numeric_bounds[attribute.name].x
-					var max_value: float = DB.attribute_numeric_bounds[attribute.name].y
-					if is_inf(max_value):
-						input_field = NumberField.instantiate()
-						if not is_inf(min_value):
-							input_field.allow_lower = false
-							input_field.min_value = min_value
-					else:
-						input_field = NumberSlider.instantiate()
-						input_field.allow_lower = false
-						input_field.allow_higher = false
-						input_field.min_value = min_value
-						input_field.max_value = max_value
-						input_field.slider_step = 0.01
-				_: input_field = UnrecognizedField.instantiate()
-			input_field.element = SVG.root_element
+			var input_field := AttributeFieldBuilder.create(attribute.name, SVG.root_element)
 			unknown_container.get_child(0).add_child(input_field)
 	if not has_unrecognized_attributes and is_instance_valid(unknown_container):
 		unknown_container.queue_free()

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -2,7 +2,12 @@
 extends LineEditButton
 
 var element: Element
-var attribute_name: String  # May propagate.
+var attribute_name: String:  # May propagate.
+	set(new_value):
+		attribute_name = new_value
+		cached_allow_url = attribute_name in DB.attribute_color_url_allowed
+
+var cached_allow_url: bool
 
 const ColorPopup = preload("res://src/ui_widgets/color_popup.tscn")
 const checkerboard = preload("res://visual/icons/backgrounds/ColorButtonBG.svg")
@@ -35,7 +40,9 @@ func _ready() -> void:
 		element.ancestor_attribute_changed.connect(_on_element_ancestor_attribute_changed)
 	text_submitted.connect(set_value.bind(true))
 	focus_entered.connect(reset_font_color)
-	SVG.changed.connect(_on_svg_changed)
+	# If URL is allowed, we need to always check if the gradient has changed.
+	if cached_allow_url:
+		SVG.changed.connect(_on_svg_changed)
 	tooltip_text = attribute_name
 	setup_placeholder()
 
@@ -58,6 +65,7 @@ func _on_svg_changed() -> void:
 func _on_pressed() -> void:
 	color_popup = ColorPopup.instantiate()
 	color_popup.current_value = element.get_attribute_value(attribute_name, true)
+	color_popup.show_url = cached_allow_url
 	color_popup.color_picked.connect(_on_color_picked)
 	HandlerGUI.popup_under_rect(color_popup, get_global_rect(), get_viewport())
 
@@ -69,7 +77,7 @@ func _draw() -> void:
 	# Draw the color or gradient.
 	var drawn := false
 	var color_value := element.get_attribute_value(attribute_name, false)
-	if ColorParser.is_valid_url(color_value):
+	if cached_allow_url and ColorParser.is_valid_url(color_value):
 		var id := color_value.substr(5, color_value.length() - 6)
 		var gradient_element := SVG.root_element.get_element_by_id(id)
 		if gradient_element != null:
@@ -120,7 +128,7 @@ func _on_color_picked(new_color: String, close_picker: bool) -> void:
 		color_popup.queue_free()
 
 func is_valid(color_text: String) -> bool:
-	return ColorParser.is_valid(ColorParser.add_hash_if_hex(color_text))
+	return ColorParser.is_valid(ColorParser.add_hash_if_hex(color_text), cached_allow_url)
 
 
 func _on_text_changed(new_text: String) -> void:
@@ -134,7 +142,8 @@ func sync(new_value: String) -> void:
 	if ColorParser.add_hash_if_hex(new_value) == element.get_default(attribute_name):
 		font_color = GlobalSettings.savedata.basic_color_warning
 	text = new_value.trim_prefix("#")
-	update_gradient_texture()
+	if cached_allow_url:
+		update_gradient_texture()
 	queue_redraw()
 
 # TODO remove this method when #94584 is fixed.

--- a/src/ui_widgets/color_popup.gd
+++ b/src/ui_widgets/color_popup.gd
@@ -8,6 +8,7 @@ const ColorSwatch = preload("res://src/ui_widgets/color_swatch.tscn")
 
 signal color_picked(new_color: String, final: bool)
 var current_value: String
+var show_url: bool
 
 var palette_mode := true
 
@@ -44,14 +45,15 @@ func update_palettes(search_text := "") -> void:
 	search_field.placeholder_text = TranslationServer.translate("Search color")
 	var reserved_colors := PackedStringArray(["none"])
 	var reserved_color_names := PackedStringArray(["No color"])
-	for element in SVG.root_element.get_all_elements():
-		if element.has_attribute("id"):
-			if element is ElementLinearGradient:
-				reserved_color_names.append("Linear gradient")
-				reserved_colors.append("url(#%s)" % element.get_attribute_value("id"))
-			elif element is ElementRadialGradient:
-				reserved_color_names.append("Radial gradient")
-				reserved_colors.append("url(#%s)" % element.get_attribute_value("id"))
+	if show_url:
+		for element in SVG.root_element.get_all_elements():
+			if element.has_attribute("id"):
+				if element is ElementLinearGradient:
+					reserved_color_names.append("Linear gradient")
+					reserved_colors.append("url(#%s)" % element.get_attribute_value("id"))
+				elif element is ElementRadialGradient:
+					reserved_color_names.append("Radial gradient")
+					reserved_colors.append("url(#%s)" % element.get_attribute_value("id"))
 	var reserved_color_palette := ColorPalette.new("", reserved_colors, reserved_color_names)
 	
 	var displayed_palettes: Array[ColorPalette] = [reserved_color_palette]

--- a/src/ui_widgets/color_popup.tscn
+++ b/src/ui_widgets/color_popup.tscn
@@ -63,6 +63,5 @@ mouse_default_cursor_shape = 2
 theme_override_font_sizes/font_size = 13
 text = "Palettes"
 
-[connection signal="tree_exited" from="." to="." method="_on_tree_exited"]
 [connection signal="color_changed" from="MainContainer/Content/ColorPicker" to="." method="pick_color"]
 [connection signal="pressed" from="MainContainer/SwitchMode" to="." method="_on_switch_mode_pressed"]

--- a/src/ui_widgets/element_content_basic_shape.gd
+++ b/src/ui_widgets/element_content_basic_shape.gd
@@ -11,28 +11,7 @@ const EnumField = preload("res://src/ui_widgets/enum_field.tscn")
 var element: Element
 
 func _ready() -> void:
-	for attribute_key in DB.recognized_attributes[element.name]:
-		var input_field: Control
-		match DB.get_attribute_type(attribute_key):
-			DB.AttributeType.TRANSFORM_LIST: input_field = TransformField.instantiate()
-			DB.AttributeType.COLOR: input_field = ColorField.instantiate()
-			DB.AttributeType.ENUM: input_field = EnumField.instantiate()
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute_key].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute_key].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-		input_field.attribute_name = attribute_key
-		input_field.element = element
+	for attribute in DB.recognized_attributes[element.name]:
+		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_g.gd
+++ b/src/ui_widgets/element_content_g.gd
@@ -11,28 +11,7 @@ const EnumField = preload("res://src/ui_widgets/enum_field.tscn")
 var element: Element
 
 func _ready() -> void:
-	for attribute_key in DB.recognized_attributes["g"]:
-		var input_field: Control
-		match DB.get_attribute_type(attribute_key):
-			DB.AttributeType.TRANSFORM_LIST: input_field = TransformField.instantiate()
-			DB.AttributeType.COLOR: input_field = ColorField.instantiate()
-			DB.AttributeType.ENUM: input_field = EnumField.instantiate()
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute_key].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute_key].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-		input_field.attribute_name = attribute_key
-		input_field.element = element
+	for attribute in DB.recognized_attributes["g"]:
+		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_linear_gradient.gd
+++ b/src/ui_widgets/element_content_linear_gradient.gd
@@ -12,35 +12,7 @@ const IdField = preload("res://src/ui_widgets/id_field.tscn")
 var element: Element
 
 func _ready() -> void:
-	for attribute_key in DB.recognized_attributes["linearGradient"]:
-		var input_field: Control
-		match DB.get_attribute_type(attribute_key):
-			DB.AttributeType.ID: input_field = IdField.instantiate()
-			DB.AttributeType.TRANSFORM_LIST:
-				input_field = TransformField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.COLOR:
-				input_field = ColorField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.ENUM:
-				input_field = EnumField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute_key].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute_key].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-				input_field.attribute_name = attribute_key
-		input_field.element = element
+	for attribute in DB.recognized_attributes["linearGradient"]:
+		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_path.gd
+++ b/src/ui_widgets/element_content_path.gd
@@ -16,31 +16,10 @@ func _ready() -> void:
 	path_field.setup()
 	path_field.focused.connect(Indications.normal_select.bind(element.xid))
 	
-	for attribute_key in DB.recognized_attributes["path"]:
-		if attribute_key == "d":
+	for attribute in DB.recognized_attributes["path"]:
+		if attribute == "d":
 			continue
-		var input_field: Control
-		match DB.get_attribute_type(attribute_key):
-			DB.AttributeType.TRANSFORM_LIST: input_field = TransformField.instantiate()
-			DB.AttributeType.COLOR: input_field = ColorField.instantiate()
-			DB.AttributeType.ENUM: input_field = EnumField.instantiate()
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute_key].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute_key].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-		input_field.attribute_name = attribute_key
-		input_field.element = element
+		var input_field := AttributeFieldBuilder.create(attribute, element)
 		# Focused signal for pathdata attribute.
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_radial_gradient.gd
+++ b/src/ui_widgets/element_content_radial_gradient.gd
@@ -12,35 +12,7 @@ const IdField = preload("res://src/ui_widgets/id_field.tscn")
 var element: Element
 
 func _ready() -> void:
-	for attribute_key in DB.recognized_attributes["radialGradient"]:
-		var input_field: Control
-		match DB.get_attribute_type(attribute_key):
-			DB.AttributeType.ID: input_field = IdField.instantiate()
-			DB.AttributeType.TRANSFORM_LIST:
-				input_field = TransformField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.COLOR:
-				input_field = ColorField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.ENUM:
-				input_field = EnumField.instantiate()
-				input_field.attribute_name = attribute_key
-			DB.AttributeType.NUMERIC:
-				var min_value: float = DB.attribute_numeric_bounds[attribute_key].x
-				var max_value: float = DB.attribute_numeric_bounds[attribute_key].y
-				if is_inf(max_value):
-					input_field = NumberField.instantiate()
-					if not is_inf(min_value):
-						input_field.allow_lower = false
-						input_field.min_value = min_value
-				else:
-					input_field = NumberSlider.instantiate()
-					input_field.allow_lower = false
-					input_field.allow_higher = false
-					input_field.min_value = min_value
-					input_field.max_value = max_value
-					input_field.slider_step = 0.01
-				input_field.attribute_name = attribute_key
-		input_field.element = element
+	for attribute in DB.recognized_attributes["radialGradient"]:
+		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_stop.gd
+++ b/src/ui_widgets/element_content_stop.gd
@@ -1,38 +1,15 @@
 extends VBoxContainer
 
-const TransformField = preload("res://src/ui_widgets/transform_field.tscn")
-const NumberField = preload("res://src/ui_widgets/number_field.tscn")
-const NumberSlider = preload("res://src/ui_widgets/number_field_with_slider.tscn")
-const ColorField = preload("res://src/ui_widgets/color_field.tscn")
-const EnumField = preload("res://src/ui_widgets/enum_field.tscn")
-
 @onready var attribute_container: HFlowContainer = $AttributeContainer
 
 var element: Element
 
 func _ready() -> void:
-	var offset_input_field: Control = NumberSlider.instantiate()
-	offset_input_field.allow_lower = false
-	offset_input_field.allow_higher = false
-	offset_input_field.min_value = DB.attribute_numeric_bounds["offset"].x
-	offset_input_field.max_value = DB.attribute_numeric_bounds["offset"].y
-	offset_input_field.slider_step = 0.01
-	offset_input_field.element = element
-	offset_input_field.attribute_name = "offset"
-	
-	var color_input_field: Control = ColorField.instantiate()
-	color_input_field.element = element
-	color_input_field.attribute_name = "stop-color"
-	
-	var opacity_input_field: Control = NumberSlider.instantiate()
-	opacity_input_field.allow_lower = false
-	opacity_input_field.allow_higher = false
-	opacity_input_field.min_value = DB.attribute_numeric_bounds["stop-opacity"].x
-	opacity_input_field.max_value = DB.attribute_numeric_bounds["stop-opacity"].y
-	opacity_input_field.slider_step = 0.01
-	opacity_input_field.element = element
-	opacity_input_field.attribute_name = "stop-opacity"
-	
+	var offset_input_field := AttributeFieldBuilder.create("offset", element)
 	attribute_container.add_child(offset_input_field)
+	
+	var color_input_field := AttributeFieldBuilder.create("stop-color", element)
 	attribute_container.add_child(color_input_field)
+	
+	var opacity_input_field := AttributeFieldBuilder.create("stop-opacity", element)
 	attribute_container.add_child(opacity_input_field)

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -2,12 +2,18 @@
 extends BetterLineEdit
 
 var element: Element
-var attribute_name: String  # May propagate.
+var attribute_name: String:  # May propagate.
+	set(new_value):
+		attribute_name = new_value
+		if DB.attribute_number_range[attribute_name] == DB.NumberRange.ARBITRARY:
+			cached_min_value = -INF
+			cached_max_value = INF
+		else:
+			cached_min_value = 0.0
+			cached_max_value = INF
 
-var min_value := 0.0
-var max_value := 1.0
-var allow_lower := true
-var allow_higher := true
+var cached_min_value: float
+var cached_max_value: float
 
 func set_value(new_value: String, save := false) -> void:
 	if not new_value.is_empty():
@@ -19,10 +25,7 @@ func set_value(new_value: String, save := false) -> void:
 				sync_to_attribute()
 				return
 			
-			if not allow_higher and numeric_value > max_value:
-				numeric_value = max_value
-			elif not allow_lower and numeric_value < min_value:
-				numeric_value = min_value
+			numeric_value = clampf(numeric_value, cached_min_value, cached_max_value)
 			new_value = element.get_attribute(attribute_name).num_to_text(numeric_value)
 		sync(element.get_attribute(attribute_name).format(new_value))
 	element.set_attribute(attribute_name, new_value)

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -4,11 +4,10 @@ extends LineEditButton
 var element: Element
 var attribute_name: String  # May propagate.
 
-var slider_step := 0.01
-var min_value := 0.0
-var max_value := 1.0
-var allow_lower := true
-var allow_higher := true
+# Could be made to not be constants if needed.
+const SLIDER_STEP := 0.01
+const MIN_VALUE := 0.0
+const MAX_VALUE := 1.0
 
 func set_value(new_value: String, save := false) -> void:
 	if not new_value.is_empty():
@@ -20,10 +19,10 @@ func set_value(new_value: String, save := false) -> void:
 				sync_to_attribute()
 				return
 			
-			if not allow_higher and numeric_value > max_value:
-				numeric_value = max_value
-			elif not allow_lower and numeric_value < min_value:
-				numeric_value = min_value
+			if numeric_value > MAX_VALUE:
+				numeric_value = MAX_VALUE
+			elif numeric_value < MIN_VALUE:
+				numeric_value = MIN_VALUE
 			new_value = element.get_attribute(attribute_name).num_to_text(numeric_value)
 	
 	sync(element.get_attribute(attribute_name).format(new_value))
@@ -106,7 +105,7 @@ func _draw() -> void:
 	stylebox.draw(ci, Rect2(get_size().x - BUTTON_WIDTH,
 			1, BUTTON_WIDTH - 2, get_size().y - 2))
 	var fill_height: float = (get_size().y - 4) *\
-			(element.get_attribute_num(attribute_name) - min_value) / max_value
+			(element.get_attribute_num(attribute_name) - MIN_VALUE) / MAX_VALUE
 	# Create a stylebox that'll occupy the exact amount of space.
 	var fill_stylebox := StyleBoxFlat.new()
 	fill_stylebox.bg_color = Color("#def")
@@ -157,8 +156,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		accept_event()
 
 func get_slider_value_at_y(y_coord: float) -> float:
-	return snappedf(lerpf(max_value, min_value,
-			(y_coord - 4) / (temp_button.get_size().y - 4)), slider_step)
+	return snappedf(lerpf(MAX_VALUE, MIN_VALUE,
+			(y_coord - 4) / (temp_button.get_size().y - 4)), SLIDER_STEP)
 
 func _on_slider_mouse_exited() -> void:
 	slider_hovered = false

--- a/src/utils/AttributeFieldBuilder.gd
+++ b/src/utils/AttributeFieldBuilder.gd
@@ -1,0 +1,32 @@
+class_name AttributeFieldBuilder
+
+const TransformField = preload("res://src/ui_widgets/transform_field.tscn")
+const NumberField = preload("res://src/ui_widgets/number_field.tscn")
+const NumberSlider = preload("res://src/ui_widgets/number_field_with_slider.tscn")
+const ColorField = preload("res://src/ui_widgets/color_field.tscn")
+const EnumField = preload("res://src/ui_widgets/enum_field.tscn")
+const IdField = preload("res://src/ui_widgets/id_field.tscn")
+const UnrecognizedField = preload("res://src/ui_widgets/unrecognized_field.tscn")
+
+static func create(attribute: String, element: Element) -> Control:
+	match DB.get_attribute_type(attribute):
+		DB.AttributeType.ID: return _generate_no_name(IdField, element)
+		DB.AttributeType.TRANSFORM_LIST: return _generate(TransformField, element, attribute)
+		DB.AttributeType.COLOR: return _generate(ColorField, element, attribute)
+		DB.AttributeType.ENUM: return _generate(EnumField, element, attribute)
+		DB.AttributeType.NUMERIC:
+			match DB.attribute_number_range[attribute]:
+				DB.NumberRange.UNIT: return _generate(NumberSlider, element, attribute)
+				_: return _generate(NumberField, element, attribute)
+		_: return _generate(UnrecognizedField, element, attribute)
+
+static func _generate(widget: PackedScene, element: Element, attribute: String) -> Control:
+	var widget_instance := widget.instantiate()
+	widget_instance.element = element
+	widget_instance.attribute_name = attribute
+	return widget_instance
+
+static func _generate_no_name(widget: PackedScene, element: Element) -> Control:
+	var widget_instance := widget.instantiate()
+	widget_instance.element = element
+	return widget_instance


### PR DESCRIPTION
Adds a class to automatically build attribute fields.

Makes color fields no longer accept URL syntax if the color attribute doesn't allow it.