### PR TITLE
Fix unnecessary SVG.changed emitting

### DIFF
--- a/src/data_classes/AttributePathdata.gd
+++ b/src/data_classes/AttributePathdata.gd
@@ -156,10 +156,10 @@ func insert_command(idx: int, cmd_char: String, vec := Vector2.ZERO) -> void:
 	sync_after_commands_change()
 
 
-func _convert_command(idx: int, cmd_char: String) -> bool:
+func _convert_command(idx: int, cmd_char: String) -> void:
 	var old_cmd := get_command(idx)
 	if old_cmd.command_char == cmd_char:
-		return false
+		return
 	
 	var cmd_absolute_char := cmd_char.to_upper()
 	var new_cmd: PathCommand = PathCommand.translation_dict[cmd_absolute_char].new()
@@ -202,22 +202,16 @@ func _convert_command(idx: int, cmd_char: String) -> bool:
 	_commands.insert(idx, new_cmd)
 	if relative:
 		_commands[idx].toggle_relative()
-	return true
 
 func convert_command(idx: int, cmd_char: String) -> void:
-	var conversion_made := _convert_command(idx, cmd_char)
-	if conversion_made:
-		sync_after_commands_change()
+	_convert_command(idx, cmd_char)
+	sync_after_commands_change()
 
 func convert_commands_optimized(indices: PackedInt32Array,
 cmd_chars: PackedStringArray) -> void:
-	var conversions_made := false
 	for i in indices.size():
-		var conversion_made := _convert_command(indices[i], cmd_chars[i])
-		if conversion_made:
-			conversions_made = true
-	if conversions_made:
-		sync_after_commands_change()
+		_convert_command(indices[i], cmd_chars[i])
+	sync_after_commands_change()
 
 
 func delete_commands(indices: Array[int]) -> void:

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -122,7 +122,6 @@ func update_size_button() -> void:
 		size_button.disabled = false
 		size_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		update_size_button_colors()
-		
 	else:
 		size_button.disabled = true
 		size_button.mouse_default_cursor_shape = Control.CURSOR_ARROW
@@ -144,8 +143,7 @@ func update_file_button() -> void:
 
 
 func _on_svg_code_edit_text_changed() -> void:
-	SVG.set_text(code_edit.text)
-	SVG.sync_elements()
+	SVG.apply_svg_text(code_edit.text, false)
 
 func _on_svg_code_edit_focus_exited() -> void:
 	SVG.queue_save()

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -5,13 +5,6 @@ const MacMenu = preload("res://src/ui_parts/global_menu.tscn")
 @onready var panel_container: PanelContainer = $PanelContainer
 
 func _ready() -> void:
-	#var svg_text := FileAccess.get_file_as_string(
-			#ProjectSettings.globalize_path("res://godot_only/source_assets/splash.svg"))
-	#var root := SVGParser.text_to_root(svg_text, Formatter.new()).svg
-	#var t := Time.get_ticks_msec()
-	#root.optimize(true)
-	#print(Time.get_ticks_msec() - t)
-	
 	Configs.theme_changed.connect(update_theme)
 	update_theme()
 	if NativeMenu.has_feature(NativeMenu.FEATURE_GLOBAL_MENU):

--- a/src/ui_parts/global_menu.gd
+++ b/src/ui_parts/global_menu.gd
@@ -45,6 +45,7 @@ func _enter_tree() -> void:
 	_generate_main_menus()
 	_setup_menu_items()
 	SVG.changed.connect(_on_svg_changed)
+	Configs.file_path_changed.connect(_on_file_path_changed)
 
 
 func _reset_menus() -> void:
@@ -116,6 +117,7 @@ func _setup_menu_items() -> void:
 	file_clear_association_idx = _add_action(file_rid, "clear_file_path")
 	file_reset_svg_idx = _add_action(file_rid, "reset_svg")
 	_on_svg_changed()
+	_on_file_path_changed()
 	# Edit and Tool menus.
 	_add_many_actions(edit_rid, ShortcutUtils.get_shortcuts("edit"))
 	_add_many_actions(tool_rid, ShortcutUtils.get_shortcuts("tool"))
@@ -181,9 +183,12 @@ func _get_keycode_for_events(input_events: Array[InputEvent]) -> Key:
 
 func _on_svg_changed() -> void:
 	NativeMenu.set_item_disabled(file_rid, file_clear_svg_idx, SVG.text == SVG.DEFAULT)
-	var is_path_empty := Configs.savedata.current_file_path.is_empty()
-	NativeMenu.set_item_disabled(file_rid, file_clear_association_idx, is_path_empty)
-	NativeMenu.set_item_disabled(file_rid, file_reset_svg_idx, is_path_empty)
+	NativeMenu.set_item_disabled(file_rid, file_reset_svg_idx,
+			FileUtils.compare_svg_to_disk_contents() == FileUtils.FileState.DIFFERENT)
+
+func _on_file_path_changed() -> void:
+	NativeMenu.set_item_disabled(file_rid, file_clear_association_idx,
+			Configs.savedata.current_file_path.is_empty())
 
 
 func _on_display_view_settings_updated(show_grid: bool, show_handles: bool, rasterized_svg: bool) -> void:

--- a/src/ui_widgets/TitledPanel.gd
+++ b/src/ui_widgets/TitledPanel.gd
@@ -1,6 +1,6 @@
-# Titled panels have two children: The first is on top and it's the title,
-# the second one is on the bottom and it's the panel.
 class_name TitledPanel extends Container
+## Titled panels have two children: The first is on top and it's the title,
+## the second one is on the bottom and it's the panel.
 
 @export var border_width: int
 @export var corner_radius_top_left: int

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -34,7 +34,7 @@ func sync_to_attribute() -> void:
 func _on_text_submitted(new_text: String) -> void:
 	if new_text.is_empty() or\
 	AttributeID.get_validity(new_text) != AttributeID.ValidityLevel.INVALID:
-		set_value(new_text)
+		set_value(new_text, true)
 	else:
 		sync_to_attribute()
 


### PR DESCRIPTION
Tweaks the logic for when SVG.changed is emitted. Fixes issue where UndoRedo isn't created when editing an id attribute.