### PR TITLE
Android: Increase default handle size

### DIFF
--- a/src/autoload/GlobalSettings.gd
+++ b/src/autoload/GlobalSettings.gd
@@ -256,6 +256,10 @@ func reset_settings() -> void:
 	modify_setting("formatters", formatters_array, true)
 	modify_setting("editor_formatter", pretty_formatter, true)
 	modify_setting("export_formatter", compact_formatter, true)
+	
+	# Higher default handle_size on Android for better touch control.
+	if DisplayServer.get_name() == "Android": modify_setting("handle_size", 2.0, true)
+
 	save()
 
 


### PR DESCRIPTION
This PR introduces a new setting that automatically adjusts the handle size based on the screen size. This setting is enabled by default, ensuring that the selection handles are appropriately scaled.