### PR TITLE
Make resource loading safer

### DIFF
--- a/src/autoload/GlobalSettings.gd
+++ b/src/autoload/GlobalSettings.gd
@@ -215,6 +215,9 @@ func load_config() -> void:
 		return
 	
 	savedata = ResourceLoader.load(savedata_path)
+	if savedata == null or not savedata is SaveData:
+		reset_settings()
+		return
 	
 	for action in ShortcutUtils.get_all_shortcuts():
 		if ShortcutUtils.is_shortcut_modifiable(action):

--- a/src/autoload/Indications.gd
+++ b/src/autoload/Indications.gd
@@ -65,7 +65,6 @@ func set_viewport_size(new_value: Vector2i) -> void:
 
 
 func _ready() -> void:
-	selection_changed.connect(print.bind("selection changed"))
 	SVG.xnodes_added.connect(_on_xnodes_added)
 	SVG.xnodes_deleted.connect(_on_xnodes_deleted)
 	SVG.xnodes_moved_in_parent.connect(_on_xnodes_moved_in_parent)

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -69,7 +69,7 @@ func update_close_button() -> void:
 	close_button.text = TranslationServer.translate("Close")
 
 func _on_tab_toggled(toggled_on: bool, tab_name: String) -> void:
-	if toggled_on:
+	if toggled_on and focused_tab != tab_name:
 		focused_tab = tab_name
 		setup_content()
 

--- a/src/ui_widgets/palette_config.gd
+++ b/src/ui_widgets/palette_config.gd
@@ -184,6 +184,8 @@ func paste_palette() -> void:
 	GlobalSettings.replace_palette(find_palette_index(), pasted_palettes[0])
 	if old_title != pasted_palettes[0].title:
 		layout_changed.emit()
+	else:
+		rebuild_colors()
 
 func open_palette_options() -> void:
 	var btn_arr: Array[Button] = []


### PR DESCRIPTION
Removes a debug print. Makes resource loading safer. Fixes issue where the palettes config doesn't update after pasting a palette with the same name. Removes unnecessary reloading of content when clicking on the active tab in the settings menu.