### PR TITLE
Fix percentages in gradients being wiped

### DIFF
--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -27,6 +27,10 @@ formatter: Formatter = GlobalSettings.savedata.editor_formatter) -> String:
 static func _element_to_text(element: Element, formatter: Formatter,
 make_attributes_absolute := false) -> String:
 	if make_attributes_absolute:
+		# A fake SVG ref is needed, for percentages to work.
+		var fake_svg_ref := element.svg
+		element = element.duplicate()
+		element.svg = fake_svg_ref
 		element.make_all_attributes_absolute()
 	
 	var text := ""


### PR DESCRIPTION
I'm glad I noticed this bug before the alpha 5 release.