### PR TITLE
Rework SaveData

### DIFF
--- a/src/autoload/Configs.gd
+++ b/src/autoload/Configs.gd
@@ -1,18 +1,32 @@
 # This singleton handles session data and settings.
 extends Node
 
+@warning_ignore("unused_signal")
 signal file_path_changed
+@warning_ignore("unused_signal")
 signal highlighting_colors_changed
+@warning_ignore("unused_signal")
 signal snap_changed
+@warning_ignore("unused_signal")
 signal language_changed
+@warning_ignore("unused_signal")
 signal ui_scale_changed
+@warning_ignore("unused_signal")
 signal theme_changed
+@warning_ignore("unused_signal")
 signal shortcuts_changed
+@warning_ignore("unused_signal")
 signal basic_colors_changed
+@warning_ignore("unused_signal")
 signal handle_visuals_changed
 
-var savedata := SaveData.new()
 const savedata_path = "user://savedata.tres"
+var savedata: SaveData:
+	set(new_value):
+		if savedata != new_value and is_instance_valid(new_value):
+			savedata = new_value
+			savedata.validate()
+			savedata.changed_deferred.connect(save)
 
 var svg_text := "":
 	set(new_value):
@@ -22,162 +36,21 @@ var svg_text := "":
 
 const svg_path = "user://save.svg"
 
-var shortcut_validities := {}
-var palette_validities := {}
-
-
-func get_signal(setting: String) -> Signal:
-	if not setting in triggers:
-		return Signal()
-	var triggers_arr: Array = triggers[setting]
-	return triggers_arr[0] if triggers_arr.size() > 0 else Signal()
-
-func get_modification_callback(setting: String) -> Callable:
-	if not setting in triggers:
-		return Callable()
-	var triggers_arr: Array = triggers[setting]
-	return triggers_arr[1] if triggers_arr.size() > 1 else Callable()
-
-var triggers = {
-	"language": [language_changed, change_locale],
-	"editor_formatter": [Signal(), sync_elements],
-	"highlighting_symbol_color": [highlighting_colors_changed],
-	"highlighting_element_color": [highlighting_colors_changed],
-	"highlighting_attribute_color": [highlighting_colors_changed],
-	"highlighting_string_color": [highlighting_colors_changed],
-	"highlighting_comment_color": [highlighting_colors_changed],
-	"highlighting_text_color": [highlighting_colors_changed],
-	"highlighting_cdata_color": [highlighting_colors_changed],
-	"highlighting_error_color": [highlighting_colors_changed],
-	"handle_inner_color": [handle_visuals_changed],
-	"handle_color": [handle_visuals_changed],
-	"handle_hovered_color": [handle_visuals_changed],
-	"handle_selected_color": [handle_visuals_changed],
-	"handle_hovered_selected_color": [handle_visuals_changed],
-	"background_color": [Signal(), change_background_color],
-	"basic_color_valid": [basic_colors_changed],
-	"basic_color_error": [basic_colors_changed],
-	"basic_color_warning": [basic_colors_changed],
-	"use_filename_for_window_title": [Signal(), update_window_title],
-	"handle_size": [handle_visuals_changed],
-	"ui_scale": [ui_scale_changed],
-	"auto_ui_scale": [ui_scale_changed],
-	"snap": [snap_changed],
-	"current_file_path": [file_path_changed],
-}
-
-
-func modify_setting(setting: String, new_value: Variant, omit_save := false) -> void:
-	if savedata.get(setting) == new_value:
-		return
-	if omit_save:
-		savedata.set(setting, new_value)
-	else:
-		save_setting(setting, new_value)
-	var related_modification_callback := get_modification_callback(setting)
-	if related_modification_callback.is_valid():
-		related_modification_callback.call()
-	var related_signal := get_signal(setting)
-	if not related_signal.is_null():
-		related_signal.emit()
-
-func modify_shortcut(action: String, new_events: Array[InputEvent]) -> void:
-	apply_shortcut(action, new_events)
-	save_shortcut(action)
-	shortcuts_changed.emit()
-
-func apply_shortcut(action: String, events: Array[InputEvent]) -> void:
-	InputMap.action_erase_events(action)
-	for event in events:
-		InputMap.action_add_event(action, event)
-
-func save_shortcut(action: String) -> void:
-	savedata.shortcuts[action] = InputMap.action_get_events(action)
-	save()
-
-func save_setting(setting: StringName, value: Variant) -> void:
-	savedata.set(setting, value)
-	save()
-
 func save() -> void:
 	ResourceSaver.save(savedata, savedata_path)
-
-
-func update_palette_validities() -> void:
-	palette_validities.clear()
-	for palette in savedata.palettes:
-		if not palette.title.is_empty():
-			palette_validities[palette.title] = not palette.title in palette_validities
-
-func is_palette_valid(checked_palette: ColorPalette) -> bool:
-	if checked_palette.title.is_empty():
-		return false
-	if not checked_palette.title in palette_validities:
-		return true
-	return palette_validities[checked_palette.title]
-
-func is_palette_title_unused(checked_title: String) -> bool:
-	for palette in savedata.palettes:
-		if palette.title == checked_title:
-			return false
-	return true
-
-func add_new_palette(new_palette: ColorPalette) -> void:
-	savedata.palettes.append(new_palette)
-	update_palette_validities()
-	save()
-
-func delete_palette(idx: int) -> void:
-	if savedata.palettes.size() <= idx:
-		return
-	savedata.palettes.remove_at(idx)
-	update_palette_validities()
-	save()
-
-func rename_palette(idx: int, new_name: String) -> void:
-	if savedata.palettes.size() <= idx:
-		return
-	savedata.palettes[idx].title = new_name
-	update_palette_validities()
-	save()
-
-func replace_palette(idx: int, new_palette: ColorPalette) -> void:
-	if savedata.palettes.size() <= idx:
-		return
-	savedata.palettes[idx] = new_palette
-	update_palette_validities()
-	save()
-
-func move_palette_up(idx: int) -> void:
-	var palette: ColorPalette = savedata.palettes.pop_at(idx)
-	savedata.palettes.insert(idx - 1, palette)
-	save()
-
-func move_palette_down(idx: int) -> void:
-	var palette: ColorPalette = savedata.palettes.pop_at(idx)
-	savedata.palettes.insert(idx + 1, palette)
-	save()
-
-func palette_apply_preset(idx: int, preset: ColorPalette.Preset) -> void:
-	savedata.palettes[idx].apply_preset(preset)
-	save()
 
 
 var default_shortcuts := {}
 
 func _enter_tree() -> void:
-	for action in InputMap.get_actions():
-		if action in ShortcutUtils.get_all_shortcuts():
+	# Fill up the default shortcuts dictionary before the shortcuts are loaded.
+	for action in ShortcutUtils.get_all_shortcuts():
+		if InputMap.has_action(action):
 			default_shortcuts[action] = InputMap.action_get_events(action)
 	load_config()
 	load_svg_text()
 	ThemeUtils.generate_and_apply_theme()
-	# Connect to settings that have a global effect.
-	file_path_changed.connect(update_window_title)
 	update_window_title()
-	shortcuts_changed.connect(update_shortcut_validities)
-	update_shortcut_validities()
-	update_palette_validities()
 
 
 func load_config() -> void:
@@ -186,49 +59,25 @@ func load_config() -> void:
 		return
 	
 	savedata = ResourceLoader.load(savedata_path)
-	if savedata == null or not savedata is SaveData:
+	if not is_instance_valid(savedata):
 		reset_settings()
 		return
 	
-	for action in ShortcutUtils.get_all_shortcuts():
-		if ShortcutUtils.is_shortcut_modifiable(action):
-			if savedata.shortcuts.has(action):
-				apply_shortcut(action, savedata.shortcuts[action])
-	if not is_instance_valid(savedata) or not savedata is SaveData:
-		reset_settings()
-	else:
-		update_window_title()
-		change_background_color()
-		change_locale()
+	update_window_title()
+	change_background_color()
+	change_locale()
 
 func load_svg_text() -> void:
 	var fa := FileAccess.open(svg_path, FileAccess.READ)
 	if fa != null:
 		svg_text = fa.get_as_text()
 
-
 func reset_settings() -> void:
 	savedata = SaveData.new()
-	modify_setting("language", "en", true)
-	
-	InputMap.load_from_project_settings()
-	for action in ShortcutUtils.get_all_shortcuts():
-		if ShortcutUtils.is_shortcut_modifiable(action):
-			save_shortcut(action)
-	shortcuts_changed.emit()
-	
-	# The array needs to be typed.
-	var palettes_array: Array[ColorPalette] = [
-			ColorPalette.new("Pure", ColorPalette.Preset.PURE)]
-	modify_setting("palettes", palettes_array, true)
-	
-	modify_setting("editor_formatter", Formatter.new(Formatter.Preset.PRETTY), true)
-	modify_setting("export_formatter", Formatter.new(Formatter.Preset.COMPACT), true)
-	
-	# Higher default handle_size on Android for better touch control.
-	if OS.get_name() == "Android":
-		modify_setting("handle_size", 2.0, true)
-	
+	savedata.reset_to_default()
+	savedata.language = "en"
+	savedata.set_shortcut_panel_presented_shortcuts({ 0: "undo", 1: "redo" })
+	savedata.set_palettes([ColorPalette.new("Pure", ColorPalette.Preset.PURE)])
 	save()
 
 
@@ -245,36 +94,6 @@ func generate_highlighter() -> SVGHighlighter:
 	return new_highlighter
 
 
-func update_shortcut_validities() -> void:
-	shortcut_validities.clear()
-	for action in ShortcutUtils.get_all_shortcuts():
-		for shortcut: InputEventKey in InputMap.action_get_events(action):
-			var shortcut_id := shortcut.get_keycode_with_modifiers()
-			# If the key already exists, set validity to false, otherwise set to true.
-			shortcut_validities[shortcut_id] = not shortcut_id in shortcut_validities
-
-func is_shortcut_valid(shortcut: InputEvent) -> bool:
-	var shortcut_id = shortcut.get_keycode_with_modifiers()
-	if not shortcut_id in shortcut_validities:
-		return true
-	return shortcut_validities[shortcut_id]
-
-func get_actions_with_shortcut(shortcut: InputEvent) -> PackedStringArray:
-	var shortcut_id = shortcut.get_keycode_with_modifiers()
-	if not shortcut_id in shortcut_validities:
-		return PackedStringArray()
-	elif shortcut_validities[shortcut_id]:
-		return PackedStringArray()
-	
-	var actions_with_shortcut := PackedStringArray()
-	for action in ShortcutUtils.get_all_shortcuts():
-		for action_shortcut: InputEventKey in InputMap.action_get_events(action):
-			if action_shortcut.get_keycode_with_modifiers() == shortcut_id:
-				actions_with_shortcut.append(action)
-				break
-	return actions_with_shortcut
-
-
 # Global effects from settings. Some of them should also be used on launch.
 
 func update_window_title() -> void:
@@ -285,9 +104,6 @@ func update_window_title() -> void:
 
 func change_background_color() -> void:
 	RenderingServer.set_default_clear_color(savedata.background_color)
-
-func sync_elements() -> void:
-	SVG.sync_elements()
 
 func change_locale() -> void:
 	TranslationServer.set_locale(savedata.language)

--- a/src/autoload/SVG.gd
+++ b/src/autoload/SVG.gd
@@ -27,9 +27,12 @@ var _update_pending := false
 var _save_pending := false
 
 var text := ""
-var root_element := ElementRoot.new()
+var root_element: ElementRoot
 
 var UR := UndoRedo.new()
+
+func _enter_tree() -> void:
+	root_element = ElementRoot.new(Configs.savedata.editor_formatter)
 
 func _ready() -> void:
 	UR.version_changed.connect(_on_undo_redo)

--- a/src/config_classes/ColorPalette.gd
+++ b/src/config_classes/ColorPalette.gd
@@ -1,5 +1,5 @@
 # A resource for the color palettes that are listed in the color picker.
-class_name ColorPalette extends Resource
+class_name ColorPalette extends ConfigResource
 
 enum Preset {EMPTY, PURE, GRAYSCALE}
 
@@ -17,24 +17,50 @@ var presets = {
 signal layout_changed
 
 # The title must be unique.
-@export var title: String
-@export var colors: PackedStringArray  # Colors must be unique within a palette.
-@export var color_names: PackedStringArray
+@export var title: String:
+	set(new_value):
+		if title != new_value:
+			title = new_value
+			emit_changed()
+
+@export var _colors: PackedStringArray
+@export var _color_names: PackedStringArray
 
 func _init(new_title := "", new_preset := Preset.EMPTY) -> void:
 	title = new_title
 	apply_preset(new_preset)
-	changed.connect(Configs.save, CONNECT_DEFERRED)
+	super()
 
-func add_color() -> void:
-	colors.append("none")
-	color_names.append("")
+func get_color(idx: int) -> String:
+	return _colors[idx]
+
+func get_color_name(idx: int) -> String:
+	return _color_names[idx]
+
+func get_color_count() -> int:
+	return _colors.size()
+
+func setup(new_colors: PackedStringArray, new_color_names: PackedStringArray) -> void:
+	_colors = new_colors.duplicate()
+	_color_names = new_color_names.duplicate()
+	_validate()
+	emit_changed()
+
+func insert_color(idx: int, color: String, color_name: String) -> void:
+	_colors.insert(idx, color)
+	_color_names.insert(idx, color_name)
+	emit_changed()
+	layout_changed.emit()
+
+func add_new_color() -> void:
+	_colors.append("none")
+	_color_names.append("")
 	emit_changed()
 	layout_changed.emit()
 
 func remove_color(idx: int) -> void:
-	colors.remove_at(idx)
-	color_names.remove_at(idx)
+	_colors.remove_at(idx)
+	_color_names.remove_at(idx)
 	emit_changed()
 	layout_changed.emit()
 
@@ -45,54 +71,61 @@ func move_color(old_idx: int, new_idx: int) -> void:
 	if old_idx < new_idx:
 		new_idx -= 1
 	
-	var old_color := colors[old_idx]
-	colors.remove_at(old_idx)
-	colors.insert(new_idx, old_color)
-	var old_name := color_names[old_idx]
-	color_names.remove_at(old_idx)
-	color_names.insert(new_idx, old_name)
+	var old_color := _colors[old_idx]
+	_colors.remove_at(old_idx)
+	_colors.insert(new_idx, old_color)
+	var old_name := _color_names[old_idx]
+	_color_names.remove_at(old_idx)
+	_color_names.insert(new_idx, old_name)
 	emit_changed()
 	layout_changed.emit()
 
 func modify_color(idx: int, new_color: String) -> void:
-	colors[idx] = new_color
+	_colors[idx] = new_color
 	emit_changed()
 
 func modify_color_name(idx: int, new_color_name: String) -> void:
-	color_names[idx] = new_color_name
+	_color_names[idx] = new_color_name
 	emit_changed()
 
 func apply_preset(new_preset: Preset) -> void:
 	if not is_same_as_preset(new_preset):
-		colors = presets[new_preset][0].duplicate()
-		color_names = presets[new_preset][1].duplicate()
+		_colors = presets[new_preset][0].duplicate()
+		_color_names = presets[new_preset][1].duplicate()
 		emit_changed()
 		layout_changed.emit()
 
 func is_same_as_preset(preset: Preset) -> bool:
-	return colors == presets[preset][0] and color_names == presets[preset][1]
+	return _colors == presets[preset][0] and _color_names == presets[preset][1]
 
 func has_unique_definitions() -> bool:
 	var dict := {}
-	for i in color_names.size():
-		var color := ColorParser.text_to_color(colors[i])
-		if dict.has(color) and dict[color].has(color_names[i]):
+	for i in _color_names.size():
+		var color := ColorParser.text_to_color(_colors[i])
+		if dict.has(color) and dict[color].has(_color_names[i]):
 			return false
 		elif dict.has(color):
-			dict[color].append(color_names[i])
+			dict[color].append(_color_names[i])
 		else:
-			dict[color] = [color_names[i]]
+			dict[color] = [_color_names[i]]
 	return true
 
 
 func to_text() -> String:
 	var text := '<palette title="%s">\n' % title
-	for i in colors.size():
-		text += '\t<color value="%s"' % colors[i]
-		if not color_names[i].is_empty():
-			text += ' name="%s"' % color_names[i]
+	for i in _colors.size():
+		text += '\t<color value="%s"' % _colors[i]
+		if not _color_names[i].is_empty():
+			text += ' name="%s"' % _color_names[i]
 		text += "/>\n"
 	return text + "</palette>"
+
+func _validate() -> void:
+	if _color_names.size() > _colors.size():
+		_color_names.resize(_colors.size())
+	elif _color_names.size() < _colors.size():
+		_colors.resize(_color_names.size())
+
 
 static func text_to_palettes(text: String) -> Array[ColorPalette]:
 	var parser := XMLParser.new()
@@ -116,8 +149,7 @@ static func text_to_palettes(text: String) -> Array[ColorPalette]:
 			XMLParser.NODE_ELEMENT_END:
 				if parser.get_node_name() == "palette":
 					var new_palette := ColorPalette.new(parsed_title)
-					new_palette.colors = parsed_colors.duplicate()
-					new_palette.color_names = parsed_color_names.duplicate()
+					new_palette.setup(parsed_colors, parsed_color_names)
 					parsed_colors.clear()
 					parsed_color_names.clear()
 					parsed_title = ""

--- a/src/config_classes/ConfigResource.gd
+++ b/src/config_classes/ConfigResource.gd
@@ -1,0 +1,18 @@
+# Implements a very useful signal.
+class_name ConfigResource extends Resource
+
+signal changed_deferred
+
+var _changed_deferred_pending := false
+
+func _init() -> void:
+	changed.connect(_queue_emit_changed_deferred)
+
+func _queue_emit_changed_deferred() -> void:
+	emit_changed_deferred.call_deferred()
+	_changed_deferred_pending = true
+
+func emit_changed_deferred() -> void:
+	if _changed_deferred_pending:
+		_changed_deferred_pending = false
+		changed_deferred.emit()

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -1,7 +1,11 @@
-class_name SaveData extends Resource
+class_name SaveData extends ConfigResource
 
 const GoodColorPicker = preload("res://src/ui_widgets/good_color_picker.gd")
 
+var _palette_validities := {}
+var _shortcut_validities := {}
+
+# Most settings don't need a default.
 func get_setting_default(setting: String) -> Variant:
 	match setting:
 		"highlighting_symbol_color": return Color("abc9ff")
@@ -32,58 +36,482 @@ func get_setting_default(setting: String) -> Variant:
 		"auto_ui_scale": return true
 	return null
 
+func reset_to_default() -> void:
+	for setting in _get_setting_names():
+		set(setting, get_setting_default(setting))
+
+func _get_setting_names() -> PackedStringArray:
+	var arr := PackedStringArray()
+	for p in get_property_list():
+		if p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE and p.usage & PROPERTY_USAGE_STORAGE:
+			if get_setting_default(p.name) != null:
+				arr.append(p.name)
+	return arr
+
+func validate() -> void:
+	if not is_instance_valid(editor_formatter):
+		editor_formatter = Formatter.new(Formatter.Preset.PRETTY)
+	if not is_instance_valid(export_formatter):
+		export_formatter = Formatter.new(Formatter.Preset.COMPACT)
+
 
 const CURRENT_VERSION = 1
-@export var version := CURRENT_VERSION
+@export var version := CURRENT_VERSION:
+	set(new_value):
+		if version != new_value:
+			version = new_value
+			emit_changed()
 
-@export var language := ""
+@export var language := "":
+	set(new_value):
+		if language != new_value:
+			language = new_value
+			emit_changed()
+			Configs.change_locale.call_deferred()
+			Configs.language_changed.emit()
 
 # Theming
-@export var highlighting_symbol_color := Color("abc9ff")
-@export var highlighting_element_color := Color("ff8ccc")
-@export var highlighting_attribute_color := Color("bce0ff")
-@export var highlighting_string_color := Color("a1ffe0")
-@export var highlighting_comment_color := Color("cdcfd280")
-@export var highlighting_text_color := Color("cdcfeaac")
-@export var highlighting_cdata_color := Color("ffeda1ac")
-@export var highlighting_error_color := Color("ff866b")
-@export var handle_inner_color := Color("fff")
-@export var handle_color := Color("111")
-@export var handle_hovered_color := Color("aaa")
-@export var handle_selected_color := Color("46f")
-@export var handle_hovered_selected_color := Color("f44")
-@export var background_color := Color(0.12, 0.132, 0.2, 1)
-@export var basic_color_valid := Color("9f9")
-@export var basic_color_error := Color("f99")
-@export var basic_color_warning := Color("ee5")
+@export var highlighting_symbol_color := Color("abc9ff"):
+	set(new_value):
+		if highlighting_symbol_color != new_value:
+			highlighting_symbol_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_element_color := Color("ff8ccc"):
+	set(new_value):
+		if highlighting_element_color != new_value:
+			highlighting_element_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_attribute_color := Color("bce0ff"):
+	set(new_value):
+		if highlighting_attribute_color != new_value:
+			highlighting_attribute_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_string_color := Color("a1ffe0"):
+	set(new_value):
+		if highlighting_string_color != new_value:
+			highlighting_string_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_comment_color := Color("cdcfd280"):
+	set(new_value):
+		if highlighting_comment_color != new_value:
+			highlighting_comment_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_text_color := Color("cdcfeaac"):
+	set(new_value):
+		if highlighting_text_color != new_value:
+			highlighting_text_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_cdata_color := Color("ffeda1ac"):
+	set(new_value):
+		if highlighting_cdata_color != new_value:
+			highlighting_cdata_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var highlighting_error_color := Color("ff866b"):
+	set(new_value):
+		if highlighting_error_color != new_value:
+			highlighting_error_color = new_value
+			emit_changed()
+			Configs.highlighting_colors_changed.emit()
+
+@export var handle_inner_color := Color("fff"):
+	set(new_value):
+		if handle_inner_color != new_value:
+			handle_inner_color = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var handle_color := Color("111"):
+	set(new_value):
+		if handle_color != new_value:
+			handle_color = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var handle_hovered_color := Color("aaa"):
+	set(new_value):
+		if handle_hovered_color != new_value:
+			handle_hovered_color = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var handle_selected_color := Color("46f"):
+	set(new_value):
+		if handle_selected_color != new_value:
+			handle_selected_color = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var handle_hovered_selected_color := Color("f44"):
+	set(new_value):
+		if handle_hovered_selected_color != new_value:
+			handle_hovered_selected_color = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var background_color := Color(0.12, 0.132, 0.2, 1):
+	set(new_value):
+		if background_color != new_value:
+			background_color = new_value
+			emit_changed()
+			Configs.change_background_color.call_deferred()
+
+@export var basic_color_valid := Color("9f9"):
+	set(new_value):
+		if basic_color_valid != new_value:
+			basic_color_valid = new_value
+			emit_changed()
+			Configs.basic_colors_changed.emit()
+
+@export var basic_color_error := Color("f99"):
+	set(new_value):
+		if basic_color_error != new_value:
+			basic_color_error = new_value
+			emit_changed()
+			Configs.basic_colors_changed.emit()
+
+@export var basic_color_warning := Color("ee5"):
+	set(new_value):
+		if basic_color_warning != new_value:
+			basic_color_warning = new_value
+			emit_changed()
+			Configs.basic_colors_changed.emit()
+
 
 # Other
-@export var invert_zoom := false
-@export var wrap_mouse := false
-@export var use_ctrl_for_zoom := true
-@export var use_native_file_dialog := true
-@export var use_filename_for_window_title := true
-@export var handle_size := 1.0
-@export var ui_scale := 1.0
-@export var auto_ui_scale := true
+@export var invert_zoom := false:
+	set(new_value):
+		if invert_zoom != new_value:
+			invert_zoom = new_value
+			emit_changed()
+
+@export var wrap_mouse := false:
+	set(new_value):
+		if wrap_mouse != new_value:
+			wrap_mouse = new_value
+			emit_changed()
+
+@export var use_ctrl_for_zoom := true:
+	set(new_value):
+		if use_ctrl_for_zoom != new_value:
+			use_ctrl_for_zoom = new_value
+			emit_changed()
+
+@export var use_native_file_dialog := true:
+	set(new_value):
+		if use_native_file_dialog != new_value:
+			use_native_file_dialog = new_value
+			emit_changed()
+
+@export var use_filename_for_window_title := true:
+	set(new_value):
+		if use_filename_for_window_title != new_value:
+			use_filename_for_window_title = new_value
+			emit_changed()
+			Configs.update_window_title.call_deferred()
+
+@export var handle_size := 1.0:
+	set(new_value):
+		if handle_size != new_value:
+			handle_size = new_value
+			emit_changed()
+			Configs.handle_visuals_changed.emit()
+
+@export var ui_scale := 1.0:
+	set(new_value):
+		if ui_scale != new_value:
+			ui_scale = new_value
+			emit_changed()
+			Configs.ui_scale_changed.emit()
+
+@export var auto_ui_scale := true:
+	set(new_value):
+		if auto_ui_scale != new_value:
+			auto_ui_scale = new_value
+			emit_changed()
+			Configs.ui_scale_changed.emit()
+
 
 # Session
-@export var snap := -0.5  # Negative when disabled.
-@export var color_picker_slider_mode := GoodColorPicker.SliderMode.RGB
-@export var path_command_relative := false
-@export var file_dialog_show_hidden := false
-@export var last_used_dir := ""
-@export var current_file_path := ""
+@export var snap := -0.5:  # Negative when disabled.
+	set(new_value):
+		if snap != new_value:
+			snap = new_value
+			emit_changed()
+			Configs.snap_changed.emit()
 
-@export var shortcuts := {}
-@export var palettes: Array[ColorPalette] = []
-@export var editor_formatter: Formatter = null
-@export var export_formatter: Formatter = null
+@export var color_picker_slider_mode := GoodColorPicker.SliderMode.RGB:
+	set(new_value):
+		if color_picker_slider_mode != new_value:
+			color_picker_slider_mode = new_value
+			emit_changed()
 
-# Shortcut Panel
-@export var active_shortcuts: Dictionary = {
-	0: "undo",
-	1: "redo",
-}
-@export var vertical_panel := false
-@export var lock_panel_position := false
+@export var path_command_relative := false:
+	set(new_value):
+		if path_command_relative != new_value:
+			path_command_relative = new_value
+			emit_changed()
+
+@export var file_dialog_show_hidden := false:
+	set(new_value):
+		if file_dialog_show_hidden != new_value:
+			file_dialog_show_hidden = new_value
+			emit_changed()
+
+@export var current_file_path := "":
+	set(new_value):
+		if current_file_path != new_value:
+			current_file_path = new_value
+			emit_changed()
+			Configs.update_window_title.call_deferred()
+			Configs.file_path_changed.emit()
+
+
+const MAX_RECENT_DIRS = 5
+@export var _recent_dirs := PackedStringArray():
+	set(new_value):
+		if _recent_dirs != new_value:
+			_recent_dirs = new_value
+			_validate_recent_dirs()
+			emit_changed()
+
+func _validate_recent_dirs() -> void:
+	var unique_dirs := PackedStringArray()
+	# Remove duplicate dirs.
+	for dir in _recent_dirs:
+		if not dir in unique_dirs:
+			unique_dirs.append(dir)
+	# Remove non-existent dirs.
+	for i in range(unique_dirs.size() - 1, -1, -1):
+		if not DirAccess.dir_exists_absolute(unique_dirs[i]):
+			_recent_dirs.remove_at(i)
+	# Remove dirs above the maximum.
+	if unique_dirs.size() > MAX_RECENT_DIRS:
+		unique_dirs.resize(MAX_RECENT_DIRS)
+	_recent_dirs = unique_dirs
+
+func get_recent_dirs() -> PackedStringArray:
+	_validate_recent_dirs()
+	return _recent_dirs
+
+func get_last_dir() -> String:
+	_validate_recent_dirs()
+	if _recent_dirs.is_empty() or not DirAccess.dir_exists_absolute(_recent_dirs[0]):
+		return OS.get_system_dir(OS.SYSTEM_DIR_PICTURES)
+	else:
+		return _recent_dirs[0]
+
+func add_recent_dir(dir: String) -> void:
+	_validate_recent_dirs()
+	# Remove occurrences of this dir in the array.
+	for i in range(_recent_dirs.size() - 1, -1, -1):
+		if _recent_dirs[i] == dir:
+			_recent_dirs.remove_at(i)
+	# Add the new dir at the start of the array.
+	_recent_dirs.resize(MAX_RECENT_DIRS - 1)
+	_recent_dirs = PackedStringArray([dir]) + _recent_dirs
+
+
+@export var _shortcuts := {}:
+	set(new_value):
+		if _shortcuts != new_value:
+			_shortcuts = new_value
+			for action in _shortcuts:
+				_action_sync_inputmap(action)
+			update_shortcut_validities()
+			emit_changed()
+			Configs.shortcuts_changed.emit()
+
+func action_has_shortcuts(action: String) -> bool:
+	return _shortcuts.has(action)
+
+func action_get_shortcuts(action: String) -> Array[InputEvent]:
+	if action_has_shortcuts(action):
+		return _shortcuts[action]
+	else:
+		return Configs.default_shortcuts[action]
+
+func action_modify_shortcuts(action: String, new_events: Array[InputEvent]) -> void:
+	if new_events != Configs.default_shortcuts[action]:
+		_shortcuts[action] = new_events
+	else:
+		_shortcuts.erase(action)
+	_action_sync_inputmap(action)
+	update_shortcut_validities()
+	emit_changed()
+	Configs.shortcuts_changed.emit()
+
+func _action_sync_inputmap(action: String) -> void:
+	InputMap.action_erase_events(action)
+	for event in action_get_shortcuts(action):
+		InputMap.action_add_event(action, event)
+
+func update_shortcut_validities() -> void:
+	_shortcut_validities.clear()
+	for action in ShortcutUtils.get_all_shortcuts():
+		for shortcut: InputEventKey in InputMap.action_get_events(action):
+			var shortcut_id := shortcut.get_keycode_with_modifiers()
+			# If the key already exists, set validity to false, otherwise set to true.
+			_shortcut_validities[shortcut_id] = not shortcut_id in _shortcut_validities
+
+func is_shortcut_valid(shortcut: InputEvent) -> bool:
+	var shortcut_id = shortcut.get_keycode_with_modifiers()
+	if not shortcut_id in _shortcut_validities:
+		return true
+	return _shortcut_validities[shortcut_id]
+
+func get_actions_with_shortcut(shortcut: InputEvent) -> PackedStringArray:
+	var shortcut_id = shortcut.get_keycode_with_modifiers()
+	if not shortcut_id in _shortcut_validities:
+		return PackedStringArray()
+	elif _shortcut_validities[shortcut_id]:
+		return PackedStringArray()
+	
+	var actions_with_shortcut := PackedStringArray()
+	for action in ShortcutUtils.get_all_shortcuts():
+		for action_shortcut: InputEventKey in InputMap.action_get_events(action):
+			if action_shortcut.get_keycode_with_modifiers() == shortcut_id:
+				actions_with_shortcut.append(action)
+				break
+	return actions_with_shortcut
+
+
+@export var _palettes: Array[ColorPalette] = []:
+	set(new_value):
+		if _palettes != new_value:
+			_palettes = new_value
+			_update_palette_validities()
+			emit_changed()
+			for palette in _palettes:
+				palette.changed.connect(emit_changed)
+
+# Mark invalid palettes, rather than removing them.
+func _update_palette_validities() -> void:
+	_palette_validities.clear()
+	for palette in _palettes:
+		if not palette.title.is_empty():
+			_palette_validities[palette.title] = not palette.title in _palette_validities
+
+func is_palette_valid(checked_palette: ColorPalette) -> bool:
+	if checked_palette.title.is_empty():
+		return false
+	if not checked_palette.title in _palette_validities:
+		return true
+	return _palette_validities[checked_palette.title]
+
+func is_palette_title_unused(checked_title: String) -> bool:
+	for palette in _palettes:
+		if palette.title == checked_title:
+			return false
+	return true
+
+func add_palette(new_palette: ColorPalette) -> void:
+	_palettes.append(new_palette)
+	new_palette.changed.connect(emit_changed)
+	_update_palette_validities()
+	emit_changed()
+
+func delete_palette(idx: int) -> void:
+	if _palettes.size() <= idx:
+		return
+	_palettes.remove_at(idx)
+	_update_palette_validities()
+	emit_changed()
+
+func rename_palette(idx: int, new_name: String) -> void:
+	if _palettes.size() <= idx:
+		return
+	_palettes[idx].title = new_name
+	_update_palette_validities()
+	emit_changed()
+
+func replace_palette(idx: int, new_palette: ColorPalette) -> void:
+	if _palettes.size() <= idx:
+		return
+	_palettes[idx] = new_palette
+	_update_palette_validities()
+	emit_changed()
+
+func move_palette_up(idx: int) -> void:
+	var palette: ColorPalette = _palettes.pop_at(idx)
+	_palettes.insert(idx - 1, palette)
+	emit_changed()
+
+func move_palette_down(idx: int) -> void:
+	var palette: ColorPalette = _palettes.pop_at(idx)
+	_palettes.insert(idx + 1, palette)
+	emit_changed()
+
+func get_palettes() -> Array[ColorPalette]:
+	return _palettes
+
+func get_palette_count() -> int:
+	return _palettes.size()
+
+func get_palette(idx: int) -> ColorPalette:
+	return _palettes[idx]
+
+func set_palettes(new_palettes: Array[ColorPalette]) -> void:
+	_palettes = new_palettes
+	emit_changed()
+
+
+@export var editor_formatter: Formatter = null:
+	set(new_value):
+		if editor_formatter != new_value and is_instance_valid(new_value):
+			editor_formatter = new_value
+			emit_changed()
+			editor_formatter.changed.connect(emit_changed)
+			editor_formatter.changed_deferred.connect(SVG.sync_elements)
+
+@export var export_formatter: Formatter = null:
+	set(new_value):
+		if export_formatter != new_value and is_instance_valid(new_value):
+			export_formatter = new_value
+			emit_changed()
+			export_formatter.changed.connect(emit_changed)
+
+
+const SHORTCUT_PANEL_MAX_PRESENTED_SHORTCUTS = 5
+@export var _shortcut_panel_presented_shortcuts := {}:  # Dictionary{int: String}
+	set(new_value):
+		if _shortcut_panel_presented_shortcuts != new_value:
+			_shortcut_panel_presented_shortcuts = new_value
+			_validate_shortcut_panel_presented_shortcuts()
+			emit_changed()
+
+# Remove invalid shortcuts.
+func _validate_shortcut_panel_presented_shortcuts() -> void:
+	for key in _shortcut_panel_presented_shortcuts:
+		if key < 0 or key >= SHORTCUT_PANEL_MAX_PRESENTED_SHORTCUTS or\
+		not _shortcut_panel_presented_shortcuts[key] in ShortcutUtils.get_all_shortcuts():
+			_shortcut_panel_presented_shortcuts.erase(key)
+
+func get_shortcut_panel_presented_shortcuts() -> Dictionary:
+	return _shortcut_panel_presented_shortcuts
+
+func get_shortcut_panel_presented_shortcut(idx: int) -> String:
+	return _shortcut_panel_presented_shortcuts.get(idx, "")
+
+func set_shortcut_panel_presented_shortcuts(shortcuts: Dictionary) -> void:
+	_shortcut_panel_presented_shortcuts = shortcuts
+
+
+# Utility
+
+func get_validity_color(error_condition: bool, warning_condition := false) -> Color:
+	return basic_color_error if error_condition else\
+			basic_color_warning if warning_condition else basic_color_valid

--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -261,6 +261,8 @@ func duplicate(include_children := true) -> Element:
 	var new_element: Element
 	if type == ElementUnrecognized:
 		new_element = ElementUnrecognized.new(self.name)
+	elif type == ElementRoot:
+		new_element = ElementRoot.new(self.formatter)
 	else:
 		new_element = type.new()
 	

--- a/src/data_classes/ElementRoot.gd
+++ b/src/data_classes/ElementRoot.gd
@@ -16,7 +16,7 @@ signal basic_xnode_rendered_text_changed(xid: PackedInt32Array)
 
 var formatter: Formatter
 
-func _init(new_formatter: Formatter = Configs.savedata.editor_formatter) -> void:
+func _init(new_formatter: Formatter) -> void:
 	super()
 	xid = PackedInt32Array()
 	root = self

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -209,11 +209,11 @@ func set_snap_amount(snap_value: float) -> void:
 	snapper.set_value(snap_value)
 
 func _on_snap_button_toggled(toggled_on: bool) -> void:
-	Configs.modify_setting("snap", absf(Configs.savedata.snap) if toggled_on\
-			else -absf(Configs.savedata.snap))
+	Configs.savedata.snap = absf(Configs.savedata.snap) if toggled_on\
+			else -absf(Configs.savedata.snap)
 
 func _on_snap_number_edit_value_changed(new_value: float) -> void:
-	Configs.modify_setting("snap", new_value * signf(Configs.savedata.snap))
+	Configs.snap = new_value * signf(Configs.savedata.snap)
 
 # The strings here are intentionally not localized.
 func update_debug() -> void:

--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -362,7 +362,7 @@ func _on_drives_list_item_selected(index: int) -> void:
 	call_selection_callback(drives_list.get_item_metadata(index))
 
 func _on_show_hidden_button_toggled(toggled_on: bool) -> void:
-	Configs.modify_setting("file_dialog_show_hidden", toggled_on)
+	Configs.savedata.file_dialog_show_hidden = toggled_on
 	refresh_dir()
 
 func _on_search_button_toggled(toggled_on: bool) -> void:
@@ -406,7 +406,7 @@ func _on_file_field_text_changed(new_text: String) -> void:
 		special_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	
 	file_field.add_theme_color_override("font_color",
-			Utils.get_validity_color(is_invalid_filename))
+			Configs.savedata.get_validity_color(is_invalid_filename))
 
 func _on_file_field_text_change_canceled() -> void:
 	file_field.remove_theme_color_override("font_color")

--- a/src/ui_parts/shortcut_panel.gd
+++ b/src/ui_parts/shortcut_panel.gd
@@ -27,7 +27,7 @@ func update() -> void:
 		child.queue_free()
 	
 	for i in range(5):
-		var shortcut: String = Configs.savedata.active_shortcuts.get(i, "")
+		var shortcut := Configs.savedata.get_shortcut_panel_presented_shortcut(i)
 		if not shortcut.is_empty():
 			add_new_shortcut(shortcut)
 	panel_container.reset_size()

--- a/src/ui_parts/shortcut_panel_config.gd
+++ b/src/ui_parts/shortcut_panel_config.gd
@@ -11,9 +11,12 @@ func _ready() -> void:
 	%LockPanelPosition.text = Translator.translate("Lock panel position")
 	%CloseButton.text = Translator.translate("Close")
 	%CloseButton.grab_focus()
-	%VerticalPanel.button_pressed = Configs.savedata.vertical_panel
-	%LockPanelPosition.button_pressed = Configs.savedata.lock_panel_position
 	setup_shortcut_slots()
+	# TODO Implement these properly when more configs are implemented.
+	%VerticalPanel.queue_free()
+	%LockPanelPosition.queue_free()
+	#%VerticalPanel.button_pressed = Configs.savedata.vertical_panel
+	#%LockPanelPosition.button_pressed = Configs.savedata.lock_panel_position
 
 func setup_shortcut_slots() -> void:
 	for i in range(slots.size()):
@@ -33,8 +36,8 @@ func setup_shortcut_slots() -> void:
 	for slot_dropdown in slots:
 		slot_dropdown.values.append_array(shortcuts)
 	
-	for i in Configs.savedata.active_shortcuts:
-		var s: String = Configs.savedata.active_shortcuts[i]
+	for i in Configs.savedata.get_shortcut_panel_presented_shortcuts():
+		var s: String = Configs.savedata.get_shortcut_panel_presented_shortcut(i)
 		slots[i].set_value(TranslationUtils.get_shortcut_description(s))
 
 
@@ -62,9 +65,6 @@ func update_popup_options() -> void:
 
 
 func _on_close_button_pressed() -> void:
-	Configs.modify_setting("active_shortcuts", selected_shortcuts, true)
-	Configs.modify_setting("vertical_panel", %VerticalPanel.button_pressed, true)
-	Configs.modify_setting("lock_panel_position", %LockPanelPosition.button_pressed, true)
-	Configs.save()
+	Configs.savedata.set_shortcut_panel_presented_shortcuts(selected_shortcuts)
 	HandlerGUI.shortcut_panel.update()
 	get_parent().queue_free()

--- a/src/ui_widgets/basic_xnode_frame.gd
+++ b/src/ui_widgets/basic_xnode_frame.gd
@@ -140,7 +140,8 @@ func _draw() -> void:
 			are_all_children_valid = false
 			break
 	
-	var drop_border_color := Utils.get_validity_color(false, not are_all_children_valid)
+	var drop_border_color := Configs.savedata.get_validity_color(false,
+			not are_all_children_valid)
 	drop_border_color.s = lerpf(drop_border_color.s, 1.0, 0.5)
 	drop_sb.border_color = drop_border_color
 	if drop_xid == parent_xid + PackedInt32Array([xnode.xid[-1]]):

--- a/src/ui_widgets/color_edit.gd
+++ b/src/ui_widgets/color_edit.gd
@@ -51,7 +51,7 @@ func _on_pressed() -> void:
 	color_picker.color_picked.connect(_on_color_picked)
 
 func _on_text_changed(new_text: String) -> void:
-	font_color = Utils.get_validity_color(!is_color_valid_non_url(new_text))
+	font_color = Configs.savedata.get_validity_color(!is_color_valid_non_url(new_text))
 
 func _draw() -> void:
 	super()

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -138,7 +138,7 @@ func is_valid(color_text: String) -> bool:
 
 
 func _on_text_changed(new_text: String) -> void:
-	font_color = Utils.get_validity_color(!is_valid(new_text))
+	font_color = Configs.savedata.get_validity_color(!is_valid(new_text))
 
 func resync() -> void:
 	sync(text)

--- a/src/ui_widgets/color_popup.gd
+++ b/src/ui_widgets/color_popup.gd
@@ -60,20 +60,19 @@ func update_palettes(search_text := "") -> void:
 				elif element is ElementRadialGradient:
 					reserved_color_names.append("Radial gradient")
 					reserved_colors.append("url(#%s)" % element.get_attribute_value("id"))
-	var reserved_color_palette := ColorPalette.new()
-	reserved_color_palette.colors = reserved_colors
-	reserved_color_palette.color_names = reserved_color_names
+	var reserved_palette := ColorPalette.new()
+	reserved_palette.setup(reserved_colors, reserved_color_names)
 	
-	var displayed_palettes: Array[ColorPalette] = [reserved_color_palette]
-	for palette in Configs.savedata.palettes:
-		if Configs.is_palette_valid(palette):
+	var displayed_palettes: Array[ColorPalette] = [reserved_palette]
+	for palette in Configs.savedata.get_palettes():
+		if Configs.savedata.is_palette_valid(palette):
 			displayed_palettes.append(palette)
 	
 	for palette in displayed_palettes:
 		var indices_to_show := PackedInt32Array()
-		for i in palette.colors.size():
+		for i in palette.get_color_count():
 			if search_text.is_empty() or\
-			search_text.is_subsequence_ofn(palette.color_names[i]):
+			search_text.is_subsequence_ofn(palette.get_color_name(i)):
 				indices_to_show.append(i)
 		
 		if indices_to_show.is_empty():
@@ -92,8 +91,8 @@ func update_palettes(search_text := "") -> void:
 		swatch_container.add_theme_constant_override("h_separation", 3)
 		for i in indices_to_show:
 			var swatch := ColorSwatch.instantiate()
-			var color_to_show := palette.colors[i]
-			swatch.color_palette = palette
+			var color_to_show := palette.get_color(i)
+			swatch.palette = palette
 			swatch.idx = i
 			swatch.pressed.connect(pick_palette_color.bind(color_to_show))
 			swatch_container.add_child(swatch)

--- a/src/ui_widgets/color_swatch.gd
+++ b/src/ui_widgets/color_swatch.gd
@@ -4,7 +4,7 @@ const bounds = Vector2(2, 2)
 
 const checkerboard = preload("res://visual/icons/backgrounds/Checkerboard.svg")
 
-var color_palette: ColorPalette
+var palette: ColorPalette
 var idx := -1  # Index inside the palette.
 
 var ci := get_canvas_item()
@@ -12,8 +12,8 @@ var gradient_texture: GradientTexture2D
 
 func _ready() -> void:
 	tooltip_text = "lmofa"  # TODO: _make_custom_tooltip() requires some text to work.
-	# TODO remove this when #94584 is fixed.
-	var color := color_palette.colors[idx]
+	# TODO remove this when #25296 is fixed.
+	var color := palette.get_color(idx)
 	if ColorParser.is_valid_url(color):
 		var id := color.substr(5, color.length() - 6)
 		var gradient_element := SVG.root_element.get_element_by_id(id)
@@ -21,7 +21,7 @@ func _ready() -> void:
 			gradient_texture = gradient_element.generate_texture()
 
 func _draw() -> void:
-	var color := color_palette.colors[idx]
+	var color := palette.get_color(idx)
 	var inside_rect := Rect2(bounds, size - bounds * 2)
 	if ColorParser.is_valid_url(color):
 		checkerboard.draw_rect(ci, inside_rect, false)
@@ -43,10 +43,10 @@ func _make_custom_tooltip(_for_text: String) -> Object:
 	rtl.bbcode_enabled = true
 	rtl.add_theme_font_override("mono_font", ThemeUtils.mono_font)
 	# Set up the text.
-	var color_name := color_palette.color_names[idx]
+	var color_name := palette.get_color_name(idx)
 	if not color_name.is_empty():
 		rtl.add_text(color_name)
 		rtl.newline()
 	rtl.push_mono()
-	rtl.add_text(color_palette.colors[idx])
+	rtl.add_text(palette.get_color(idx))
 	return rtl

--- a/src/ui_widgets/configure_color_popup.gd
+++ b/src/ui_widgets/configure_color_popup.gd
@@ -8,13 +8,13 @@ signal color_deletion_requested
 @onready var delete_button: Button = %ConfigureContainer/BottomContainer/DeleteButton
 @onready var label_container: HBoxContainer = %LabelContainer
 
-var color_palette: ColorPalette
+var palette: ColorPalette
 var idx: int
 
 func _ready() -> void:
 	Configs.language_changed.connect(update_translation)
-	set_label_text(color_palette.color_names[idx])
-	color_edit.value = color_palette.colors[idx]
+	set_label_text(palette.get_color_name(idx))
+	color_edit.value = palette.get_color(idx)
 	update_translation()
 	color_name_edit.text_submitted.connect(_on_name_edit_text_submitted)
 	color_name_edit.text_change_canceled.connect(hide_name_edit)
@@ -27,7 +27,7 @@ func update_translation() -> void:
 			Translator.translate("Delete color")
 
 func _on_edit_button_pressed() -> void:
-	color_name_edit.text = color_palette.color_names[idx]
+	color_name_edit.text = palette.get_color_name(idx)
 	color_name_edit.show()
 	color_name_edit.grab_focus()
 	color_name_edit.caret_column = color_name_edit.text.length()

--- a/src/ui_widgets/dropdown.gd
+++ b/src/ui_widgets/dropdown.gd
@@ -60,4 +60,4 @@ func _on_text_submitted(new_text: String) -> void:
 func _on_text_changed(new_text: String) -> void:
 	if restricted:
 		line_edit.add_theme_color_override("font_color",
-				Utils.get_validity_color(not new_text in values))
+				Configs.savedata.get_validity_color(not new_text in values))

--- a/src/ui_widgets/element_frame.gd
+++ b/src/ui_widgets/element_frame.gd
@@ -219,7 +219,8 @@ func _draw() -> void:
 			are_all_children_valid = false
 			break
 	
-	var drop_border_color := Utils.get_validity_color(false, not are_all_children_valid)
+	var drop_border_color := Configs.savedata.get_validity_color(false,
+			not are_all_children_valid)
 	drop_border_color.s = lerpf(drop_border_color.s, 1.0, 0.5)
 	drop_sb.border_color = drop_border_color
 	if drop_xid == parent_xid + PackedInt32Array([element.xid[-1]]):

--- a/src/ui_widgets/enum_field.gd
+++ b/src/ui_widgets/enum_field.gd
@@ -73,7 +73,7 @@ func _on_text_submitted(new_text: String) -> void:
 
 
 func _on_text_changed(new_text: String) -> void:
-	font_color = Utils.get_validity_color(
+	font_color = Configs.savedata.get_validity_color(
 			not new_text in DB.attribute_enum_values[attribute_name])
 
 func resync() -> void:

--- a/src/ui_widgets/good_color_picker.gd
+++ b/src/ui_widgets/good_color_picker.gd
@@ -341,7 +341,7 @@ func _on_hsv_pressed() -> void:
 
 func change_slider_mode(new_slider_mode: SliderMode) -> void:
 	slider_mode = new_slider_mode
-	Configs.modify_setting("color_picker_slider_mode", new_slider_mode)
+	Configs.savedata.color_picker_slider_mode = new_slider_mode
 
 
 # Gray out the start color rect if it's not actually a color.

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -40,7 +40,7 @@ func _on_text_submitted(new_text: String) -> void:
 
 func _on_text_changed(new_text: String) -> void:
 	var validity_level := AttributeID.get_validity(new_text)
-	var font_color := Utils.get_validity_color(
+	var font_color := Configs.savedata.get_validity_color(
 			validity_level == AttributeID.ValidityLevel.INVALID,
 			validity_level == AttributeID.ValidityLevel.INVALID_XML_NAMETOKEN)
 	add_theme_color_override("font_color", font_color)

--- a/src/ui_widgets/number_dropdown.gd
+++ b/src/ui_widgets/number_dropdown.gd
@@ -54,4 +54,4 @@ func _on_text_submitted(new_text: String) -> void:
 func _on_text_changed(new_text: String) -> void:
 	if restricted:
 		line_edit.add_theme_color_override("font_color",
-				Utils.get_validity_color(not new_text.to_float() in values))
+				Configs.savedata.get_validity_color(not new_text.to_float() in values))

--- a/src/ui_widgets/path_popup.gd
+++ b/src/ui_widgets/path_popup.gd
@@ -19,7 +19,7 @@ func emit_picked(cmd_char: String) -> void:
 	queue_free()
 
 func _on_relative_toggle_toggled(toggled_on: bool) -> void:
-	Configs.modify_setting("path_command_relative", toggled_on)
+	Configs.savedata.path_command_relative = toggled_on
 	for command_button in command_container.get_children():
 		command_button.command_char = command_button.command_char.to_lower() if toggled_on\
 				else command_button.command_char.to_upper()

--- a/src/ui_widgets/presented_shortcut.gd
+++ b/src/ui_widgets/presented_shortcut.gd
@@ -33,10 +33,10 @@ func check_shortcuts_validity() -> void:
 	var events := InputMap.action_get_events(action)
 	for i in events.size():
 		var shortcut_btn := shortcut_container.get_child(i)
-		if not Configs.is_shortcut_valid(events[i]):
+		if not Configs.savedata.is_shortcut_valid(events[i]):
 			var error_color := Color(Configs.savedata.basic_color_error, 0.8)
 			shortcut_btn.add_theme_color_override("font_disabled_color", error_color)
-			var conflicts := Configs.get_actions_with_shortcut(events[i])
+			var conflicts := Configs.savedata.get_actions_with_shortcut(events[i])
 			var action_pos := conflicts.find(action)
 			if action_pos != -1:
 				conflicts.remove_at(action_pos)

--- a/src/ui_widgets/setting_shortcut.gd
+++ b/src/ui_widgets/setting_shortcut.gd
@@ -127,7 +127,7 @@ func delete_shortcut(idx: int) -> void:
 	sync()
 
 func update_shortcut() -> void:
-	Configs.modify_shortcut(action, events)
+	Configs.savedata.action_modify_shortcuts(action, events)
 
 func _input(event: InputEvent) -> void:
 	if not (listening_idx >= 0 and event is InputEventKey):
@@ -191,10 +191,10 @@ func set_shortcut_button_text(button: Button, new_text: String) -> void:
 func check_shortcuts_validity() -> void:
 	for i in events.size():
 		var shortcut_btn := shortcut_buttons[i]
-		if not Configs.is_shortcut_valid(events[i]):
+		if not Configs.savedata.is_shortcut_valid(events[i]):
 			setup_shortcut_button_font_colors(shortcut_btn,
 					Configs.savedata.basic_color_error)
-			var conflicts := Configs.get_actions_with_shortcut(events[i])
+			var conflicts := Configs.savedata.get_actions_with_shortcut(events[i])
 			var action_pos := conflicts.find(action)
 			if action_pos != -1:
 				conflicts.remove_at(action_pos)

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -81,7 +81,7 @@ static func fn(shortcut: String) -> Callable:
 		"copy_svg_text": return DisplayServer.clipboard_set.bind(SVG.text)
 		"clear_svg": return SVG.apply_svg_text.bind(SVG.DEFAULT)
 		"optimize": return SVG.optimize
-		"clear_file_path": return Configs.modify_setting.bind("current_file_path", "")
+		"clear_file_path": return Configs.savedata.set.bind("current_file_path", "")
 		"reset_svg": return FileUtils.apply_svg_from_path.bind(
 				Configs.savedata.current_file_path)
 		"open_svg": return FileUtils.open_svg.bind(Configs.savedata.current_file_path)
@@ -146,4 +146,4 @@ static func is_action_pressed(event: InputEvent, action: String) -> bool:
 	# is the correct one... But it should be handled gracefully.
 	if event is InputEventAction:
 		event = InputMap.action_get_events(event.action)[event.event_index]
-	return event.is_action_pressed(action) and Configs.is_shortcut_valid(event)
+	return event.is_action_pressed(action) and Configs.savedata.is_shortcut_valid(event)

--- a/src/utils/Utils.gd
+++ b/src/utils/Utils.gd
@@ -101,19 +101,6 @@ static func throw_mouse_motion_event() -> void:
 	Input.call_deferred("parse_input_event", mouse_motion_event)
 
 
-static func get_last_dir() -> String:
-	if Configs.savedata.last_used_dir.is_empty() or\
-	not DirAccess.dir_exists_absolute(Configs.savedata.last_used_dir):
-		return OS.get_system_dir(OS.SYSTEM_DIR_PICTURES)
-	else:
-		return Configs.savedata.last_used_dir
-
-static func get_validity_color(error_condition: bool, warning_condition := false) -> Color:
-	return Configs.savedata.basic_color_error if error_condition else\
-			Configs.savedata.basic_color_warning if warning_condition else\
-			Configs.savedata.basic_color_valid
-
-
 static func generate_gradient(element: Element) -> Gradient:
 	if not (element is ElementLinearGradient or element is ElementRadialGradient):
 		return null

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: GodSVG\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2024-12-30 11:19+0200\n"
-"Last-Translator: volkov <volkovissocool@gmail.com>\n"
+"Last-Translator: volkov\n"
 "Language-Team: \n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
@@ -15,7 +15,7 @@ msgstr ""
 
 msgid "translation-credits"
 msgstr ""
-"volkov <volkovissocool@gmail.com>, Gallifreyan <gallifreyan@protonmail.ch>"
+"volkov, Gallifreyan <gallifreyan@protonmail.ch>"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Quit GodSVG"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: GodSVG\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: volkov <volkovissocool@gmail.com>\n"
+"Last-Translator: volkov\n"
 "Language-Team: \n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
@@ -13,7 +13,7 @@ msgstr ""
 "X-Generator: Poedit 3.5\n"
 
 msgid "translation-credits"
-msgstr "volkov <volkovissocool@gmail.com>"
+msgstr "volkov"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Quit GodSVG"


### PR DESCRIPTION
Cleans up the system around SaveData.

- Implements ConfigResource class which implements the useful `changed_deferred` signal. This signal is used in situations where the many times `changed` can run aren't necessary, and prevents us from instead needing to implement queueing in many different places.

- Moves SaveData operations from the Configs singleton to the resource itself. Setters in SaveData now emit the singleton signals and call modification callbacks, meaning that things should be modified directly in the SaveData now.

- Some exported properties in the config resources are now private and can only be interacted with through methods.

- Shortcuts are now an empty dictionary, only modifications are stored. Logic is changed to work around that.

- Validations now also happen within SaveData. All settings with defaults are reset in reset_config(), as well as other initial settings. There is universal validation of the editor and export formatters, as a savefile not having them would make GodSVG impossible to use.

- Recent dirs are now an array with 5 elements, which will later be used for the custom file dialog and possibly other things.