### PR TITLE
Fix issues with palette pasting

### DIFF
--- a/src/config_classes/ColorPalette.gd
+++ b/src/config_classes/ColorPalette.gd
@@ -105,10 +105,14 @@ static func text_to_palettes(text: String) -> Array[ColorPalette]:
 		match parser.get_node_type():
 			XMLParser.NODE_ELEMENT:
 				if parser.get_node_name() == "palette":
-					parsed_title = parser.get_named_attribute_value_safe("title")
+					parsed_title = parser.get_named_attribute_value_safe("title").strip_edges()
 				elif parser.get_node_name() == "color":
-					parsed_colors.append(parser.get_named_attribute_value_safe("value"))
-					parsed_color_names.append(parser.get_named_attribute_value_safe("name"))
+					var invalid_color := Color(255, 255, 255)
+					var col_str := parser.get_named_attribute_value_safe("value").strip_edges()
+					if ColorParser.text_to_color(col_str, invalid_color) != invalid_color:
+						parsed_color_names.append(
+								parser.get_named_attribute_value_safe("name").strip_edges())
+						parsed_colors.append(col_str)
 			XMLParser.NODE_ELEMENT_END:
 				var new_palette := ColorPalette.new(parsed_title)
 				new_palette.colors = parsed_colors.duplicate()

--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -65,8 +65,10 @@ static func text_to_color(color: String, backup := Color.BLACK,
 allow_alpha := false) -> Color:
 	color = color.strip_edges()
 	if is_valid_named(color):
-		if color in ["none", "transparent"]:
+		if color == "none":
 			return Color(0, 0, 0, 0)
+		elif color == "transparent":
+			return Color(0, 0, 0, 0) if allow_alpha else backup
 		elif color == "currentColor":
 			return backup
 		else:

--- a/src/ui_widgets/color_swatch.gd
+++ b/src/ui_widgets/color_swatch.gd
@@ -33,8 +33,8 @@ func _draw() -> void:
 		var parsed_color := ColorParser.text_to_color(color)
 		if parsed_color.a != 1 or color == "none":
 			checkerboard.draw_rect(ci, inside_rect, false)
-		if color != "none":
-			RenderingServer.canvas_item_add_rect(ci,inside_rect, parsed_color)
+		if color != "none" and parsed_color.a != 0:
+			RenderingServer.canvas_item_add_rect(ci, inside_rect, parsed_color)
 
 func _make_custom_tooltip(_for_text: String) -> Object:
 	var rtl := RichTextLabel.new()

--- a/src/ui_widgets/color_swatch_config.gd
+++ b/src/ui_widgets/color_swatch_config.gd
@@ -25,12 +25,13 @@ func _draw() -> void:
 		return
 	
 	var color := color_palette.colors[idx]
-	var parsed_color := Color.from_string(color, Color(0, 0, 0))
+	var parsed_color := ColorParser.text_to_color(color)
 	var bounds := Vector2(2, 2)
+	var inside_rect := Rect2(bounds, size - bounds * 2)
 	if parsed_color.a != 1 or color == "none":
-		draw_texture_rect(checkerboard, Rect2(bounds, size - bounds * 2), false)
-	if color != "none":
-		draw_rect(Rect2(bounds, size - bounds * 2), color)
+		draw_texture_rect(checkerboard, inside_rect, false)
+	if color != "none" and parsed_color.a != 0:
+		draw_rect(inside_rect, parsed_color)
 	
 	RenderingServer.canvas_item_clear(surface)
 	if proposed_drop_data.size() != 2 or proposed_drop_data[0] != color_palette:

--- a/src/ui_widgets/palette_config.gd
+++ b/src/ui_widgets/palette_config.gd
@@ -177,15 +177,11 @@ func move_down() -> void:
 	layout_changed.emit()
 
 func paste_palette() -> void:
-	var old_title := current_palette.title
 	var pasted_palettes := ColorPalette.text_to_palettes(DisplayServer.clipboard_get())
 	if pasted_palettes.is_empty():
 		return
 	GlobalSettings.replace_palette(find_palette_index(), pasted_palettes[0])
-	if old_title != pasted_palettes[0].title:
-		layout_changed.emit()
-	else:
-		rebuild_colors()
+	layout_changed.emit()  # Emit it in any case, since the palette is a new object.
 
 func open_palette_options() -> void:
 	var btn_arr: Array[Button] = []


### PR DESCRIPTION
Fixes palettes not displaying any colors other than named or hex properly (I'm surprised it even worked before)

Adds palette color validation.

Improves handling of the "transparent" color inside ColorParser.

Fixes issue where pasting a palette with the same name doesn't cause a necessary update.