### PR TITLE
Optimize SVG cutouts

### DIFF
--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -267,6 +267,7 @@ func apply_to(element: Element, dropped_attributes: PackedStringArray) -> void:
 			element.set_attribute(attribute_name, get_attribute_value(attribute_name))
 
 # Converts all percentage numeric attributes to absolute.
+# TODO this is no longer used, but might become useful again in the future.
 func make_all_attributes_absolute() -> void:
 	var attributes_to_convert := _attributes.keys()
 	if DB.recognized_attributes.has(self.name):
@@ -276,6 +277,7 @@ func make_all_attributes_absolute() -> void:
 			make_attribute_absolute(attribute_name)
 
 # Converts a percentage numeric attribute to absolute.
+# TODO this is no longer used, but might become useful again in the future.
 func make_attribute_absolute(attribute_name: String) -> void:
 	if is_attribute_percentage(attribute_name):
 		var new_attrib := new_attribute(attribute_name)
@@ -329,4 +331,9 @@ func new_default_attribute(name: String) -> Attribute:
 	return _create_attribute(name, get_default(name))
 
 func _create_attribute(name: String, value := "") -> Attribute:
-	return DB.attribute(name, root.formatter if root != null else Formatter.new(), value)
+	if root != null:
+		return DB.attribute(name, root.formatter, value)
+	elif root == self:
+		return DB.attribute(name, self.formatter, value)
+	else:
+		return DB.attribute(name, Formatter.new(), value)

--- a/src/utils/Utils.gd
+++ b/src/utils/Utils.gd
@@ -114,6 +114,6 @@ static func generate_gradient(element: Element) -> Gradient:
 				Color(ColorParser.text_to_color(child.get_attribute_value("stop-color")),
 				child.get_attribute_num("stop-opacity")))
 	# Remove the default two gradient points.
-	gradient.remove_point(0)
-	gradient.remove_point(0)
+	while gradient.get_point_count() > 1:
+		gradient.remove_point(0)
 	return gradient


### PR DESCRIPTION
Partially addresses #915. Instead of generating a new element and making its attributes absolute, we take the existing element's attributes and replace the percentage ones with absolute ones. This makes a lot more sense and avoids unnecessary parsing, but I hadn't thought of it.

Unrelated changes: Small optimization to _create_attribute() in certain cases, fix to an error that could appear with gradients (but didn't have any impact)