### PR TITLE
Android: Fix viewport zoom issue

### DIFF
--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -78,7 +78,7 @@ func _unhandled_input(event: InputEvent) -> void:
 			set_view(view.position - (wrap_mouse(event.relative) if\
 					GlobalSettings.savedata.wrap_mouse else event.relative) / Indications.zoom)
 	
-	elif event is InputEventPanGesture:
+	elif event is InputEventPanGesture and not DisplayServer.get_name() == "Android":
 		# Zooming with Ctrl + touch?
 		if event.ctrl_pressed:
 			zoom_menu.set_zoom(Indications.zoom * (1 + event.delta.y / 2))


### PR DESCRIPTION
- Fixes https://github.com/MewPurPur/GodSVG/issues/160

The issue was that the Pan gesture was interfering with the Magnify gesture, and I couldn't identify a specific use case for the Pan gesture. Therefore, I have disabled it for Android. I chose not to remove the code entirely, as its exact usage is unclear. 

Everything is working as expected in my tests.