### PR TITLE
Add default keybind for snap toggle

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -161,10 +161,6 @@ view_rasterized_svg={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":true,"pressed":false,"keycode":82,"physical_keycode":0,"key_label":0,"unicode":82,"location":0,"echo":false,"script":null)
 ]
 }
-snap_toggle={
-"deadzone": 0.5,
-"events": []
-}
 about_info={
 "deadzone": 0.5,
 "events": []
@@ -310,6 +306,11 @@ view_overlay_reference={
 find={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":70,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+toggle_snap={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":true,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":83,"physical_keycode":0,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -62,15 +62,15 @@ func _unhandled_input(input_event: InputEvent) -> void:
 		toggle_reference_image()
 	elif input_event.is_action_pressed("view_overlay_reference"):
 		toggle_reference_overlay()
-	elif input_event.is_action_pressed("snap_toggle"):
+	elif input_event.is_action_pressed("toggle_snap"):
 		toggle_snap()
 
 
 func update_translations() -> void:
 	%LeftMenu/Settings.tooltip_text = TranslationServer.translate("Settings")
 	%LeftMenu/Visuals.tooltip_text = TranslationServer.translate("Visuals")
-	%LeftMenu/Snapping/SnapButton.tooltip_text = TranslationServer.translate(
-			"Enable snapping")
+	%LeftMenu/Snapping/SnapButton.tooltip_text =\
+			TranslationUtils.get_shortcut_description("toggle_snap")
 	%LeftMenu/Snapping/SnapNumberEdit.tooltip_text = TranslationServer.translate(
 			"Snap size")
 

--- a/src/ui_parts/global_menu.gd
+++ b/src/ui_parts/global_menu.gd
@@ -129,7 +129,7 @@ func _setup_menu_items() -> void:
 	_add_action(view_rid, "zoom_out")
 	_add_action(view_rid, "zoom_reset")
 	# Snap menu.
-	snap_enable_idx = _add_check_item(snap_rid, "snap_toggle")
+	snap_enable_idx = _add_check_item(snap_rid, "toggle_snap")
 	NativeMenu.add_separator(snap_rid)
 	snap_0125_idx = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
 	snap_025_idx = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -34,6 +34,7 @@ const _keybinds_dict = {
 		"view_overlay_reference": true,
 	},
 	"tool": {
+		"toggle_snap": true,
 		"move_relative": false,
 		"move_absolute": false,
 		"line_relative": false,
@@ -97,6 +98,7 @@ static func fn(shortcut: String) -> Callable:
 		"about_website": return OS.shell_open.bind("https://godsvg.com")
 		"check_updates": return HandlerGUI.open_update_checker
 		"open_settings": return HandlerGUI.open_settings
+		"toggle_snap": return Callable()
 		_: return Callable()
 
 static func get_keybinds(category: String) -> PackedStringArray:

--- a/src/utils/TranslationUtils.gd
+++ b/src/utils/TranslationUtils.gd
@@ -24,7 +24,7 @@ static func get_shortcut_description(action_name: String) -> String:
 		"view_show_grid": return TranslationServer.translate("Show grid")
 		"view_show_handles": return TranslationServer.translate("Show handles")
 		"view_rasterized_svg": return TranslationServer.translate("Show rasterized SVG")
-		"snap_toggle": return TranslationServer.translate("Enable snap")
+		"toggle_snap": return TranslationServer.translate("Toggle snapping")
 		"load_reference": return TranslationServer.translate("Load reference image")
 		"view_show_reference": return TranslationServer.translate("Show reference image")
 		"view_overlay_reference": return TranslationServer.translate("Overlay reference image")

--- a/src/utils/XNodeChildrenBuilder.gd
+++ b/src/utils/XNodeChildrenBuilder.gd
@@ -5,14 +5,12 @@ const BasicXNodeFrame = preload("res://src/ui_widgets/basic_xnode_frame.tscn")
 
 static func create(element: Element) -> Array[Control]:
 	var arr: Array[Control] = []
-	var text_xnode_chain_container: VBoxContainer
 	for xnode in element.get_children():
 		if xnode is Element:
 			var element_editor := ElementFrame.instantiate()
 			element_editor.element = xnode
 			arr.append(element_editor)
 		else:
-			var next_child := xnode.parent.get_child(xnode.xid[-1])
 			var xnode_editor := BasicXNodeFrame.instantiate()
 			xnode_editor.xnode = xnode
 			arr.append(xnode_editor)

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -260,10 +260,6 @@ msgid "About…"
 msgstr ""
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr ""
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr ""
 
@@ -919,7 +915,7 @@ msgid "Show rasterized SVG"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
+msgid "Toggle snapping"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -262,10 +262,6 @@ msgid "About…"
 msgstr "Относно приложението…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "Включи захващането"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "Размер на захващането"
 
@@ -933,8 +929,8 @@ msgid "Show rasterized SVG"
 msgstr "Покажи растеризиран SVG"
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
-msgstr "Включи захващането"
+msgid "Toggle snapping"
+msgstr "Превключи захващането"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show reference image"

--- a/translations/de.po
+++ b/translations/de.po
@@ -264,10 +264,6 @@ msgid "About…"
 msgstr "Über…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "Einrasten aktivieren"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "Rastergröße"
 
@@ -936,7 +932,8 @@ msgid "Show rasterized SVG"
 msgstr "Rasterisiertes SVG anzeigen"
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
+#, fuzzy
+msgid "Toggle snapping"
 msgstr "Einrasten aktivieren"
 
 #: src/utils/TranslationUtils.gd
@@ -1014,6 +1011,9 @@ msgstr "Kubischer Bezier to"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "Kurzhand-Kubischer Bezier to"
+
+#~ msgid "Enable snap"
+#~ msgstr "Einrasten aktivieren"
 
 #~ msgid "General"
 #~ msgstr "Allgemein"

--- a/translations/en.po
+++ b/translations/en.po
@@ -260,10 +260,6 @@ msgid "About…"
 msgstr ""
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr ""
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr ""
 
@@ -919,7 +915,7 @@ msgid "Show rasterized SVG"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
+msgid "Toggle snapping"
 msgstr ""
 
 #: src/utils/TranslationUtils.gd

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -264,10 +264,6 @@ msgid "About…"
 msgstr "Over…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "Snappen inschakelen"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "Snap maat"
 
@@ -935,8 +931,9 @@ msgid "Show rasterized SVG"
 msgstr "Gerasterd SVG weergeven"
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
-msgstr "Snap inschakelen"
+#, fuzzy
+msgid "Toggle snapping"
+msgstr "Snappen inschakelen"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show reference image"
@@ -1013,3 +1010,6 @@ msgstr "Kubieke Bézier naar"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "Korte Kubieke Bézier naar"
+
+#~ msgid "Enable snap"
+#~ msgstr "Snap inschakelen"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -265,10 +265,6 @@ msgid "About…"
 msgstr "Про программу…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "Включить привязку"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "Размер привязки"
 
@@ -939,7 +935,8 @@ msgid "Show rasterized SVG"
 msgstr "Показать растеризованый SVG"
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
+#, fuzzy
+msgid "Toggle snapping"
 msgstr "Включить привязку"
 
 #: src/utils/TranslationUtils.gd
@@ -1017,6 +1014,9 @@ msgstr "Кубическая Безье до"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "Сокращенная кубическая Безье до"
+
+#~ msgid "Enable snap"
+#~ msgstr "Включить привязку"
 
 #~ msgid "General"
 #~ msgstr "Общие"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -264,10 +264,6 @@ msgid "About…"
 msgstr "Про додаток…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "Активувати прилипання"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "Розмір прилипання"
 
@@ -942,7 +938,8 @@ msgid "Show rasterized SVG"
 msgstr "Показати растеризуваний SVG"
 
 #: src/utils/TranslationUtils.gd
-msgid "Enable snap"
+#, fuzzy
+msgid "Toggle snapping"
 msgstr "Активувати прилипання"
 
 # Нехай "reference image" буде "еталонне зображення", мені так гугл сказав
@@ -1021,6 +1018,9 @@ msgstr "Кубічна Безьє до"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "Скорочена кубічна Безьє до"
+
+#~ msgid "Enable snap"
+#~ msgstr "Активувати прилипання"
 
 #~ msgid "General"
 #~ msgstr "Загальні"

--- a/translations/zh.po
+++ b/translations/zh.po
@@ -263,10 +263,6 @@ msgid "About…"
 msgstr "关于…"
 
 #: src/ui_parts/display.gd
-msgid "Enable snapping"
-msgstr "启用吸附"
-
-#: src/ui_parts/display.gd
 msgid "Snap size"
 msgstr "吸附大小"
 
@@ -950,7 +946,7 @@ msgstr "显示光栅化 SVG"
 
 #: src/utils/TranslationUtils.gd
 #, fuzzy
-msgid "Enable snap"
+msgid "Toggle snapping"
 msgstr "启用吸附"
 
 #: src/utils/TranslationUtils.gd
@@ -1028,6 +1024,10 @@ msgstr "三点三次贝塞尔曲线"
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
 msgstr "两点三次贝塞尔曲线"
+
+#, fuzzy
+#~ msgid "Enable snap"
+#~ msgstr "启用吸附"
 
 #~ msgid "General"
 #~ msgstr "通用"


### PR DESCRIPTION
Tweaks a few things about the keybind (it wasn't modifiable, name was "Enable snap" even when it was already toggled on, etc.) and adds a default with Alt+S.