### PR TITLE
Fix GoodFileDialog's file field keeping its tint when editing is canceled

### DIFF
--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -384,6 +384,9 @@ func _on_file_field_text_changed(new_text: String) -> void:
 	file_field.add_theme_color_override("font_color",
 			GlobalSettings.get_validity_color(is_invalid_filename))
 
+func _on_file_field_text_change_canceled() -> void:
+	file_field.remove_theme_color_override("font_color")
+
 
 func _on_replace_button_pressed() -> void:
 	file_selected.emit(current_dir.path_join(current_file))

--- a/src/ui_parts/good_file_dialog.tscn
+++ b/src/ui_parts/good_file_dialog.tscn
@@ -195,6 +195,7 @@ mouse_default_cursor_shape = 2
 [connection signal="item_activated" from="VBoxContainer/MainContainer/FilePicker/VisualPicker/FileList" to="." method="_on_file_list_item_activated"]
 [connection signal="item_clicked" from="VBoxContainer/MainContainer/FilePicker/VisualPicker/FileList" to="." method="_on_file_list_item_clicked"]
 [connection signal="item_selected" from="VBoxContainer/MainContainer/FilePicker/VisualPicker/FileList" to="." method="_on_file_list_item_selected"]
+[connection signal="text_change_canceled" from="VBoxContainer/MainContainer/FilePicker/FileContainer/FileField" to="." method="_on_file_field_text_change_canceled"]
 [connection signal="text_changed" from="VBoxContainer/MainContainer/FilePicker/FileContainer/FileField" to="." method="_on_file_field_text_changed"]
 [connection signal="text_submitted" from="VBoxContainer/MainContainer/FilePicker/FileContainer/FileField" to="." method="_on_file_field_text_submitted"]
 [connection signal="text_changed" from="CreateFolderCenterContainer/CreateFolderDialog/MainContainer/CreateFolderLineEdit" to="." method="_on_create_folder_line_edit_text_changed"]


### PR DESCRIPTION
Fixes a small unreported issue.