### PR TITLE
Fix duplication using children references directly

### DIFF
--- a/app_info.json
+++ b/app_info.json
@@ -33,3 +33,4 @@
 	"past_diamond_donors": [],
 	"past_anonymous_diamond_donors": 0
 }
+

--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -268,7 +268,7 @@ func duplicate(include_children := true) -> Element:
 	
 	if include_children:
 		for i in get_child_count():
-			new_element.insert_child(i, get_child(i))
+			new_element.insert_child(i, get_child(i).duplicate())
 	return new_element
 
 # Applies children and attributes to another element. Useful for conversion.

--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -27,7 +27,7 @@ formatter: Formatter = GlobalSettings.savedata.editor_formatter) -> String:
 static func _element_to_text(element: Element, formatter: Formatter,
 make_attributes_absolute := false) -> String:
 	if make_attributes_absolute:
-		# A fake SVG ref is needed, for percentages to work.
+		# A fake SVG ref is needed for percentages to work.
 		var fake_svg_ref := element.svg
 		element = element.duplicate()
 		element.svg = fake_svg_ref


### PR DESCRIPTION
Fixes element duplication directly using children references instead of duplicating them too. I can't believe this flew under the radar, but I'm glad I found it before locking in alpha 5.