### PR TITLE
Unify inspector visuals

### DIFF
--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -4,17 +4,37 @@ const ElementFrame = preload("res://src/ui_widgets/element_frame.tscn")
 const BasicXNodeFrame = preload("res://src/ui_widgets/basic_xnode_frame.tscn")
 
 @onready var xnodes_container: VBoxContainer = %RootChildren
-@onready var add_button: Button = $AddButton
+@onready var add_button: Button = %ActionContainer/AddButton
+@onready var action_panel: PanelContainer = $ActionPanel
+@onready var element_container: PanelContainer = $ElementContainer
 
 
 func _ready() -> void:
+	GlobalSettings.theme_changed.connect(update_theme)
 	GlobalSettings.language_changed.connect(update_translation)
+	update_theme()
 	update_translation()
 	SVG.xnode_layout_changed.connect(full_rebuild)
 	SVG.changed_unknown.connect(full_rebuild)
 	add_button.pressed.connect(_on_add_button_pressed)
 	full_rebuild()
 
+
+func update_theme() -> void:
+	var bottom_stylebox := StyleBoxFlat.new()
+	bottom_stylebox.set_border_width_all(2)
+	bottom_stylebox.border_color = ThemeUtils.common_panel_inner_color
+	var top_stylebox := bottom_stylebox.duplicate()
+	
+	bottom_stylebox.corner_radius_bottom_left = 5
+	bottom_stylebox.corner_radius_bottom_right = 5
+	bottom_stylebox.draw_center = false
+	top_stylebox.corner_radius_top_left = 5
+	top_stylebox.corner_radius_top_right = 5
+	top_stylebox.bg_color = Color(ThemeUtils.common_panel_inner_color, 0.4)
+	top_stylebox.set_content_margin_all(4)
+	action_panel.add_theme_stylebox_override("panel", top_stylebox)
+	element_container.add_theme_stylebox_override("panel", bottom_stylebox)
 
 func update_translation() -> void:
 	add_button.text = Translator.translate("Add element")

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -1,22 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://ccynisiuyn5qn"]
+[gd_scene load_steps=6 format=3 uid="uid://ccynisiuyn5qn"]
 
 [ext_resource type="Script" path="res://src/ui_parts/inspector.gd" id="1_16ggy"]
 [ext_resource type="PackedScene" uid="uid://bktmk76u7dsu0" path="res://src/ui_parts/root_element_editor.tscn" id="2_jnl50"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://visual/icons/Plus.svg" id="3_vo6hf"]
 [ext_resource type="Script" path="res://src/ui_parts/element_container.gd" id="4_i4hc2"]
 [ext_resource type="Script" path="res://src/ui_parts/move_to_overlay.gd" id="5_otlmf"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4j4hv"]
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.0980392, 0.0980392, 0.14902, 1)
-corner_radius_top_left = 5
-corner_radius_top_right = 5
-corner_radius_bottom_right = 5
-corner_radius_bottom_left = 5
 
 [node name="Inspector" type="VBoxContainer"]
 custom_minimum_size = Vector2(408, 0)
@@ -26,10 +14,17 @@ offset_right = 392.0
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_constants/separation = 6
+theme_override_constants/separation = -2
 script = ExtResource("1_16ggy")
 
-[node name="AddButton" type="Button" parent="."]
+[node name="ActionPanel" type="PanelContainer" parent="."]
+layout_mode = 2
+
+[node name="ActionContainer" type="HBoxContainer" parent="ActionPanel"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="AddButton" type="Button" parent="ActionPanel/ActionContainer"]
 layout_mode = 2
 size_flags_horizontal = 0
 focus_mode = 0
@@ -43,7 +38,6 @@ custom_minimum_size = Vector2(0, 240)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_4j4hv")
 script = ExtResource("4_i4hc2")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="ElementContainer"]


### PR DESCRIPTION
Makes the inspector look like this:

![image](https://github.com/user-attachments/assets/d0daacfb-9854-421f-b6b7-f70dd8bd0dd5)

instead of this:

![image](https://github.com/user-attachments/assets/658bbea2-dade-4d5b-8dd3-4a84882dd96d)

This makes the border between the inspector and the code editor clear.