### PR TITLE
Unify X11 and Wayland again

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -21,78 +21,11 @@ env:
   BUILD_OPTIONS: target=template_release lto=full production=yes deprecated=no minizip=no brotli=no vulkan=no openxr=no use_volk=no disable_3d=yes modules_enabled_by_default=no module_freetype_enabled=yes module_gdscript_enabled=yes module_svg_enabled=yes module_jpg_enabled=yes module_text_server_adv_enabled=yes graphite=no module_webp_enabled=yes
 
 jobs:
-  build-linux-x11:
-    name: Export GodSVG for Linux X11
+  build-linux:
+    name: Export GodSVG for Linux
     runs-on: ubuntu-latest
     env:
-      PLATFORM: "Linux/X11"
-      EXTENSION: "exe"
-      BUILD_NAME: "linux-64bit"
-    steps:
-      - name: Cache Template
-        id: cache-template
-        uses: actions/cache@v3
-        with:
-          key: template-${{ env.PLATFORM }}-${{ env.GODOT_VERSION }}-${{ env.GODOT_RELEASE }}-${{ env.GODOT_REPO }}-${{ env.GODOT_COMMIT_HASH }}-${{ env.BUILD_OPTIONS }}
-          path: |
-            ~/.local/share/godot/export_templates/
-      - name: Set up Godot Editor
-        run: |
-          mkdir -v -p ~/godot-editor
-          cd ~/godot-editor
-          wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
-          unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
-          mv ./Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64 ~/godot-editor/godot
-          echo "~/godot-editor" >> $GITHUB_PATH
-
-      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' }}
-        name: Install dependencies
-        run: sudo apt install -y scons python3
-
-      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' }}
-        name: Clone Godot repository
-        run: git clone $GODOT_REPO godot
-
-      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' }}
-        name: Checkout specific commit
-        run: |
-          cd godot
-          git fetch
-          git checkout $GODOT_COMMIT_HASH
-
-      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' }}
-        name: Build Godot template for Linux
-        run: |
-          cd godot
-          scons p=linuxbsd arch=x86_64 ${BUILD_OPTIONS}
-          mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
-          mv ./bin/godot.linuxbsd.template_release.x86_64 ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/linux_release.x86_64
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          path: godsvg
-
-      - name: Export project
-        run: |
-          ls -l
-          cd godsvg
-          mkdir -v -p build
-          godot --headless --export-release "${{ env.PLATFORM }}" build/GodSVG.x86_64
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.PROJECT_NAME }}.Linux-X11
-          path: godsvg/build/GodSVG.x86_64
-          if-no-files-found: error
-          retention-days: 28
-
-  build-linux-wayland:
-    name: Export GodSVG for Linux Wayland
-    runs-on: ubuntu-latest
-    env:
-      PLATFORM: "Linux/Wayland"
+      PLATFORM: "Linux"
       EXTENSION: "exe"
       BUILD_NAME: "linux-64bit"
     steps:
@@ -150,7 +83,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PROJECT_NAME }}.Linux-Wayland
+          name: ${{ env.PROJECT_NAME }}.Linux
           path: godsvg/build/GodSVG.x86_64
           if-no-files-found: error
           retention-days: 28

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -69,7 +69,7 @@ texture_format/etc2=false
 
 [preset.1]
 
-name="Linux/X11"
+name="Linux"
 platform="Linux"
 runnable=true
 advanced_options=false
@@ -113,50 +113,6 @@ texture_format/etc2=false
 
 [preset.2]
 
-name="Linux/Wayland"
-platform="Linux"
-runnable=false
-advanced_options=false
-dedicated_server=false
-custom_features="wayland"
-export_filter="all_resources"
-include_filter=""
-exclude_filter="godot_only/*, web-build/*, *.md, *.ico, *.icns"
-export_path=""
-encryption_include_filters=""
-encryption_exclude_filters=""
-encrypt_pck=false
-encrypt_directory=false
-script_export_mode=2
-
-[preset.2.options]
-
-custom_template/debug=""
-custom_template/release=""
-debug/export_console_wrapper=1
-binary_format/embed_pck=true
-texture_format/s3tc_bptc=true
-texture_format/etc2_astc=false
-binary_format/architecture="x86_64"
-ssh_remote_deploy/enabled=false
-ssh_remote_deploy/host="user@host_ip"
-ssh_remote_deploy/port="22"
-ssh_remote_deploy/extra_args_ssh=""
-ssh_remote_deploy/extra_args_scp=""
-ssh_remote_deploy/run_script="#!/usr/bin/env bash
-export DISPLAY=:0
-unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
-\"{temp_dir}/{exe_name}\" {cmd_args}"
-ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
-kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
-rm -rf \"{temp_dir}\""
-texture_format/bptc=true
-texture_format/s3tc=true
-texture_format/etc=false
-texture_format/etc2=false
-
-[preset.3]
-
 name="macOS"
 platform="macOS"
 runnable=true
@@ -173,7 +129,7 @@ encrypt_pck=false
 encrypt_directory=false
 script_export_mode=2
 
-[preset.3.options]
+[preset.2.options]
 
 export/distribution_type=1
 binary_format/architecture="universal"
@@ -405,7 +361,7 @@ ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
 kill $(pgrep -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\")
 rm -rf \"{temp_dir}\""
 
-[preset.4]
+[preset.3]
 
 name="Web"
 platform="Web"
@@ -424,7 +380,7 @@ encrypt_pck=false
 encrypt_directory=false
 script_export_mode=2
 
-[preset.4.options]
+[preset.3.options]
 
 custom_template/debug=""
 custom_template/release=""
@@ -448,7 +404,7 @@ progressive_web_app/icon_180x180=""
 progressive_web_app/icon_512x512=""
 progressive_web_app/background_color=Color(0, 0, 0, 1)
 
-[preset.5]
+[preset.4]
 
 name="Android"
 platform="Android"
@@ -466,7 +422,7 @@ encrypt_pck=false
 encrypt_directory=false
 script_export_mode=2
 
-[preset.5.options]
+[preset.4.options]
 
 custom_template/debug=""
 custom_template/release=""

--- a/project.godot
+++ b/project.godot
@@ -41,8 +41,8 @@ window/size/viewport_width=1024
 window/size/viewport_height=640
 window/size/mode=2
 window/energy_saving/keep_screen_on=false
+display_server/driver.linuxbsd="wayland"
 mouse_cursor/tooltip_position_offset=Vector2(0, 10)
-display_server/driver.wayland="wayland"
 
 [filesystem]
 


### PR DESCRIPTION
It would appear that Godot tries out all display servers it can in order, and X11 and Wayland are both available by default, so there's no need for separate builds. Changes the default to try out Wayland first (even though it's experimental).