### PR TITLE
Various improvements

### DIFF
--- a/src/ui_parts/eyedropper_popup.gd
+++ b/src/ui_parts/eyedropper_popup.gd
@@ -80,9 +80,9 @@ func _draw() -> void:
 	
 	draw_circle(pos, FRAME_RADIUS + FRAME_WIDTH / 2.0, theme_color, false, FRAME_WIDTH,
 			true)
-	draw_rect(Rect2(pos - Vector2(1, 1) * (PIXEL_SIZE / 2.0 - 0.5),
-			Vector2(1, 1) * PIXEL_SIZE), Color.WHITE, false, 1.0)
 	draw_rect(Rect2(pos - Vector2(1, 1) * (PIXEL_SIZE / 2.0 + 0.5),
+			Vector2(1, 1) * PIXEL_SIZE), Color.WHITE, false, 1.0)
+	draw_rect(Rect2(pos - Vector2(1, 1) * (PIXEL_SIZE / 2.0 + 1.5),
 			Vector2(1, 1) * (PIXEL_SIZE + 2)), Color.BLACK, false, 1.0)
 	
 	var stylebox_width := FRAME_RADIUS * 2

--- a/src/ui_widgets/palette_config.gd
+++ b/src/ui_widgets/palette_config.gd
@@ -176,12 +176,12 @@ func move_down() -> void:
 	Configs.savedata.move_palette_down(find_palette_index())
 	layout_changed.emit()
 
-func paste_palette() -> void:
-	var pasted_palettes := Palette.text_to_palettes(Utils.get_clipboard_web_safe())
-	if pasted_palettes.is_empty():
-		return
-	Configs.savedata.replace_palette(find_palette_index(), pasted_palettes[0])
-	layout_changed.emit()  # Emit it in any case, since the palette is a new object.
+func copy_palette(palette_idx: int) -> void:
+	DisplayServer.clipboard_set(Configs.savedata.get_palette(palette_idx).to_text())
+
+func save_palette(palette_idx: int) -> void:
+	var saved_palette := Configs.savedata.get_palette(palette_idx)
+	FileUtils.open_xml_export_dialog(saved_palette.to_text(), saved_palette.title)
 
 func open_palette_options() -> void:
 	var btn_arr: Array[Button] = []
@@ -215,28 +215,29 @@ func find_palette_index() -> int:
 
 func _on_palette_button_pressed() -> void:
 	var palette_idx := find_palette_index()
+	var separator_idx := 3
 	var btn_arr: Array[Button] = []
 	btn_arr.append(ContextPopup.create_button(Translator.translate("Rename"),
 			popup_edit_name, false, load("res://assets/icons/Rename.svg")))
 	if palette_idx >= 1:
+		separator_idx += 1
 		btn_arr.append(ContextPopup.create_button(Translator.translate("Move Up"),
 				move_up, false, load("res://assets/icons/MoveUp.svg")))
 	if palette_idx < Configs.savedata.get_palette_count() - 1:
+		separator_idx += 1
 		btn_arr.append(ContextPopup.create_button(Translator.translate("Move Down"),
 				move_down, false, load("res://assets/icons/MoveDown.svg")))
-	btn_arr.append(ContextPopup.create_button(Translator.translate("Copy as XML"),
-			DisplayServer.clipboard_set.bind(Configs.savedata.get_palette(palette_idx).\
-			to_text()), false, load("res://assets/icons/Copy.svg")))
-	btn_arr.append(ContextPopup.create_button(Translator.translate("Paste XML"),
-			paste_palette, !Palette.is_valid_palette(Utils.get_clipboard_web_safe()),
-			load("res://assets/icons/Paste.svg")))
 	btn_arr.append(ContextPopup.create_button(Translator.translate("Apply Preset"),
 			open_palette_options, false, load("res://assets/icons/Import.svg")))
 	btn_arr.append(ContextPopup.create_button(Translator.translate("Delete"),
 			delete, false, load("res://assets/icons/Delete.svg")))
+	btn_arr.append(ContextPopup.create_button(Translator.translate("Copy as XML"),
+			copy_palette.bind(palette_idx), false, load("res://assets/icons/Copy.svg")))
+	btn_arr.append(ContextPopup.create_button(Translator.translate("Save as XML"),
+			save_palette.bind(palette_idx), false, load("res://assets/icons/Paste.svg")))
 	
 	var context_popup := ContextPopup.new()
-	context_popup.setup(btn_arr, true)
+	context_popup.setup(btn_arr, true, -1, -1, PackedInt32Array([separator_idx]))
 	HandlerGUI.popup_under_rect_center(context_popup, palette_button.get_global_rect(),
 			get_viewport())
 

--- a/src/utils/ImageExportData.gd
+++ b/src/utils/ImageExportData.gd
@@ -35,7 +35,7 @@ var lossy := false:
 			changed.emit()
 
 
-func svg_to_buffer() -> PackedByteArray:
+static func svg_to_buffer() -> PackedByteArray:
 	return State.get_export_text().to_utf8_buffer()
 
 func image_to_buffer(image: Image) -> PackedByteArray:


### PR DESCRIPTION
Fixes a slightly misaligned graphic in the eyedropper.

Fixes some issues in situations where the viewbox is independent from the width and height of the graphic:
- "Add shape" no longer puts shapes in a wrong position
- The bounding box is no longer significantly off for highly scaled viewboxes

Removes the "Paste XML" option in the individual palette context popup, and adds an "Save as XML" option.