### PR TITLE
Tweak Android build's name

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -435,7 +435,7 @@ jobs:
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PROJECT_NAME }}.release.Android
+          name: ${{ env.PROJECT_NAME }}.Android
           path: godsvg/build/android/GodSVG.apk
           if-no-files-found: ignore
           retention-days: 28


### PR DESCRIPTION
Removes ".release" from the Android build.

To be honest, this is just an excuse to commit something and test workflows, but I already do this anyway.