### PR TITLE
Add transparent keyword

### DIFF
--- a/src/data_classes/AttributeColor.gd
+++ b/src/data_classes/AttributeColor.gd
@@ -55,7 +55,7 @@ func format(text: String) -> String:
 	return text
 
 
-const special_colors = ["none", "currentColor"]
+const special_colors = ["transparent", "none", "currentColor"]
 
 const named_colors = {  # Dictionary{String: String}
 	"aliceblue": "#f0f8ff",

--- a/src/data_classes/AttributeNumeric.gd
+++ b/src/data_classes/AttributeNumeric.gd
@@ -38,5 +38,5 @@ static func text_to_num(text: String) -> float:
 		return text.to_float() / 100
 	return text.to_float()
 
-func text_check_percentage(text: String) -> bool:
+static func text_check_percentage(text: String) -> bool:
 	return text.strip_edges().ends_with("%")

--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -65,9 +65,9 @@ static func text_to_color(color: String, backup := Color.BLACK,
 allow_alpha := false) -> Color:
 	color = color.strip_edges()
 	if is_valid_named(color):
-		if color == "none":
+		if color in ["none", "transparent"]:
 			return Color(0, 0, 0, 0)
-		elif color in AttributeColor.special_colors:
+		elif color == "currentColor":
 			return backup
 		else:
 			return Color(AttributeColor.named_colors[color])

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -12,6 +12,7 @@ func _ready() -> void:
 	update_translation()
 	SVG.elements_layout_changed.connect(full_rebuild)
 	SVG.changed_unknown.connect(full_rebuild)
+	add_button.pressed.connect(_on_add_button_pressed)
 	full_rebuild()
 
 

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -76,5 +76,3 @@ theme_override_constants/separation = 5
 visible = false
 layout_mode = 2
 script = ExtResource("5_otlmf")
-
-[connection signal="pressed" from="AddButton" to="." method="_on_add_button_pressed"]

--- a/src/ui_widgets/basic_xnode_frame.gd
+++ b/src/ui_widgets/basic_xnode_frame.gd
@@ -27,8 +27,9 @@ func _ready() -> void:
 	mouse_exited.connect(_on_mouse_exited)
 	determine_selection_highlight()
 	title_bar.queue_redraw()
-	text_edit.text = xnode.get_text()
+	text_edit.text_set.connect(_on_text_modified)
 	text_edit.text_changed.connect(_on_text_modified)
+	text_edit.text = xnode.get_text()
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(surface)
@@ -221,6 +222,17 @@ func _on_title_button_gui_input(event: InputEvent, title_button: Button) -> void
 	title_button.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)
 
 func _on_text_modified() -> void:
+	# TODO figure out a way to make this work.
+	#if text_edit.get_line_count() >= 3 or (text_edit.get_line_count() == 2 and\
+	#text_edit.get_line_wrap_count(0) + text_edit.get_line_wrap_count(1) >= 1) or\
+	#(text_edit.get_line_count() == 1 and text_edit.get_line_wrap_count(0) >= 2):
+		#size.y = 36 + text_edit.get_line_height() * 2
+	#elif text_edit.get_line_count() >= 2 or (text_edit.get_line_count() == 1 and\
+	#text_edit.get_line_wrap_count(0) >= 1):
+		#size.y = 36 + text_edit.get_line_height()
+	#else:
+		#size.y = 36
+	
 	if xnode.check_text_validity(text_edit.text):
 		xnode.set_text(text_edit.text)
 		text_edit.remove_theme_color_override("font_color")

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -5,8 +5,8 @@ var element: Element
 const attribute_name = "id"  # Never propagates.
 
 func set_value(new_value: String, save := false) -> void:
+	sync(new_value)
 	element.set_attribute(attribute_name, new_value)
-	sync_to_attribute()
 	if save:
 		SVG.queue_save()
 


### PR DESCRIPTION
Adds support for the "transparent" keyword. The renderer doesn't support it, but at least it won't break while going through GodSVG.