### PR TITLE
Dim formatter settings that aren't relevant and fix some bugs

### DIFF
--- a/src/data_classes/AttributeColor.gd
+++ b/src/data_classes/AttributeColor.gd
@@ -10,10 +10,10 @@ func set_value(new_value: String) -> void:
 func format(text: String) -> String:
 	text = text.strip_edges()
 	
-	if ColorParser.is_valid_url(text):
-		return "url(" + text.substr(4, text.length() - 5).strip_edges() + ")"
-	elif text in special_colors:
+	if text.is_empty() or text in special_colors:
 		return text
+	elif ColorParser.is_valid_url(text):
+		return "url(" + text.substr(4, text.length() - 5).strip_edges() + ")"
 	
 	var named_colors_usage := formatter.color_use_named_colors
 	# First make sure we have a 6-digit hex.

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -429,7 +429,8 @@ func rebuild_formatters() -> void:
 	# TODO Do I need to do this...
 	var formatter_names := PackedStringArray()
 	for formatter_name in formatters.keys():
-		formatter_names.append(formatter_name)
+		if not formatter_name.is_empty():
+			formatter_names.append(formatter_name)
 	
 	for context in [["editor_formatter", TranslationServer.translate("Editor formatter")],
 	["export_formatter", TranslationServer.translate("Export formatter")]]:

--- a/src/ui_widgets/formatter_config.gd
+++ b/src/ui_widgets/formatter_config.gd
@@ -105,10 +105,11 @@ func construct() -> void:
 	current_setup_config = "xml_pretty_formatting"
 	add_checkbox(TranslationServer.translate("Use pretty formatting"))
 	current_setup_config = "xml_indentation_use_spaces"
-	add_checkbox(TranslationServer.translate("Use spaces instead of tabs"))
+	add_checkbox(TranslationServer.translate("Use spaces instead of tabs"),
+			not current_formatter.xml_pretty_formatting)
 	current_setup_config = "xml_indentation_spaces"
 	add_number_dropdown(TranslationServer.translate("Number of indentation spaces"),
-			[2, 3, 4, 6, 8], true, false, 0, 16)
+			[2, 3, 4, 6, 8], true, false, 0, 16, not current_formatter.xml_pretty_formatting)
 	
 	add_section(TranslationServer.translate("Numbers"))
 	current_setup_config = "number_remove_leading_zero"
@@ -122,7 +123,8 @@ func construct() -> void:
 	current_setup_config = "color_primary_syntax"
 	add_dropdown(TranslationServer.translate("Primary syntax"))
 	current_setup_config = "color_capital_hex"
-	add_checkbox(TranslationServer.translate("Capitalize hexadecimal letters"))
+	add_checkbox(TranslationServer.translate("Capitalize hexadecimal letters"),
+			current_formatter.color_primary_syntax == Formatter.PrimaryColorSyntax.RGB)
 	
 	add_section(TranslationServer.translate("Pathdata"))
 	current_setup_config = "pathdata_compress_numbers"
@@ -154,8 +156,9 @@ func add_section(section_name: String) -> void:
 	vbox.add_child(spacer)
 	configs_container.add_child(vbox)
 
-func add_checkbox(text: String) -> void:
+func add_checkbox(text: String, dim_text := false) -> void:
 	var frame := SettingFrame.instantiate()
+	frame.dim_text = dim_text
 	frame.text = text
 	setup_frame(frame)
 	frame.setup_checkbox()
@@ -169,8 +172,9 @@ func add_dropdown(text: String) -> void:
 	add_frame(frame)
 
 func add_number_dropdown(text: String, values: PackedFloat64Array, is_integer := false,
-restricted := true, min_value := -INF, max_value := INF) -> void:
+restricted := true, min_value := -INF, max_value := INF, dim_text := false) -> void:
 	var frame := SettingFrame.instantiate()
+	frame.dim_text = dim_text
 	frame.text = text
 	setup_frame(frame)
 	frame.setup_number_dropdown(values, is_integer, restricted, min_value, max_value)

--- a/src/ui_widgets/profile_frame.gd
+++ b/src/ui_widgets/profile_frame.gd
@@ -40,4 +40,4 @@ func _draw() -> void:
 	if Rect2(Vector2.ZERO, size).has_point(get_local_mouse_position()):
 		get_theme_stylebox("hover", "FlatButton").draw(ci, Rect2(Vector2.ZERO, size))
 	ThemeUtils.regular_font.draw_string(ci, Vector2(4, 18), text,
-			HORIZONTAL_ALIGNMENT_LEFT, -1, 13, Color.WHITE)
+			HORIZONTAL_ALIGNMENT_LEFT, -1, 13, Color(1, 1, 1, 0.9))

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -20,6 +20,8 @@ var disabled := false:
 			disabled = new_value
 			update_widgets()
 
+var dim_text := false  # For settings that wouldn't have an effect.
+
 var widget: Control
 var panel_width := 0
 
@@ -154,9 +156,11 @@ func _draw() -> void:
 	if is_hovered:
 		get_theme_stylebox("hover", "FlatButton").draw(ci, Rect2(Vector2.ZERO, size))
 	
-	var color := Color.WHITE
+	var color := Color(1, 1, 1, 0.9)
 	if disabled:
 		color = ThemeUtils.common_subtle_text_color
+	elif dim_text:
+		color = Color(1, 1, 1, 0.5)
 	
 	var non_panel_width := size.x - panel_width
 	var text_obj := TextLine.new()


### PR DESCRIPTION
Fixes issue when reformatting colors. Fixes issue where unnamed formatters show up when choosing a formatter for the editor or export. Dims out a few formatter options when they are actually unavailable.