### PR TITLE
Simplify file paths in tab tooltip

### DIFF
--- a/src/config_classes/TabData.gd
+++ b/src/config_classes/TabData.gd
@@ -81,6 +81,19 @@ func get_edited_file_path() -> String:
 static func get_edited_file_path_for_id(checked_id: int) -> String:
 	return "%s/save%d.svg" % [EDITED_FILES_DIR, checked_id]
 
+# Method for showing the file path without stuff like "/home/mewpurpur/".
+# This information is pretty much always unnecessary clutter.
+func get_presented_svg_file_path() -> String:
+	var home_dir: String
+	if OS.get_name() == "Windows":
+		home_dir = OS.get_environment("USERPROFILE")
+	else:
+		home_dir = OS.get_environment("HOME")
+	
+	if svg_file_path.begins_with(home_dir):
+		return svg_file_path.trim_prefix(home_dir).trim_prefix("/").trim_prefix("\\")
+	return svg_file_path
+
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:

--- a/src/ui_parts/current_file_button.gd
+++ b/src/ui_parts/current_file_button.gd
@@ -1,0 +1,47 @@
+extends Button
+
+func _ready() -> void:
+	Configs.active_tab_name_changed.connect(update_file_button)
+	Configs.active_tab_changed.connect(update_file_button)
+	pressed.connect(_on_file_button_pressed)
+	update_file_button()
+
+func _make_custom_tooltip(_for_text: String) -> Object:
+	var label := Label.new()
+	label.add_theme_font_override("font", ThemeUtils.mono_font)
+	label.add_theme_font_size_override("font_size", 12)
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	label.text = Configs.savedata.get_active_tab().get_presented_svg_file_path()
+	Utils.set_max_text_width(label, 192.0, 4.0)
+	return label
+
+func _on_file_button_pressed() -> void:
+	var btn_array: Array[Button] = []
+	btn_array.append(ContextPopup.create_button(Translator.translate("Save SVG"),
+			FileUtils.save_svg, false, load("res://assets/icons/Save.svg"), "save"))
+	btn_array.append(ContextPopup.create_button(Translator.translate("Save SVG as…"),
+			FileUtils.save_svg_as, false, load("res://assets/icons/Save.svg"), "save_as"))
+	btn_array.append(ContextPopup.create_button(Translator.translate("Reset SVG"),
+			ShortcutUtils.fn("reset_svg"),
+			FileUtils.compare_svg_to_disk_contents() != FileUtils.FileState.DIFFERENT,
+			load("res://assets/icons/Reload.svg"), "reset_svg"))
+	btn_array.append(ContextPopup.create_button(Translator.translate("Open externally"),
+			ShortcutUtils.fn("open_externally"),
+			not FileAccess.file_exists(Configs.savedata.get_active_tab().svg_file_path),
+			load("res://assets/icons/OpenFile.svg"), "open_externally"))
+	btn_array.append(ContextPopup.create_button(Translator.translate("Show in File Manager"),
+			ShortcutUtils.fn("open_in_folder"),
+			not FileAccess.file_exists(Configs.savedata.get_active_tab().svg_file_path),
+			load("res://assets/icons/OpenFolder.svg"), "open_in_folder"))
+	
+	var context_popup := ContextPopup.new()
+	context_popup.setup(btn_array, true, size.x, -1, PackedInt32Array([2]))
+	HandlerGUI.popup_under_rect_center(context_popup, get_global_rect(), get_viewport())
+
+func update_file_button() -> void:
+	var file_name := State.transient_tab_path.get_file() if\
+			not State.transient_tab_path.is_empty() else\
+			Configs.savedata.get_active_tab().presented_name
+	text = file_name
+	tooltip_text = file_name
+	Utils.set_max_text_width(self, 140.0, 12.0)

--- a/src/ui_parts/current_file_button.gd.uid
+++ b/src/ui_parts/current_file_button.gd.uid
@@ -1,0 +1,1 @@
+uid://41g64ussxcbn

--- a/src/ui_parts/global_actions.tscn
+++ b/src/ui_parts/global_actions.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://cxmrx6t4jkhyj"]
+[gd_scene load_steps=8 format=3 uid="uid://cxmrx6t4jkhyj"]
 
 [ext_resource type="Script" uid="uid://cgbgw4ok5jxk5" path="res://src/ui_parts/global_actions.gd" id="1_x4rqo"]
 [ext_resource type="Texture2D" uid="uid://ccbta5q43jobk" path="res://assets/icons/More.svg" id="2_71075"]
@@ -6,6 +6,7 @@
 [ext_resource type="Texture2D" uid="uid://d0uvwj0t44n6v" path="res://assets/icons/Export.svg" id="3_4ckhj"]
 [ext_resource type="Texture2D" uid="uid://ckkkgof1hcbld" path="res://assets/icons/Gear.svg" id="3_xl5uh"]
 [ext_resource type="FontFile" uid="uid://dc0w4sx0h0fui" path="res://assets/fonts/FontBold.ttf" id="4_xl5uh"]
+[ext_resource type="Script" uid="uid://41g64ussxcbn" path="res://src/ui_parts/current_file_button.gd" id="5_14xct"]
 
 [node name="GlobalActions" type="HBoxContainer"]
 offset_right = 52.0
@@ -44,13 +45,14 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"TranslucentButton"
 theme_override_fonts/font = ExtResource("4_xl5uh")
 
-[node name="FileButton" type="Button" parent="RightSide"]
+[node name="CurrentFileButton" type="Button" parent="RightSide"]
 layout_mode = 2
 size_flags_horizontal = 2
 focus_mode = 0
 mouse_default_cursor_shape = 2
 theme_type_variation = &"FlatButton"
 text_overrun_behavior = 3
+script = ExtResource("5_14xct")
 
 [node name="ImportButton" type="Button" parent="RightSide"]
 layout_mode = 2

--- a/src/ui_parts/tab_bar.gd
+++ b/src/ui_parts/tab_bar.gd
@@ -404,7 +404,6 @@ func activate() -> void:
 		add_child(add_button)
 		active_controls.append(add_button)
 		add_button.pressed.connect(Configs.savedata.add_empty_tab)
-	
 
 
 func _get_tooltip(at_position: Vector2) -> String:
@@ -426,9 +425,9 @@ func _get_tooltip(at_position: Vector2) -> String:
 	# We have to pass some metadata to the tooltip.
 	# Since "*" isn't valid in filepaths, we use it as a delimiter.
 	elif hovered_tab_idx == Configs.savedata.get_active_tab_index():
-		return "%s*hovered" % current_tab.svg_file_path
+		return "%s*hovered" % current_tab.get_presented_svg_file_path()
 	
-	return "%s*%d" % [current_tab.svg_file_path, current_tab.id]
+	return "%s*%d" % [current_tab.get_presented_svg_file_path(), current_tab.id]
 
 func _make_custom_tooltip(for_text: String) -> Object:
 	var asterisk_pos := for_text.find("*")
@@ -440,8 +439,8 @@ func _make_custom_tooltip(for_text: String) -> Object:
 	label.add_theme_font_override("font", ThemeUtils.mono_font)
 	label.add_theme_font_size_override("font_size", 12)
 	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	label.custom_minimum_size.x = 192
 	label.text = path
+	Utils.set_max_text_width(label, 192.0, 4.0)
 	
 	var metadata := for_text.right(-asterisk_pos - 1)
 	if metadata == "hovered":


### PR DESCRIPTION
A path like `/home/mewpurpur/Desktop/batsie.svg` becomes just `Desktop/batsie.svg`