### PR TITLE
Fix element frame button deselecting

### DIFF
--- a/src/ui_widgets/element_frame.gd
+++ b/src/ui_widgets/element_frame.gd
@@ -28,6 +28,8 @@ var element: Element
 var surface := RenderingServer.canvas_item_create()  # Used for the drop indicator.
 @onready var title_bar_ci := title_bar.get_canvas_item()
 
+var suppress_drag: bool = false
+
 func _ready() -> void:
 	RenderingServer.canvas_item_set_parent(surface, get_canvas_item())
 	RenderingServer.canvas_item_set_z_index(surface, 1)
@@ -76,7 +78,7 @@ func _exit_tree() -> void:
 
 # Logic for dragging.
 func _get_drag_data(_at_position: Vector2) -> Variant:
-	if Indications.selected_xids.is_empty():
+	if suppress_drag or Indications.selected_xids.is_empty():
 		return null
 	
 	var data: Array[PackedInt32Array] = XIDUtils.filter_descendants(
@@ -144,7 +146,7 @@ func _on_mouse_entered() -> void:
 			Vector2(half_bar_width - title_width / 2 - element_icon_size.x / 2 - 6, 3)
 	title_button.size = Vector2(title_width + 28, 20)
 	title_bar.add_child(title_button)
-	title_button.gui_input.connect(_on_title_button_gui_input.bind(title_button))
+	title_button.gui_input.connect(_on_title_button_gui_input)
 	title_button.pressed.connect(_on_title_button_pressed)
 	mouse_exited.connect(title_button.queue_free)
 	# Add warning button.
@@ -159,6 +161,7 @@ func _on_mouse_entered() -> void:
 		mouse_exited.connect(warning_sign.queue_free)
 
 func _on_mouse_exited() -> void:
+	suppress_drag = false
 	Indications.remove_hovered(element.xid)
 	determine_selection_highlight()
 
@@ -280,5 +283,9 @@ func _on_title_bar_draw() -> void:
 				warning_icon.get_size()), false)
 
 # Block dragging from starting when pressing the title button.
-func _on_title_button_gui_input(event: InputEvent, title_button: Button) -> void:
-	title_button.mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)
+func _on_title_button_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.is_pressed():
+			suppress_drag = true
+		else:
+			suppress_drag = false

--- a/src/ui_widgets/element_frame.gd
+++ b/src/ui_widgets/element_frame.gd
@@ -285,7 +285,4 @@ func _on_title_bar_draw() -> void:
 # Block dragging from starting when pressing the title button.
 func _on_title_button_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:
-		if event.is_pressed():
-			suppress_drag = true
-		else:
-			suppress_drag = false
+		suppress_drag = event.is_pressed()


### PR DESCRIPTION
- Fixes https://github.com/MewPurPur/GodSVG/issues/793

To prevent dragging when interacting with the `title_button`, its `mouse_filter` was set to STOP. This caused the `title_button` to capture the mouse input, triggering the `mouse_exited` signal of the base node. The `mouse_exited` signal deleted the current `title_button`, which allowed the base node to capture the mouse input again. Subsequently, the mouse_entered signal of the base node was triggered, creating a `new title_button`. However, this new button was unpressed due to the transition.

The suggested solution introduces a flag to suppress dragging while the title_button is pressed. This prevents the dragging without unintentionally deleting and recreating the button.