### PR TITLE
Improve precision of generic transforms

### DIFF
--- a/src/data_classes/AttributeTransformList.gd
+++ b/src/data_classes/AttributeTransformList.gd
@@ -2,12 +2,18 @@
 class_name AttributeTransformList extends Attribute
 
 var _transform_list: Array[Transform] = []
+
+# Automatically updated with the precise transform.
 var _final_transform := Transform2D.IDENTITY
-var _final_precise_transform := PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+
+var _final_precise_transform := PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]):
+	set(new_value):
+		_final_precise_transform = new_value
+		_final_transform = Utils64Bit.get_transform(_final_precise_transform)
+
 
 func _sync() -> void:
 	_transform_list = text_to_transform_list(get_value())
-	_final_transform = compute_final_transform(_transform_list)
 	_final_precise_transform = compute_final_precise_transform(_transform_list)
 
 func sync_after_transforms_change() -> void:
@@ -18,7 +24,6 @@ func format(text: String) -> String:
 
 func set_transform_list(new_transform_list: Array[Transform]) -> void:
 	_transform_list = new_transform_list
-	_final_transform = compute_final_transform(new_transform_list)
 	_final_precise_transform = compute_final_precise_transform(new_transform_list)
 	set_value(transform_list_to_text(new_transform_list))
 
@@ -42,12 +47,6 @@ func get_final_transform() -> Transform2D:
 func get_final_precise_transform() -> PackedFloat64Array:
 	return _final_precise_transform
 
-
-static func compute_final_transform(transform_list: Array[Transform]) -> Transform2D:
-	var final_transform := Transform2D.IDENTITY
-	for t in transform_list:
-		final_transform *= t.compute_transform()
-	return final_transform
 
 static func compute_final_precise_transform(
 transform_list: Array[Transform]) -> PackedFloat64Array:

--- a/src/data_classes/ElementCircle.gd
+++ b/src/data_classes/ElementCircle.gd
@@ -1,4 +1,4 @@
-# A <circle/> element.
+# A <circle> element.
 class_name ElementCircle extends Element
 
 const name = "circle"

--- a/src/data_classes/ElementEllipse.gd
+++ b/src/data_classes/ElementEllipse.gd
@@ -1,4 +1,4 @@
-# An <ellipse/> element.
+# An <ellipse> element.
 class_name ElementEllipse extends Element
 
 const name = "ellipse"

--- a/src/data_classes/ElementG.gd
+++ b/src/data_classes/ElementG.gd
@@ -1,3 +1,4 @@
+# A <g> element.
 class_name ElementG extends Element
 
 const name = "g"

--- a/src/data_classes/ElementLine.gd
+++ b/src/data_classes/ElementLine.gd
@@ -1,4 +1,4 @@
-# A <line/> element.
+# A <line> element.
 class_name ElementLine extends Element
 
 const name = "line"

--- a/src/data_classes/ElementLinearGradient.gd
+++ b/src/data_classes/ElementLinearGradient.gd
@@ -1,3 +1,4 @@
+# A <linearGradient> element.
 class_name ElementLinearGradient extends Element
 
 const name = "linearGradient"

--- a/src/data_classes/ElementPath.gd
+++ b/src/data_classes/ElementPath.gd
@@ -1,4 +1,4 @@
-# A <path/> element.
+# A <path> element.
 class_name ElementPath extends Element
 
 const name = "path"

--- a/src/data_classes/ElementPolygon.gd
+++ b/src/data_classes/ElementPolygon.gd
@@ -1,4 +1,4 @@
-# A <polygon/> element.
+# A <polygon> element.
 class_name ElementPolygon extends Element
 
 const name = "polygon"

--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -1,4 +1,4 @@
-# A <polyline/> element.
+# A <polyline> element.
 class_name ElementPolyline extends Element
 
 const name = "polyline"

--- a/src/data_classes/ElementRadialGradient.gd
+++ b/src/data_classes/ElementRadialGradient.gd
@@ -1,3 +1,4 @@
+# A <radialGradient> element.
 class_name ElementRadialGradient extends Element
 
 const name = "radialGradient"

--- a/src/data_classes/ElementRect.gd
+++ b/src/data_classes/ElementRect.gd
@@ -1,4 +1,4 @@
-# A <rect/> element.
+# A <rect> element.
 class_name ElementRect extends Element
 
 const name = "rect"

--- a/src/data_classes/ElementStop.gd
+++ b/src/data_classes/ElementStop.gd
@@ -1,4 +1,4 @@
-# A <stop/> element.
+# A <stop> element.
 class_name ElementStop extends Element
 
 const name = "stop"

--- a/src/utils/Utils64Bit.gd
+++ b/src/utils/Utils64Bit.gd
@@ -3,6 +3,13 @@
 # and this class implements the necessary functionality to make them work.
 class_name Utils64Bit extends RefCounted
 
+static func get_vector(vector: PackedFloat64Array) -> Vector2:
+	return Vector2(vector[0], vector[1])
+
+static func get_transform(transform: PackedFloat64Array) -> Transform2D:
+	return Transform2D(Vector2(transform[0], transform[1]),
+			Vector2(transform[2], transform[3]), Vector2(transform[4], transform[5]))
+
 # Vector2 * Transform2D
 static func transform_vector_mult(transform: PackedFloat64Array,
 vector: PackedFloat64Array) -> PackedFloat64Array:


### PR DESCRIPTION
No need to do both calculations now - do only the precise ones, and get a Transform2D from it directly.