### PR TITLE
Fix precision issues in PathData and NumstringParser

### DIFF
--- a/src/data_classes/ElementPath.gd
+++ b/src/data_classes/ElementPath.gd
@@ -34,7 +34,7 @@ func get_bounding_box() -> Rect2:
 			"M", "L":
 				# Move / Line
 				var v := Vector2(cmd.x, cmd.y)
-				var end := cmd.start + v if relative else v
+				var end := cmd.get_start_coords() + v if relative else v
 				min_x = minf(min_x, end.x)
 				min_y = minf(min_y, end.y)
 				max_x = maxf(max_x, end.x)
@@ -42,13 +42,13 @@ func get_bounding_box() -> Rect2:
 			"H":
 				# Horizontal line
 				var v := Vector2(cmd.x, 0)
-				var end := cmd.start + v if relative else v
+				var end := cmd.get_start_coords() + v if relative else v
 				min_x = minf(min_x, end.x)
 				max_x = maxf(max_x, end.x)
 			"V":
 				# Vertical line
 				var v := Vector2(0, cmd.y)
-				var end := cmd.start + v if relative else v
+				var end := cmd.get_start_coords() + v if relative else v
 				min_y = minf(min_y, end.y)
 				max_y = maxf(max_y, end.y)
 			"C", "S":
@@ -57,7 +57,7 @@ func get_bounding_box() -> Rect2:
 				var v1 := Vector2(cmd.x1, cmd.y1) if cmd_char == "C" else\
 						pathdata.get_implied_S_control(cmd_idx)
 				var v2 := Vector2(cmd.x2, cmd.y2)
-				var cp1 := cmd.start
+				var cp1 := cmd.get_start_coords()
 				var cp4 := cp1 + v if relative else v
 				var cp2 := cp1 + v1 if relative else v1
 				var cp3 := cp1 + v2 if relative else v2
@@ -94,7 +94,7 @@ func get_bounding_box() -> Rect2:
 				var v1 := Vector2(cmd.x1, cmd.y1) if cmd_char == "Q" else\
 						pathdata.get_implied_T_control(cmd_idx)
 				
-				var cp1 := cmd.start
+				var cp1 := cmd.get_start_coords()
 				var cp2 := cp1 + v1 if relative else v1
 				var cp3 := cp1 + v if relative else v
 				
@@ -116,7 +116,7 @@ func get_bounding_box() -> Rect2:
 					max_y = maxf(max_y, y_extrema)
 			"A":
 				# Elliptical arc.
-				var start := cmd.start
+				var start := cmd.get_start_coords()
 				var v := Vector2(cmd.x, cmd.y)
 				var end := start + v if relative else v
 				

--- a/src/data_classes/ElementRoot.gd
+++ b/src/data_classes/ElementRoot.gd
@@ -264,12 +264,12 @@ func optimize(not_applied := false) -> bool:
 							conversion_indices.append(cmd_idx)
 							conversion_cmd_chars.append("h")
 					elif cmd_char == "L":
-						if command.x == command.start.x:
+						if command.x == command.get_start_coordinates().x:
 							if not_applied:
 								return true
 							conversion_indices.append(cmd_idx)
 							conversion_cmd_chars.append("V")
-						elif command.y == command.start.y:
+						elif command.y == command.get_start_coordinates().y:
 							if not_applied:
 								return true
 							conversion_indices.append(cmd_idx)

--- a/src/data_classes/NumstringParser.gd
+++ b/src/data_classes/NumstringParser.gd
@@ -42,17 +42,17 @@ static func evaluate(text: String) -> float:
 	var expr := Expression.new()
 	var err := expr.parse(text.replace(",", "."))
 	if err == OK:
-		var result: String = var_to_str(expr.execute())
-		if not expr.has_execute_failed() and result.is_valid_float():
-			return str_to_var(result)
+		var result: Variant = expr.execute()
+		if not expr.has_execute_failed() and typeof(result) == TYPE_FLOAT:
+			return result
 	err = expr.parse(text.replace(";", "."))
 	if err == OK:
-		var result: String = var_to_str(expr.execute())
-		if not expr.has_execute_failed() and result.is_valid_float():
-			return str_to_var(result)
+		var result: Variant = expr.execute()
+		if not expr.has_execute_failed() and typeof(result) == TYPE_FLOAT:
+			return result
 	err = expr.parse(text)
 	if err == OK:
-		var result: String = var_to_str(expr.execute())
-		if not expr.has_execute_failed() and result.is_valid_float():
-			return str_to_var(result)
+		var result: Variant = expr.execute()
+		if not expr.has_execute_failed() and typeof(result) == TYPE_FLOAT:
+			return result
 	return NAN

--- a/src/data_classes/PathCommand.gd
+++ b/src/data_classes/PathCommand.gd
@@ -11,26 +11,34 @@ const translation_dict := {
 var command_char := ""
 var arg_count := 0
 var relative := false
-var start: Vector2
+
+# This must be floats, because 64-bit precision is needed for intermediate operations.
+var start_x := 0.0
+var start_y := 0.0
+
+func get_start_coords() -> Vector2:
+	return Vector2(start_x, start_y)
+
+
 func toggle_relative() -> void:
 	if relative:
 		relative = false
 		command_char = command_char.to_upper()
 		for property in ["x", "x1", "x2"]:
 			if property in self:
-				set(property, start.x + get(property))
+				set(property, start_x + get(property))
 		for property in ["y", "y1", "y2"]:
 			if property in self:
-				set(property, start.y + get(property))
+				set(property, start_y + get(property))
 	else:
 		relative = true
 		command_char = command_char.to_lower()
 		for property in ["x", "x1", "x2"]:
 			if property in self:
-				set(property, get(property) - start.x)
+				set(property, get(property) - start_x)
 		for property in ["y", "y1", "y2"]:
 			if property in self:
-				set(property, get(property) - start.y)
+				set(property, get(property) - start_y)
 
 
 class MoveCommand extends PathCommand:

--- a/src/ui_parts/PathHandle.gd
+++ b/src/ui_parts/PathHandle.gd
@@ -19,8 +19,8 @@ func _init(new_element: Element, command_idx: int, x_name: String, y_name: Strin
 func set_pos(new_pos: Vector2) -> void:
 	if pos != new_pos:
 		var path_attribute: AttributePathdata = element.get_attribute(pathdata_name)
-		var command := path_attribute.get_command(command_index)
-		var new_coords := new_pos - command.start if command.relative else new_pos
+		var cmd := path_attribute.get_command(command_index)
+		var new_coords := new_pos - cmd.get_start_coords() if cmd.relative else new_pos
 		path_attribute.set_command_property(command_index, x_param, new_coords.x)
 		path_attribute.set_command_property(command_index, y_param, new_coords.y)
 		sync()
@@ -35,12 +35,12 @@ func sync() -> void:
 			element.get_attribute(pathdata_name).get_command(command_index)
 	if x_param in command:
 		var command_x: float = command.get(x_param)
-		pos.x = command.start.x + command_x if command.relative else command_x
+		pos.x = command.start_x + command_x if command.relative else command_x
 	else:
-		pos.x = command.start.x
+		pos.x = command.start_x
 	if y_param in command:
 		var command_y: float = command.get(y_param)
-		pos.y = command.start.y + command_y if command.relative else command_y
+		pos.y = command.start_y + command_y if command.relative else command_y
 	else:
-		pos.y = command.start.y
+		pos.y = command.start_y
 	super()

--- a/src/ui_parts/handles_manager.gd
+++ b/src/ui_parts/handles_manager.gd
@@ -411,24 +411,26 @@ func _draw() -> void:
 						"L":
 							# Line contour.
 							var v := Vector2(cmd.x, cmd.y)
-							var end := cmd.start + v if relative else v
-							points = PackedVector2Array([cmd.start, end])
+							var end := cmd.get_start_coords() + v if relative else v
+							points = PackedVector2Array([cmd.start_x, end])
 						"H":
 							# Horizontal line contour.
 							var v := Vector2(cmd.x, 0)
-							var end := cmd.start + v if relative else Vector2(v.x, cmd.start.y)
-							points = PackedVector2Array([cmd.start, end])
+							var end := cmd.get_start_coords() + v if\
+									relative else Vector2(v.x, cmd.start_y)
+							points = PackedVector2Array([cmd.get_start_coords(), end])
 						"V":
 							# Vertical line contour.
 							var v := Vector2(0, cmd.y)
-							var end := cmd.start + v if relative else Vector2(cmd.start.x, v.y)
-							points = PackedVector2Array([cmd.start, end])
+							var end := cmd.get_start_coords() + v if\
+									relative else Vector2(cmd.start_x, v.y)
+							points = PackedVector2Array([cmd.get_start_coords(), end])
 						"C":
 							# Cubic Bezier curve contour.
 							var v := Vector2(cmd.x, cmd.y)
 							var v1 := Vector2(cmd.x1, cmd.y1)
 							var v2 := Vector2(cmd.x2, cmd.y2)
-							var cp1 := cmd.start
+							var cp1 := cmd.get_start_coords()
 							var cp4 := cp1 + v if relative else v
 							var cp2 := v1 if relative else v1 - cp1
 							var cp3 := v2 - v
@@ -445,7 +447,7 @@ func _draw() -> void:
 							var v1 := pathdata.get_implied_S_control(cmd_idx)
 							var v2 := Vector2(cmd.x2, cmd.y2)
 							
-							var cp1 := cmd.start
+							var cp1 := cmd.get_start_coords()
 							var cp4 := cp1 + v if relative else v
 							var cp2 := v1 if relative else v1 - cp1
 							var cp3 := v2 - v
@@ -457,7 +459,7 @@ func _draw() -> void:
 							# Quadratic Bezier curve contour.
 							var v := Vector2(cmd.x, cmd.y)
 							var v1 := Vector2(cmd.x1, cmd.y1)
-							var cp1 := cmd.start
+							var cp1 := cmd.get_start_coords()
 							var cp2 := cp1 + v1 if relative else v1
 							var cp3 := cp1 + v if relative else v
 							
@@ -468,7 +470,7 @@ func _draw() -> void:
 							var v := Vector2(cmd.x, cmd.y)
 							var v1 := pathdata.get_implied_T_control(cmd_idx)
 							
-							var cp1 := cmd.start
+							var cp1 := cmd.get_start_coords()
 							var cp2 := v1 + cp1 if relative else v1
 							var cp3 := cp1 + v if relative else v
 							
@@ -480,7 +482,7 @@ func _draw() -> void:
 										PackedVector2Array([cp1, cp2, cp2, cp3]))
 						"A":
 							# Elliptical arc contour.
-							var start := cmd.start
+							var start := cmd.get_start_coords()
 							var v := Vector2(cmd.x, cmd.y)
 							var end := start + v if relative else v
 							# Correct for out-of-range radii.
@@ -565,9 +567,9 @@ func _draw() -> void:
 							
 							var end := Vector2(prev_M_cmd.x, prev_M_cmd.y)
 							if prev_M_cmd.relative:
-								end += prev_M_cmd.start
+								end += prev_M_cmd.get_start_coords()
 							
-							points = PackedVector2Array([cmd.start, end])
+							points = PackedVector2Array([cmd.get_start_coords(), end])
 						"M":
 							continue
 					

--- a/src/ui_widgets/dropdown.gd
+++ b/src/ui_widgets/dropdown.gd
@@ -13,8 +13,8 @@ var value := "":
 		if value != new_value:
 			value = new_value
 			value_changed.emit(value)
-			if is_instance_valid(line_edit):
-				line_edit.text = value
+		if is_instance_valid(line_edit):
+			line_edit.text = value
 
 func _ready() -> void:
 	line_edit.text_changed.connect(_on_text_changed)

--- a/src/ui_widgets/mini_number_field.gd
+++ b/src/ui_widgets/mini_number_field.gd
@@ -32,7 +32,7 @@ func _on_text_submitted(submitted_text: String) -> void:
 func evaluate_after_input(eval_text: String) -> float:
 	var num := NumstringParser.evaluate(eval_text)
 	match mode:
-		Mode.ONLY_POSITIVE: return maxf(absf(num), 0.000001)
+		Mode.ONLY_POSITIVE: return maxf(absf(num), 0.1 ** Utils.MAX_NUMERIC_PRECISION)
 		Mode.HALF_ANGLE: return fmod(num, 180.0)
 		Mode.ANGLE: return fmod(num, 360.0)
 		_: return num

--- a/src/ui_widgets/number_dropdown.gd
+++ b/src/ui_widgets/number_dropdown.gd
@@ -22,8 +22,8 @@ var value := "":
 		if not is_equal_approx(current_num, proposed_num):
 			value = to_str(proposed_num)
 			value_changed.emit(value)
-			if is_instance_valid(line_edit):
-				line_edit.text = value
+		if is_instance_valid(line_edit):
+			line_edit.text = value
 
 func _on_button_pressed() -> void:
 	var btn_arr: Array[Button] = []


### PR DESCRIPTION
While it's okay for SVGs to have 32-bit precision, intermediate operations should generally be in 64-bit land. The `start` variable in PathCommand violated this rule, as Vector2 is made of two 32-bit values. It was also prone to become inaccurate as it got calculated by adding all the coordinates.