### PR TITLE
Remove verbose prints

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up Godot Editor
         run: |
-          mkdir -v -p ~/godot-editor
+          mkdir -p ~/godot-editor
           cd ~/godot-editor
           wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
           unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
@@ -66,7 +66,7 @@ jobs:
         run: |
           cd godot
           scons p=linuxbsd arch=x86_64 ${BUILD_OPTIONS}
-          mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
+          mkdir -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
           mv ./bin/godot.linuxbsd.template_release.x86_64 ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/linux_release.x86_64
 
       - name: Checkout repository
@@ -78,7 +78,7 @@ jobs:
         run: |
           ls -l
           cd godsvg
-          mkdir -v -p build
+          mkdir -p build
           godot --headless --export-release "${{ env.PLATFORM }}" build/GodSVG.x86_64
 
       - name: Upload artifact
@@ -105,7 +105,7 @@ jobs:
 
       - name: Set up Godot Editor
         run: |
-          mkdir -v -p ~/godot-editor
+          mkdir -p ~/godot-editor
           cd ~/godot-editor
           wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
           unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
@@ -119,7 +119,7 @@ jobs:
           sudo apt install -y g++-mingw-w64-x86-64-posix
           sudo apt install -y --fix-missing wine64
           wget -q https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe
-          mkdir -v -p ~/.local/share/rcedit
+          mkdir -p ~/.local/share/rcedit
           mv rcedit-x64.exe ~/.local/share/rcedit
           godot --headless --quit
           echo 'export/windows/wine = "/usr/bin/wine64"' >> ~/.config/godot/editor_settings-${GODOT_FEATURE_VERSION}.tres
@@ -141,7 +141,7 @@ jobs:
         run: |
           cd godot
           scons p=windows ${BUILD_OPTIONS}
-          mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
+          mkdir -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
           mv ./bin/godot.windows.template_release.x86_64.exe ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/windows_release_x86_64.exe
 
       - name: Checkout repository
@@ -152,7 +152,7 @@ jobs:
       - name: Export project
         run: |
           cd godsvg
-          mkdir -v -p build
+          mkdir -p build
           godot --headless --export-release "Windows Desktop" build/GodSVG.exe
 
       - name: Upload artifact
@@ -179,7 +179,7 @@ jobs:
 
       - name: Set up Godot Editor
         run: |
-          mkdir -v -p ~/godot-editor
+          mkdir -p ~/godot-editor
           cd ~/godot-editor
           wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_macos.universal.zip
           unzip -a Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_macos.universal.zip
@@ -229,7 +229,7 @@ jobs:
           cp godot.macos.template_release.universal macos_template.app/Contents/MacOS/godot_macos_release.universal;
           chmod +x macos_template.app/Contents/MacOS/godot_macos*;
           zip -q -9 -r macos.zip macos_template.app;
-          mkdir -v -p "/Users/runner/Library/Application Support/Godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}"
+          mkdir -p "/Users/runner/Library/Application Support/Godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}"
           mv macos.zip "/Users/runner/Library/Application Support/Godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}"
 
       - name: Checkout repository
@@ -240,7 +240,7 @@ jobs:
       - name: Export project
         run: |
           cd godsvg
-          mkdir -v -p build
+          mkdir -p build
           godot --headless --export-release "macOS" build/GodSVG.zip
 
       - name: Upload artifact
@@ -267,7 +267,7 @@ jobs:
 
       - name: Set up Godot Editor
         run: |
-          mkdir -v -p ~/godot-editor
+          mkdir -p ~/godot-editor
           cd ~/godot-editor
           wget -q https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}-${GODOT_RELEASE}/Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
           unzip Godot_v${GODOT_VERSION}-${GODOT_RELEASE}_linux.x86_64.zip
@@ -305,7 +305,7 @@ jobs:
           cd godot
           source ../emsdk/emsdk_env.sh
           scons p=web arch=wasm32 ${BUILD_OPTIONS} threads=no
-          mkdir -v -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
+          mkdir -p ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/
           mv ./bin/godot.web.template_release.wasm32.nothreads.zip ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/web_nothreads_release.zip
 
       - name: Checkout repository
@@ -316,7 +316,7 @@ jobs:
       - name: Export project
         run: |
           cd godsvg
-          mkdir -v -p build/web
+          mkdir -p build/web
           godot --headless --export-release "Web" build/web/index.html
 
       - name: Upload artifact

--- a/src/data_classes/AttributePathdata.gd
+++ b/src/data_classes/AttributePathdata.gd
@@ -1,8 +1,6 @@
 # The "d" attribute of ElementPath.
 class_name AttributePathdata extends Attribute
 
-const translation_dict = PathCommand.translation_dict
-
 var _commands: Array[PathCommand]
 
 func _sync() -> void:
@@ -258,7 +256,7 @@ static func pathdata_to_arrays(text: String) -> Array[Array]:
 				"M", "m", "L", "l", "H", "h", "V", "v", "A", "a", "Q", "q", "T", "t",\
 				"C", "c", "S", "s", "Z", "z":
 					curr_command = char
-					args_left = translation_dict[curr_command.to_upper()].new().arg_count
+					args_left = PathCommand.arg_count_dict[curr_command.to_upper()]
 				" ", "\t", "\n", "\r": continue
 				"-", "+", ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
 					if prev_command.is_empty():
@@ -269,11 +267,11 @@ static func pathdata_to_arrays(text: String) -> Array[Array]:
 							return new_commands
 						"M", "m":
 							curr_command = "L" if prev_command == "M" else "l"
-							args_left = translation_dict[curr_command.to_upper()].new().arg_count
+							args_left = PathCommand.arg_count_dict[curr_command.to_upper()]
 						"L", "l", "H", "h", "V", "v", "A", "a", "Q", "q", "T", "t", "C", "c",\
 						"S", "s":
 							curr_command = prev_command
-							args_left = translation_dict[curr_command.to_upper()].new().arg_count
+							args_left = PathCommand.arg_count_dict[curr_command.to_upper()]
 					idx -= 1
 				_: return new_commands
 		# Logic for parsing new numbers until args_left == 0.
@@ -388,7 +386,7 @@ static func path_commands_from_parsed_data(data: Array[Array]) -> Array[PathComm
 	for a in data:
 		var new_cmd: PathCommand
 		# The idx 0 element is the command char, the rest are the arguments.
-		var cmd_type: Script = translation_dict[a[0].to_upper()]
+		var cmd_type: Script = PathCommand.translation_dict[a[0].to_upper()]
 		var relative := Utils.is_string_lower(a[0])
 		match a.size():
 			1: new_cmd = cmd_type.new(relative)

--- a/src/data_classes/PathCommand.gd
+++ b/src/data_classes/PathCommand.gd
@@ -8,8 +8,11 @@ const translation_dict := {
 	"C": CubicBezierCommand, "S": ShorthandCubicBezierCommand
 }
 
+const arg_count_dict := {  # Dictionary{String: int}
+	"M": 2, "L": 2, "H": 1, "V": 1, "Z": 0, "A": 7, "Q": 4, "T": 2, "C": 6, "S": 4
+}
+
 var command_char := ""
-var arg_count := 0
 var relative := false
 
 # This must be floats, because 64-bit precision is needed for intermediate operations.
@@ -47,7 +50,6 @@ class MoveCommand extends PathCommand:
 	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "m" if p_rel else "M"
-		arg_count = 2
 		x = new_x
 		y = new_y
 
@@ -57,7 +59,6 @@ class LineCommand extends PathCommand:
 	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "l" if p_rel else "L"
-		arg_count = 2
 		x = new_x
 		y = new_y
 
@@ -66,7 +67,6 @@ class HorizontalLineCommand extends PathCommand:
 	func _init(new_x := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "h" if p_rel else "H"
-		arg_count = 1
 		x = new_x
 
 class VerticalLineCommand extends PathCommand:
@@ -74,7 +74,6 @@ class VerticalLineCommand extends PathCommand:
 	func _init(new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "v" if p_rel else "V"
-		arg_count = 1
 		y = new_y
 
 class EllipticalArcCommand extends PathCommand:
@@ -89,7 +88,6 @@ class EllipticalArcCommand extends PathCommand:
 	new_sweep_flag := 0, new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "a" if p_rel else "A"
-		arg_count = 7
 		rx = new_rx
 		ry = new_ry
 		rot = new_rot
@@ -107,7 +105,6 @@ class QuadraticBezierCommand extends PathCommand:
 	p_rel := false) -> void:
 		relative = p_rel
 		command_char = "q" if p_rel else "Q"
-		arg_count = 4
 		x1 = new_x1
 		y1 = new_y1
 		x = new_x
@@ -119,7 +116,6 @@ class ShorthandQuadraticBezierCommand extends PathCommand:
 	func _init(new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "t" if p_rel else "T"
-		arg_count = 2
 		x = new_x
 		y = new_y
 
@@ -134,7 +130,6 @@ class CubicBezierCommand extends PathCommand:
 	new_x := 0.0, new_y := 0.0, p_rel := false) -> void:
 		relative = p_rel
 		command_char = "c" if p_rel else "C"
-		arg_count = 6
 		x1 = new_x1
 		y1 = new_y1
 		x2 = new_x2
@@ -151,7 +146,6 @@ class ShorthandCubicBezierCommand extends PathCommand:
 	p_rel := false) -> void:
 		relative = p_rel
 		command_char = "s" if p_rel else "S"
-		arg_count = 4
 		x2 = new_x2
 		y2 = new_y2
 		x = new_x


### PR DESCRIPTION
Removes verbose mkdir, I don't think that's necessary. For debugging and initial development it's cool, to ensure everything runs as expected, but in production workflows it just makes logs more verbose and the information is not useful.

Makes it so arg_count isn't a variable in every PathCommand object, but instead something with a dictionary in the base PathCommand class. This saves us from needing to create a new object every time we're trying to find out the argcount of a certain type of path command. This breaches the feature freeze a little, but I decided it's safe enough.