### PR TITLE
Bugfix spree

### DIFF
--- a/src/data_classes/DB.gd
+++ b/src/data_classes/DB.gd
@@ -144,6 +144,12 @@ const attribute_number_range = {
 const attribute_color_url_allowed = ["fill", "stroke"]
 
 
+static func get_recognized_attributes(element_name: String) -> Array:
+	if recognized_attributes.has(element_name):
+		return recognized_attributes[element_name]
+	else:
+		return []
+
 static func is_attribute_recognized(element_name: String, attribute_name: String) -> bool:
 	return recognized_attributes.has(element_name) and\
 			attribute_name in recognized_attributes[element_name]

--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -60,6 +60,7 @@ func get_all_element_descendants() -> Array[Element]:
 			elements += child.get_all_element_descendants()
 	return elements
 
+# Gets the basic XML nodes too.
 func get_all_xnode_descendants() -> Array[XNode]:
 	var xnodes: Array[XNode] = []
 	for child in get_children():
@@ -85,9 +86,17 @@ func replace_child(idx: int, new_xnode: XNode) -> void:
 func insert_child(idx: int, new_xnode: XNode) -> void:
 	if idx < 0:
 		idx += get_child_count() + 1
+	
 	new_xnode.parent = self
 	new_xnode.root = root
 	new_xnode.svg = self if self is ElementSVG else svg
+	
+	if new_xnode is Element:
+		for xnode_descendant in new_xnode.get_all_xnode_descendants():
+			xnode_descendant.svg = xnode_descendant if xnode_descendant is ElementSVG else\
+					xnode_descendant.parent.svg
+			xnode_descendant.root = root
+	
 	var new_xid := xid.duplicate()
 	new_xid.append(idx)
 	new_xnode.xid = new_xid
@@ -265,16 +274,6 @@ func apply_to(element: Element, dropped_attributes: PackedStringArray) -> void:
 	for attribute_name in _attributes:
 		if not attribute_name in dropped_attributes:
 			element.set_attribute(attribute_name, get_attribute_value(attribute_name))
-
-# Converts all percentage numeric attributes to absolute.
-# TODO this is no longer used, but might become useful again in the future.
-func make_all_attributes_absolute() -> void:
-	var attributes_to_convert := _attributes.keys()
-	if DB.recognized_attributes.has(self.name):
-		attributes_to_convert += DB.recognized_attributes[self.name]
-	for attribute_name in attributes_to_convert:
-		if DB.get_attribute_type(attribute_name) == DB.AttributeType.NUMERIC:
-			make_attribute_absolute(attribute_name)
 
 # Converts a percentage numeric attribute to absolute.
 # TODO this is no longer used, but might become useful again in the future.

--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -46,7 +46,7 @@ make_attributes_absolute := false) -> String:
 	var attribute_array := element.get_all_attributes()
 	if make_attributes_absolute:
 		# Add known default value attributes if they are percentage-based.
-		for attrib_name in DB.recognized_attributes[element.name]:
+		for attrib_name in DB.get_recognized_attributes(element.name):
 			if DB.get_attribute_type(attrib_name) != DB.AttributeType.NUMERIC:
 				continue
 			

--- a/src/ui_widgets/basic_xnode_frame.gd
+++ b/src/ui_widgets/basic_xnode_frame.gd
@@ -49,7 +49,6 @@ func _get_drag_data(_at_position: Vector2) -> Variant:
 		elements_container.add_child(preview)
 	elements_container.modulate = Color(1, 1, 1, 0.85)
 	set_drag_preview(elements_container)
-	modulate = Color(1, 1, 1, 0.55)
 	return data
 
 func _notification(what: int) -> void:

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -108,7 +108,7 @@ func _draw() -> void:
 				points.append(pt + Vector2(h_offset, 0))
 				colors.append(Color.WHITE)
 				uvs.append(pt / Vector2(BUTTON_WIDTH - 1, size.y - 1))
-			draw_polygon(points, colors, uvs, gradient_texture)
+			RenderingServer.canvas_item_add_polygon(ci, points, colors, uvs, gradient_texture)
 			drawn = true
 	
 	if not drawn:

--- a/src/ui_widgets/element_content_basic_shape.gd
+++ b/src/ui_widgets/element_content_basic_shape.gd
@@ -5,7 +5,7 @@ extends VBoxContainer
 var element: Element
 
 func _ready() -> void:
-	for attribute in DB.recognized_attributes[element.name]:
+	for attribute in DB.get_recognized_attributes(element.name):
 		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_g.gd
+++ b/src/ui_widgets/element_content_g.gd
@@ -5,7 +5,7 @@ extends VBoxContainer
 var element: Element
 
 func _ready() -> void:
-	for attribute in DB.recognized_attributes["g"]:
+	for attribute in DB.get_recognized_attributes("g"):
 		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_linear_gradient.gd
+++ b/src/ui_widgets/element_content_linear_gradient.gd
@@ -5,7 +5,7 @@ extends VBoxContainer
 var element: Element
 
 func _ready() -> void:
-	for attribute in DB.recognized_attributes["linearGradient"]:
+	for attribute in DB.get_recognized_attributes("linearGradient"):
 		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_content_path.gd
+++ b/src/ui_widgets/element_content_path.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	path_field.setup()
 	path_field.focused.connect(Indications.normal_select.bind(element.xid))
 	
-	for attribute in DB.recognized_attributes["path"]:
+	for attribute in DB.get_recognized_attributes("path"):
 		if attribute == "d":
 			continue
 		var input_field := AttributeFieldBuilder.create(attribute, element)

--- a/src/ui_widgets/element_content_polyshape.gd
+++ b/src/ui_widgets/element_content_polyshape.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	points_field.setup()
 	points_field.focused.connect(Indications.normal_select.bind(element.xid))
 	
-	for attribute in DB.recognized_attributes[element.name]:
+	for attribute in DB.get_recognized_attributes(element.name):
 		if attribute == "points":
 			continue
 		var input_field := AttributeFieldBuilder.create(attribute, element)

--- a/src/ui_widgets/element_content_radial_gradient.gd
+++ b/src/ui_widgets/element_content_radial_gradient.gd
@@ -5,7 +5,7 @@ extends VBoxContainer
 var element: Element
 
 func _ready() -> void:
-	for attribute in DB.recognized_attributes["radialGradient"]:
+	for attribute in DB.get_recognized_attributes("radialGradient"):
 		var input_field := AttributeFieldBuilder.create(attribute, element)
 		input_field.focus_entered.connect(Indications.normal_select.bind(element.xid))
 		attribute_container.add_child(input_field)

--- a/src/ui_widgets/element_frame.gd
+++ b/src/ui_widgets/element_frame.gd
@@ -96,9 +96,22 @@ func _get_drag_data(_at_position: Vector2) -> Variant:
 		preview.custom_minimum_size.x = size.x
 		preview.z_index = 2
 		elements_container.add_child(preview)
+	
+	#var vp := SubViewport.new()
+	#vp.transparent_bg = true
+	#vp.render_target_update_mode = SubViewport.UPDATE_ONCE
+	#vp.size = Vector2.ZERO
+	#vp.add_child(elements_container)
+	#add_child(vp)
+	#vp.transparent_bg = false
+	#var texture_rect := TextureRect.new()
+	#await RenderingServer.frame_post_draw
+	#texture_rect.texture = ImageTexture.create_from_image(vp.get_texture().get_image())
+	#texture_rect.modulate = Color(1, 1, 1, 0.85)
+	#vp.queue_free()
+	#set_drag_preview(texture_rect)
 	elements_container.modulate = Color(1, 1, 1, 0.85)
 	set_drag_preview(elements_container)
-	modulate = Color(1, 1, 1, 0.55)
 	return data
 
 func _notification(what: int) -> void:

--- a/src/ui_widgets/element_frame.tscn
+++ b/src/ui_widgets/element_frame.tscn
@@ -11,7 +11,7 @@ theme_override_constants/separation = 0
 script = ExtResource("1_5mc4m")
 
 [node name="TitleBar" type="Panel" parent="."]
-custom_minimum_size = Vector2(0, 26)
+custom_minimum_size = Vector2(180, 26)
 layout_mode = 2
 mouse_filter = 2
 

--- a/visual/icons/Arrow.svg
+++ b/visual/icons/Arrow.svg
@@ -1,1 +1,1 @@
-<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg"><path d="M1.5 2h9l-4.5 8z" opacity=".8" fill="#def" stroke="#def" stroke-width="2" stroke-linejoin="round"/></svg>
+<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg"><path d="M2 3h8l-4 7z" opacity=".8" fill="#def" stroke="#def" stroke-width="2" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
Addresses point 2 of #937 

Fixes a recently introduced bug that made unrecognized elements crash.

Fixes issue in the Element.insert_child() method, used in various places, where only the root element would get the reference for its root and svg properties, leading to crashes when they are needed.

Sets minimum size for element frames.