### PR TITLE
Fix path popup command disabling

### DIFF
--- a/src/ui_widgets/path_command_button.gd
+++ b/src/ui_widgets/path_command_button.gd
@@ -1,6 +1,8 @@
 # A button for a path command picker.
 extends Button
 
+var warned := false
+
 signal pressed_custom(cmd_char: String)
 
 @export var command_char := ""
@@ -17,10 +19,18 @@ func set_invalid(new_state := true) -> void:
 	disabled = new_state
 	mouse_default_cursor_shape = CURSOR_ARROW if new_state else CURSOR_POINTING_HAND
 
+func set_warning(new_state := true) -> void:
+	warned = true
+
 # Couldn't think of any way to get RichTextLabel to autoresize its font on one line.
 func _draw() -> void:
 	var text_obj := TextLine.new()
-	var text_color := Color(0.5, 0.5, 0.5) if disabled else Color(1, 1, 1)
+	var text_color := Color(1, 1, 1)
+	if disabled:
+		text_color = Color(0.5, 0.5, 0.5)
+	elif warned:
+		text_color = GlobalSettings.savedata.basic_color_warning
+	
 	var left_margin := get_theme_stylebox("normal").content_margin_left
 	var right_margin := get_theme_stylebox("normal").content_margin_right
 	var max_size := size.x - left_margin - right_margin

--- a/src/ui_widgets/path_popup.gd
+++ b/src/ui_widgets/path_popup.gd
@@ -25,10 +25,11 @@ func _on_relative_toggle_toggled(toggled_on: bool) -> void:
 				else command_button.command_char.to_upper()
 		command_button.queue_redraw()
 
-func disable_invalid(cmd_chars: Array) -> void:
-	for cmd_char in cmd_chars:
-		var cmd_char_upper: String = cmd_char.to_upper()
-		command_container.get_node(cmd_char_upper).set_invalid()
+func mark_invalid(warned: PackedStringArray, disabled: PackedStringArray) -> void:
+	for cmd_char in warned:
+		command_container.get_node(cmd_char.to_upper()).set_warning()
+	for cmd_char in disabled:
+		command_container.get_node(cmd_char.to_upper()).set_invalid()
 
 func force_relativity(relative: bool) -> void:
 	relative_toggle.hide()


### PR DESCRIPTION
Fixes #957 and other similar bugs. Now commands that are syntactically valid will be just warnings, while the rest will be really disabled.