### PR TITLE
Fix stop element not selected on attribute field click

### DIFF
--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -1,6 +1,5 @@
 extends Node
 
-# Not a good idea to preload scenes inside a singleton.
 const AlertDialog = preload("res://src/ui_widgets/alert_dialog.tscn")
 const ConfirmDialog = preload("res://src/ui_widgets/confirm_dialog.tscn")
 const SettingsMenu = preload("res://src/ui_parts/settings_menu.tscn")
@@ -281,7 +280,7 @@ func get_max_ui_scale() -> float:
 	var window_default_size := get_window_default_size()
 	# How much can the default size be increased before it takes all usable screen space.
 	var max_expansion := Vector2(usable_screen_size) / Vector2(window_default_size)
-	return minf(snappedf(minf(max_expansion.x, max_expansion.y) - 0.025, 0.05), 4.0)
+	return clampf(snappedf(minf(max_expansion.x, max_expansion.y) - 0.025, 0.05), 0.75, 4.0)
 
 func get_min_ui_scale() -> float:
 	return maxf(snappedf(get_max_ui_scale() / 2.0 - 0.125, 0.25), 0.75)
@@ -302,7 +301,7 @@ func get_auto_ui_scale() -> float:
 	var auto_scale := get_max_ui_scale() * clampf(aspect_ratio * 0.375, 0.6, 0.8)
 	if OS.get_name() == "Android":
 		auto_scale *= 1.1  # Default to giving mobile a bit more space.
-	return snappedf(auto_scale, 0.25)
+	return clampf(snappedf(auto_scale, 0.25), get_min_ui_scale(), get_max_ui_scale())
 
 
 func update_ui_scale() -> void:
@@ -331,9 +330,9 @@ func update_ui_scale() -> void:
 		SaveData.ScalingApproach.MAX: final_scale = max_scale
 	final_scale = clampf(final_scale, min_scale, max_scale)
 	
-	var resize_factor := final_scale / old_scale_factor
 	if not OS.get_name() in ["Android", "Web"]:
 		if window.mode == Window.MODE_WINDOWED:
+			var resize_factor := final_scale / old_scale_factor
 			# The window's minimum size can mess with the size change, so we set it to zero.
 			window.min_size = Vector2i.ZERO
 			window.size = Vector2i(mini(int(window.size.x * resize_factor),

--- a/src/ui_widgets/element_content_stop.gd
+++ b/src/ui_widgets/element_content_stop.gd
@@ -5,11 +5,7 @@ extends VBoxContainer
 var element: Element
 
 func _ready() -> void:
-	var offset_input_field := AttributeFieldBuilder.create("offset", element)
-	attribute_container.add_child(offset_input_field)
-	
-	var color_input_field := AttributeFieldBuilder.create("stop-color", element)
-	attribute_container.add_child(color_input_field)
-	
-	var opacity_input_field := AttributeFieldBuilder.create("stop-opacity", element)
-	attribute_container.add_child(opacity_input_field)
+	for attrib_name in ["offset", "stop-color", "stop-opacity"]:
+		var input_field := AttributeFieldBuilder.create(attrib_name, element)
+		input_field.focus_entered.connect(State.normal_select.bind(element.xid))
+		attribute_container.add_child(input_field)


### PR DESCRIPTION
Fixes \<stop> not being selected when focusing an attribute field.

Fixes #1182 by defining auto UI scale and max scale a bit better, enforcing 0.75 as a minimum. I don't know how to do much better than that, since I don't think you can detect when the browser is resizing?