### PR TITLE
Fix custom file dialog scroll issue and MacOS crash

### DIFF
--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -151,6 +151,7 @@ func set_dir(dir: String) -> void:
 		return
 	
 	file_list.clear()
+	file_list.get_v_scroll_bar().value = 0
 	# Basic setup.
 	unfocus_file()
 	current_dir = dir

--- a/src/ui_parts/mac_menu.gd
+++ b/src/ui_parts/mac_menu.gd
@@ -185,7 +185,7 @@ func _on_svg_changed() -> void:
 			FileUtils.compare_svg_to_disk_contents() == FileUtils.FileState.DIFFERENT)
 
 func _on_view_rasterized_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.rasterized_svg)
+	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.view_rasterized)
 
 func _on_show_grid_changed() -> void:
 	NativeMenu.set_item_checked(view_rid, view_show_grid_idx, State.show_grid)


### PR DESCRIPTION
Fixes recent regression in MacOS and a small issue in the custom file dialog where the scroll wasn't set to 0 when changing the directory.