### PR TITLE
Fix SVG.changed emitted twice

### DIFF
--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -122,7 +122,6 @@ func update_size_button() -> void:
 		size_button.disabled = false
 		size_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 		update_size_button_colors()
-		
 	else:
 		size_button.disabled = true
 		size_button.mouse_default_cursor_shape = Control.CURSOR_ARROW
@@ -144,8 +143,7 @@ func update_file_button() -> void:
 
 
 func _on_svg_code_edit_text_changed() -> void:
-	SVG.set_text(code_edit.text)
-	SVG.sync_elements()
+	SVG.apply_svg_text(code_edit.text, false)
 
 func _on_svg_code_edit_focus_exited() -> void:
 	SVG.queue_save()

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -5,13 +5,6 @@ const MacMenu = preload("res://src/ui_parts/global_menu.tscn")
 @onready var panel_container: PanelContainer = $PanelContainer
 
 func _ready() -> void:
-	#var svg_text := FileAccess.get_file_as_string(
-			#ProjectSettings.globalize_path("res://godot_only/source_assets/splash.svg"))
-	#var root := SVGParser.text_to_root(svg_text, Formatter.new()).svg
-	#var t := Time.get_ticks_msec()
-	#root.optimize(true)
-	#print(Time.get_ticks_msec() - t)
-	
 	Configs.theme_changed.connect(update_theme)
 	update_theme()
 	if NativeMenu.has_feature(NativeMenu.FEATURE_GLOBAL_MENU):

--- a/src/ui_parts/global_menu.gd
+++ b/src/ui_parts/global_menu.gd
@@ -45,6 +45,7 @@ func _enter_tree() -> void:
 	_generate_main_menus()
 	_setup_menu_items()
 	SVG.changed.connect(_on_svg_changed)
+	Configs.file_path_changed.connect(_on_file_path_changed)
 
 
 func _reset_menus() -> void:
@@ -116,6 +117,7 @@ func _setup_menu_items() -> void:
 	file_clear_association_idx = _add_action(file_rid, "clear_file_path")
 	file_reset_svg_idx = _add_action(file_rid, "reset_svg")
 	_on_svg_changed()
+	_on_file_path_changed()
 	# Edit and Tool menus.
 	_add_many_actions(edit_rid, ShortcutUtils.get_shortcuts("edit"))
 	_add_many_actions(tool_rid, ShortcutUtils.get_shortcuts("tool"))
@@ -181,16 +183,17 @@ func _get_keycode_for_events(input_events: Array[InputEvent]) -> Key:
 
 func _on_svg_changed() -> void:
 	NativeMenu.set_item_disabled(file_rid, file_clear_svg_idx, SVG.text == SVG.DEFAULT)
-	var is_path_empty := Configs.savedata.current_file_path.is_empty()
-	NativeMenu.set_item_disabled(file_rid, file_clear_association_idx, is_path_empty)
-	NativeMenu.set_item_disabled(file_rid, file_reset_svg_idx, is_path_empty)
+	NativeMenu.set_item_disabled(file_rid, file_reset_svg_idx,
+			FileUtils.compare_svg_to_disk_contents() == FileUtils.FileState.DIFFERENT)
 
+func _on_file_path_changed() -> void:
+	NativeMenu.set_item_disabled(file_rid, file_clear_association_idx,
+			Configs.savedata.current_file_path.is_empty())
 
 func _on_display_view_settings_updated(show_grid: bool, show_handles: bool, rasterized_svg: bool) -> void:
 	NativeMenu.set_item_checked(view_rid, view_show_grid_idx, show_grid)
 	NativeMenu.set_item_checked(view_rid, view_show_handles_idx, show_handles)
 	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, rasterized_svg)
-
 
 func _on_display_snap_settings_updated(snap_enabled: bool, snap_amount: float) -> void:
 	NativeMenu.set_item_checked(snap_rid, snap_enable_idx, snap_enabled)

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -34,7 +34,7 @@ func sync_to_attribute() -> void:
 func _on_text_submitted(new_text: String) -> void:
 	if new_text.is_empty() or\
 	AttributeID.get_validity(new_text) != AttributeID.ValidityLevel.INVALID:
-		set_value(new_text)
+		set_value(new_text, true)
 	else:
 		sync_to_attribute()
 


### PR DESCRIPTION
Tweaks the logic for when SVG.changed is emitted. Fixes issue where UndoRedo isn't created when editing an id attribute.