### PR TITLE
Fix issues with polygon and polyline

### DIFF
--- a/src/data_classes/DB.gd
+++ b/src/data_classes/DB.gd
@@ -51,7 +51,7 @@ const recognized_attributes = {  # Dictionary{String: Array[String]}
 	"line": ["transform", "opacity", "stroke", "stroke-opacity", "stroke-width",
 			"stroke-linecap", "x1", "y1", "x2", "y2"],
 	"polygon": ["transform", "opacity", "fill", "fill-opacity", "stroke", "stroke-opacity",
-			"stroke-width", "stroke-linecap", "stroke-linejoin", "points"],
+			"stroke-width", "stroke-linejoin", "points"],
 	"polyline": ["transform", "opacity", "fill", "fill-opacity", "stroke",
 			"stroke-opacity", "stroke-width", "stroke-linecap", "stroke-linejoin", "points"],
 	"stop": ["offset", "stop-color", "stop-opacity"],

--- a/src/data_classes/ElementPolygon.gd
+++ b/src/data_classes/ElementPolygon.gd
@@ -6,7 +6,8 @@ const possible_conversions = ["path", "rect"]
 
 func user_setup(pos := Vector2.ZERO) -> void:
 	if pos != Vector2.ZERO:
-		set_attribute("points", "0 0")
+		var attrib: AttributeList = get_attribute("points")
+		attrib.set_points(PackedVector2Array([pos]))
 
 func _get_own_default(attribute_name: String) -> String:
 	if attribute_name == "opacity":

--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -6,7 +6,8 @@ const possible_conversions = ["path", "line"]
 
 func user_setup(pos := Vector2.ZERO) -> void:
 	if pos != Vector2.ZERO:
-		set_attribute("points", "0 0")
+		var attrib: AttributeList = get_attribute("points")
+		attrib.set_points(PackedVector2Array([pos]))
 	set_attribute("fill", "none")
 	set_attribute("stroke", "black")
 


### PR DESCRIPTION
Fixes issue where polygons present a stroke-linecap attribute that never has an effect. Fixes issue where polygons and polylines created from the viewport are placed at (0, 0).