### PR TITLE
Add direct support for color attribute and currentColor keyword

### DIFF
--- a/src/data_classes/AttributeTransformList.gd
+++ b/src/data_classes/AttributeTransformList.gd
@@ -2,15 +2,7 @@
 class_name AttributeTransformList extends Attribute
 
 var _transform_list: Array[Transform] = []
-
-# Automatically updated with the precise transform.
-var _final_transform := Transform2D.IDENTITY
-
-var _final_precise_transform := PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0]):
-	set(new_value):
-		_final_precise_transform = new_value
-		_final_transform = Utils64Bit.get_transform(_final_precise_transform)
-
+var _final_precise_transform := PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
 
 func _sync() -> void:
 	_transform_list = text_to_transform_list(get_value())
@@ -40,9 +32,6 @@ func get_transform_count() -> int:
 
 func get_transform(idx: int) -> Transform:
 	return _transform_list[idx]
-
-func get_final_transform() -> Transform2D:
-	return _final_transform
 
 func get_final_precise_transform() -> PackedFloat64Array:
 	return _final_precise_transform

--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -7,9 +7,13 @@ static func add_hash_if_hex(color: String) -> String:
 		color = "#" + color
 	return color
 
-static func is_valid(color: String, allow_alpha := false, allow_url := true) -> bool:
+static func is_valid(color: String, allow_alpha := false, allow_element_context := false,
+allow_url := true) -> bool:
+	if not allow_element_context:
+		allow_url = false
 	return is_valid_hex(color, allow_alpha) or is_valid_rgb(color, allow_alpha) or\
-			is_valid_hsl(color, allow_alpha) or is_valid_named(color, allow_alpha) or\
+			is_valid_hsl(color, allow_alpha) or\
+			is_valid_named(color, allow_alpha, allow_element_context) or\
 			(allow_url and is_valid_url(color))
 
 static func is_valid_hex(color: String, allow_alpha := false) -> bool:
@@ -85,15 +89,16 @@ static func _hsl_check(stripped_color: String) -> bool:
 	return _is_valid_number(channels[0]) and _is_valid_percentage(channels[1]) and\
 			_is_valid_percentage(channels[2])
 
-static func is_valid_named(color: String, enable_alpha := false) -> bool:
+static func is_valid_named(color: String, allow_alpha := false,
+allow_element_context := false) -> bool:
 	color = color.strip_edges()
-	if AttributeColor.named_colors.has(color):
+	if AttributeColor.get_named_colors(allow_alpha).has(color):
 		return true
-	
-	var checked_arr := AttributeColor.special_colors.duplicate()
-	if not enable_alpha:
-		checked_arr.erase("transparent")
-	return color in checked_arr
+	elif color == "none":
+		return true
+	elif allow_element_context and color == "currentColor":
+		return true
+	return false
 
 static func is_valid_url(color: String) -> bool:
 	color = color.strip_edges()
@@ -109,15 +114,11 @@ static func _get_url_id(stripped_color: String) -> String:
 static func text_to_color(color: String, backup := Color.BLACK,
 allow_alpha := false) -> Color:
 	color = color.strip_edges()
-	if is_valid_named(color):
+	if is_valid_named(color, allow_alpha):
 		if color == "none":
 			return Color(0, 0, 0, 0)
-		elif color == "transparent":
-			return Color(0, 0, 0, 0) if allow_alpha else backup
-		elif color == "currentColor":
-			return backup
 		else:
-			return Color(AttributeColor.named_colors[color])
+			return Color(AttributeColor.get_named_colors(allow_alpha)[color])
 	elif is_valid_rgb(color, allow_alpha):
 		var inside_brackets := color.substr(4, color.length() - 5)
 		var args := inside_brackets.split(",", false)
@@ -163,11 +164,10 @@ allow_alpha := false) -> Color:
 static func are_colors_same(col1: String, col2: String) -> bool:
 	col1 = col1.strip_edges()
 	col2 = col2.strip_edges()
-	# Ensure that the two colors aren't the same,
-	# but of a type that can't be represented as hex.
+	# Handle color keywords that can't be represented as hex.
 	if col1 == col2:
 		return true
-	elif col1 in AttributeColor.special_colors or col2 in AttributeColor.special_colors:
+	elif col1 == "none" or col2 == "none":
 		return false
 	else:
 		var is_col1_url := is_valid_url(col1)
@@ -185,8 +185,8 @@ static func are_colors_same(col1: String, col2: String) -> bool:
 			col = text_to_color(col).to_html(false)
 		elif is_valid_hex(col) and col.length() == 4:
 			col = col[1] + col[1] + col[2] + col[2] + col[3] + col[3]
-		elif is_valid_named(col):
-			col = AttributeColor.named_colors[col]
+		elif is_valid_named(col, true):
+			col = AttributeColor.get_named_colors()[col]
 		col = col.trim_prefix("#")
 		# End of conversion logic.
 		if i == 0:

--- a/src/data_classes/DB.gd
+++ b/src/data_classes/DB.gd
@@ -75,7 +75,7 @@ const valid_children = {  # Dictionary{String: Array[String]}
 }
 
 const propagated_attributes = ["fill", "fill-opacity", "stroke", "stroke-opacity",
-		"stroke-width", "stroke-linecap", "stroke-linejoin"]
+		"stroke-width", "stroke-linecap", "stroke-linejoin", "color"]
 
 const attribute_types = {
 	"viewBox": AttributeType.LIST,
@@ -100,6 +100,7 @@ const attribute_types = {
 	"stroke-width": AttributeType.NUMERIC,
 	"stroke-linecap": AttributeType.ENUM,
 	"stroke-linejoin": AttributeType.ENUM,
+	"color": AttributeType.COLOR,
 	"d": AttributeType.PATHDATA,
 	"points": AttributeType.LIST,
 	"transform": AttributeType.TRANSFORM_LIST,

--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -173,6 +173,16 @@ func get_attribute_num(attribute_name: String) -> float:
 				DB.PercentageHandling.NORMALIZED: return svg.normalized_diagonal * num
 	return num
 
+func get_attribute_true_color(attribute_name: String) -> String:
+	if DB.get_attribute_type(attribute_name) != DB.AttributeType.COLOR:
+		push_error("Attribute not the correct type.")
+	var attrib: AttributeColor = _attributes[attribute_name] if\
+			has_attribute(attribute_name) else new_default_attribute(attribute_name)
+	var attrib_value := attrib.get_value()
+	if attrib_value == "currentColor":
+		return get_default("color")
+	return attrib_value
+
 func is_attribute_percentage(attribute_name: String) -> bool:
 	if DB.get_attribute_type(attribute_name) != DB.AttributeType.NUMERIC:
 		push_error("Attribute not the correct type.")
@@ -207,13 +217,6 @@ func get_attribute_transforms(attribute_name: String) -> Array[Transform]:
 	var attrib: AttributeTransformList = _attributes[attribute_name] if\
 			has_attribute(attribute_name) else new_default_attribute(attribute_name)
 	return attrib.get_transform_list()
-
-func get_attribute_final_transform(attribute_name: String) -> Transform2D:
-	if DB.get_attribute_type(attribute_name) != DB.AttributeType.TRANSFORM_LIST:
-		push_error("Attribute not the correct type.")
-	var attrib: AttributeTransformList = _attributes[attribute_name] if\
-			has_attribute(attribute_name) else new_default_attribute(attribute_name)
-	return attrib.get_final_transform()
 
 func get_attribute_final_precise_transform(attribute_name: String) -> PackedFloat64Array:
 	if DB.get_attribute_type(attribute_name) != DB.AttributeType.TRANSFORM_LIST:
@@ -329,13 +332,6 @@ func user_setup(_what = null) -> void:
 func is_parent_g() -> bool:
 	return parent != null and parent is ElementG
 
-func get_transform() -> Transform2D:
-	var result := Transform2D.IDENTITY
-	if is_parent_g():
-		result *= parent.get_transform()
-	if has_attribute("transform"):
-		result *= get_attribute_final_transform("transform")
-	return result
 
 func get_precise_transform() -> PackedFloat64Array:
 	var result := PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
@@ -345,6 +341,9 @@ func get_precise_transform() -> PackedFloat64Array:
 		result = Utils64Bit.transforms_mult(result,
 				get_attribute_final_precise_transform("transform"))
 	return result
+
+func get_transform() -> Transform2D:
+	return Utils64Bit.get_transform(get_precise_transform())
 
 func new_attribute(name: String, value := "") -> Attribute:
 	var attrib := _create_attribute(name, value)

--- a/src/data_classes/ElementRoot.gd
+++ b/src/data_classes/ElementRoot.gd
@@ -46,6 +46,7 @@ func _get_own_default(attribute_name: String) -> String:
 		"stroke-width": return "1"
 		"stroke-linecap": return "butt"
 		"stroke-linejoin": return "miter"
+		"color": return "black"
 		_: return ""
 
 

--- a/src/ui_widgets/transform_popup.gd
+++ b/src/ui_widgets/transform_popup.gd
@@ -129,25 +129,25 @@ func delete_transform(idx: int) -> void:
 	UR.commit_action()
 
 func _on_apply_matrix_pressed() -> void:
-	var final_transform := attribute_ref.get_final_transform()
+	var final_transform := attribute_ref.get_final_precise_transform()
 	UR.create_action("")
 	UR.add_do_method(attribute_ref.set_transform_list.bind([
-			Transform.TransformMatrix.new(final_transform.x.x, final_transform.x.y,
-			final_transform.y.x, final_transform.y.y, final_transform.origin.x,
-			final_transform.origin.y)] as Array[Transform]))
+			Transform.TransformMatrix.new(final_transform[0], final_transform[1],
+			final_transform[2], final_transform[3], final_transform[4],
+			final_transform[5])] as Array[Transform]))
 	UR.add_do_method(rebuild)
 	UR.add_undo_method(attribute_ref.set_transform_list.bind(get_transform_list()))
 	UR.add_undo_method(rebuild)
 	UR.commit_action()
 
 func update_final_transform() -> void:
-	var final_transform := attribute_ref.get_final_transform()
-	x1_edit.set_value(final_transform[0].x)
-	x2_edit.set_value(final_transform[0].y)
-	y1_edit.set_value(final_transform[1].x)
-	y2_edit.set_value(final_transform[1].y)
-	o1_edit.set_value(final_transform[2].x)
-	o2_edit.set_value(final_transform[2].y)
+	var final_transform := attribute_ref.get_final_precise_transform()
+	x1_edit.set_value(final_transform[0])
+	x2_edit.set_value(final_transform[1])
+	y1_edit.set_value(final_transform[2])
+	y2_edit.set_value(final_transform[3])
+	o1_edit.set_value(final_transform[4])
+	o2_edit.set_value(final_transform[5])
 
 
 func popup_transform_actions(idx: int, control: Control) -> void:


### PR DESCRIPTION
Implements the "color" attribute

Rearchitects ColorParser and AttributeColor a little to handle color keywords and element context better, including for the currentColor keyword.

Miscellaneous fix to transform popup to make its matrix use the 64-bit transform calculations.