### PR TITLE
Fix TextLine performance

### DIFF
--- a/src/ui_widgets/LineEditButton.gd
+++ b/src/ui_widgets/LineEditButton.gd
@@ -163,12 +163,13 @@ func _draw() -> void:
 		draw_line(Vector2(size.x - BUTTON_WIDTH, 0),
 				Vector2(size.x - BUTTON_WIDTH, size.y), sb.border_color, 2)
 		# The default overrun behavior couldn't be changed for the simplest draw methods.
-		var text_line_object := TextLine.new()
-		text_line_object.text_overrun_behavior = TextServer.OVERRUN_TRIM_CHAR
-		text_line_object.width = size.x - BUTTON_WIDTH - horizontal_margin_width
-		text_line_object.add_string(placeholder_text if text.is_empty() else text,
-				_get_font(), get_theme_font_size("font_size", "LineEdit"))
-		text_line_object.draw(ci, Vector2(5, 2), get_theme_color("font_placeholder_color",
+		var text_obj := TextLine.new()
+		text_obj.ellipsis_char = "a"  # TODO: #98841 will address the need for this.
+		text_obj.text_overrun_behavior = TextServer.OVERRUN_TRIM_CHAR
+		text_obj.width = size.x - BUTTON_WIDTH - horizontal_margin_width
+		text_obj.add_string(placeholder_text if text.is_empty() else text, _get_font(),
+				get_theme_font_size("font_size", "LineEdit"))
+		text_obj.draw(ci, Vector2(5, 2), get_theme_color("font_placeholder_color",
 				"LineEdit") if text.is_empty() else _get_font_color())
 	
 	if is_instance_valid(icon):

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -159,10 +159,10 @@ func _draw() -> void:
 		color = ThemeUtils.common_subtle_text_color
 	
 	var non_panel_width := size.x - panel_width
-	var text_line := TextLine.new()
-	text_line.add_string(text, ThemeUtils.regular_font, 13)
-	text_line.width = non_panel_width - 16
-	text_line.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
-	text_line.draw(ci, Vector2(4, 5), color)
+	var text_obj := TextLine.new()
+	text_obj.add_string(text, ThemeUtils.regular_font, 13)
+	text_obj.width = non_panel_width - 16
+	text_obj.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	text_obj.draw(ci, Vector2(4, 5), color)
 	get_theme_stylebox("panel", "DarkPanel").draw(ci, Rect2(non_panel_width - 2, 2,
 			panel_width, size.y - 4))

--- a/visual/icons/element/xmlnodeText.svg
+++ b/visual/icons/element/xmlnodeText.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke-opacity=".6" stroke="#def" d="M5 8v-4h-1a1 1 0 000 4zM11 2v6h1a1.8 1.8 0 10-.5-3.5M9 10h-.5a1 1 0 000 4h.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke-opacity=".6" stroke="#def" d="M5 8v-4h-1a1 1 0 000 4zM11 2v6h1a1.85 1.85 0 10-.5-3.575M9 10h-.5a1 1 0 000 4h.5" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
Small workaround for the issue that https://github.com/godotengine/godot/pull/98841 fixes. I expect it to be merged for 4.4, so I've not gone on to do any deeper optimizations - I expect this would help LineEdit too.

Saves more than 5ms on rebuilding the fox SVG. There are scenarios where it can save *much* more time.