### PR TITLE
Fix warning icon not always disappearing when issue is fixed

### DIFF
--- a/src/ui_parts/element_frame.gd
+++ b/src/ui_parts/element_frame.gd
@@ -173,9 +173,8 @@ func _on_mouse_entered() -> void:
 	# Add warning button.
 	var element_warnings := element.get_config_warnings()
 	if not element_warnings.is_empty():
-		var warning_sign := TextureRect.new()
+		var warning_sign := Control.new()
 		warning_sign.tooltip_text = "\n".join(element_warnings)
-		warning_sign.texture = warning_icon
 		warning_sign.size = Vector2(warning_icon.get_size())
 		warning_sign.position = title_bar.position + Vector2(title_bar.size.x - 23, 4)
 		title_bar.add_child(warning_sign)


### PR DESCRIPTION
Replaces the TextureRect with a control since the warning icon is handled in drawing.