### PR TITLE
Remove unnecessary function argument

### DIFF
--- a/src/data_classes/ElementCircle.gd
+++ b/src/data_classes/ElementCircle.gd
@@ -48,7 +48,7 @@ func get_replacement(new_element: String) -> Element:
 	return element
 
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"cx", "cy": return "0"
 		"r": return "0"

--- a/src/data_classes/ElementEllipse.gd
+++ b/src/data_classes/ElementEllipse.gd
@@ -57,7 +57,7 @@ func get_ry() -> float:
 			get_attribute_num("rx") if has_attribute("rx") else 0.0
 
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"cx", "cy": return "0"
 		"rx": return "auto"

--- a/src/data_classes/ElementG.gd
+++ b/src/data_classes/ElementG.gd
@@ -3,7 +3,7 @@ class_name ElementG extends Element
 const name = "g"
 const possible_conversions = []
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"opacity": return "1"
 		_: return ""

--- a/src/data_classes/ElementLine.gd
+++ b/src/data_classes/ElementLine.gd
@@ -36,7 +36,7 @@ func get_replacement(new_element: String) -> Element:
 	return element
 
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"x1", "y1", "x2", "y2": return "0"
 		"opacity": return "1"

--- a/src/data_classes/ElementLinearGradient.gd
+++ b/src/data_classes/ElementLinearGradient.gd
@@ -3,7 +3,7 @@ class_name ElementLinearGradient extends Element
 const name = "linearGradient"
 const possible_conversions = []
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"x1", "y1", "y2": return "0%"
 		"x2": return "100%"

--- a/src/data_classes/ElementPath.gd
+++ b/src/data_classes/ElementPath.gd
@@ -11,7 +11,7 @@ func user_setup(pos := Vector2.ZERO) -> void:
 		attrib.set_command_property(0, "x", pos.x)
 		attrib.set_command_property(0, "y", pos.y)
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	if attribute_name == "opacity":
 		return "1"
 	return ""

--- a/src/data_classes/ElementPolygon.gd
+++ b/src/data_classes/ElementPolygon.gd
@@ -8,7 +8,7 @@ func user_setup(pos := Vector2.ZERO) -> void:
 	if pos != Vector2.ZERO:
 		set_attribute("points", "0 0")
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	if attribute_name == "opacity":
 		return "1"
 	return ""

--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -10,7 +10,7 @@ func user_setup(pos := Vector2.ZERO) -> void:
 	set_attribute("fill", "none")
 	set_attribute("stroke", "black")
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	if attribute_name == "opacity":
 		return "1"
 	return ""

--- a/src/data_classes/ElementRadialGradient.gd
+++ b/src/data_classes/ElementRadialGradient.gd
@@ -3,7 +3,7 @@ class_name ElementRadialGradient extends Element
 const name = "radialGradient"
 const possible_conversions = []
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"cx", "cy", "r": return "50%"
 		"gradientUnits": return "objectBoundingBox"

--- a/src/data_classes/ElementRect.gd
+++ b/src/data_classes/ElementRect.gd
@@ -112,7 +112,7 @@ func get_ry() -> float:
 		return 0.0
 
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"x", "y", "width", "height": return "0"
 		"rx": return "auto"

--- a/src/data_classes/ElementRoot.gd
+++ b/src/data_classes/ElementRoot.gd
@@ -34,7 +34,7 @@ func get_element_by_id(id: String) -> Element:
 	return null
 
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"fill": return "black"
 		"fill-opacity": return "1"

--- a/src/data_classes/ElementStop.gd
+++ b/src/data_classes/ElementStop.gd
@@ -4,7 +4,7 @@ class_name ElementStop extends Element
 const name = "stop"
 const possible_conversions = []
 
-func get_own_default(attribute_name: String) -> String:
+func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"offset": return "0"
 		"stop-color": return "black"


### PR DESCRIPTION
Fixes a mistake from earlier, and simplifies `get_attribute()`.