### PR TITLE
Fix some fields not syncing after formatting

### DIFF
--- a/src/data_classes/AttributeList.gd
+++ b/src/data_classes/AttributeList.gd
@@ -6,12 +6,16 @@ var _list: PackedFloat32Array
 func _sync() -> void:
 	_list = text_to_list(get_value())
 
+func format(text: String) -> String:
+	return list_to_text(text_to_list(text))
+
+
 func set_list(new_list: PackedFloat32Array) -> void:
 	_list = new_list
 	sync_after_list_change()
 
 func sync_after_list_change() -> void:
-	super.set_value(list_to_text(_list))
+	set_value(list_to_text(_list))
 
 func get_list() -> PackedFloat32Array:
 	return _list

--- a/src/ui_widgets/path_command_button.gd
+++ b/src/ui_widgets/path_command_button.gd
@@ -20,7 +20,7 @@ func set_invalid(new_state := true) -> void:
 	mouse_default_cursor_shape = CURSOR_ARROW if new_state else CURSOR_POINTING_HAND
 
 func set_warning(new_state := true) -> void:
-	warned = true
+	warned = new_state
 
 # Couldn't think of any way to get RichTextLabel to autoresize its font on one line.
 func _draw() -> void:

--- a/src/ui_widgets/pathdata_field.gd
+++ b/src/ui_widgets/pathdata_field.gd
@@ -51,8 +51,8 @@ var add_move_button: Control
 
 
 func set_value(new_value: String, save := false) -> void:
-	sync(new_value)
 	element.set_attribute(attribute_name, new_value)
+	sync(element.get_attribute(attribute_name).get_value())
 	if save:
 		SVG.queue_save()
 
@@ -68,6 +68,7 @@ func setup() -> void:
 	line_edit.text_submitted.connect(set_value.bind(true))
 	line_edit.text_changed.connect(setup_font)
 	line_edit.text_change_canceled.connect(func(): setup_font(line_edit.text))
+	line_edit.text_change_canceled.connect(sync_to_attribute)
 	line_edit.focus_entered.connect(_on_line_edit_focus_entered)
 	commands_container.draw.connect(commands_draw)
 	commands_container.gui_input.connect(_on_commands_gui_input)

--- a/src/ui_widgets/points_field.gd
+++ b/src/ui_widgets/points_field.gd
@@ -43,8 +43,8 @@ var add_move_button: Control
 
 
 func set_value(new_value: String, save := false) -> void:
-	sync(new_value)
 	element.set_attribute(attribute_name, new_value)
+	sync(element.get_attribute(attribute_name).get_value())
 	if save:
 		SVG.queue_save()
 

--- a/src/ui_widgets/transform_field.gd
+++ b/src/ui_widgets/transform_field.gd
@@ -7,8 +7,8 @@ var attribute_name: String  # Never propagates.
 const TransformPopup = preload("res://src/ui_widgets/transform_popup.tscn")
 
 func set_value(new_value: String, save := false) -> void:
-	sync(new_value)
 	element.set_attribute(attribute_name, new_value)
+	sync(element.get_attribute(attribute_name).get_value())
 	if save:
 		SVG.queue_save()
 


### PR DESCRIPTION
For example, path field used to have an issue where if you type "zzz" while the only path command is "z", it would let you do that and go out of sync.

Also fixes list attributes not having formatting.