### PR TITLE
Fix pressing Esc in the import warning dialog

### DIFF
--- a/src/ui_parts/good_file_dialog.tscn
+++ b/src/ui_parts/good_file_dialog.tscn
@@ -20,6 +20,7 @@ theme_override_constants/separation = 8
 
 [node name="TitleLabel" type="Label" parent="VBoxContainer"]
 layout_mode = 2
+theme_override_font_sizes/font_size = 15
 horizontal_alignment = 1
 
 [node name="TopBar" type="HBoxContainer" parent="VBoxContainer"]

--- a/src/ui_parts/import_warning_menu.gd
+++ b/src/ui_parts/import_warning_menu.gd
@@ -1,5 +1,7 @@
 extends PanelContainer
 
+var import_success := false
+
 signal imported
 signal canceled
 
@@ -11,11 +13,16 @@ signal canceled
 
 var imported_text := ""
 
+func _exit_tree() -> void:
+	if import_success:
+		imported.emit()
+	else:
+		canceled.emit()
+
 func _ready() -> void:
 	imported.connect(queue_free)
 	ok_button.pressed.connect(imported.emit)
-	canceled.connect(queue_free)
-	cancel_button.pressed.connect(canceled.emit)
+	cancel_button.pressed.connect(queue_free)
 	
 	# Convert forward and backward to show how GodSVG would display the given SVG.
 	var imported_text_parse_result := SVGParser.text_to_root(imported_text)
@@ -38,14 +45,14 @@ func _ready() -> void:
 	else:
 		var svg_warnings := get_svg_warnings(imported_text_parse_result.svg)
 		if svg_warnings.is_empty():
-			imported.emit()
+			import_success = true
 		else:
 			warnings_label.add_theme_color_override("default_color",
 					Configs.savedata.basic_color_warning)
 			for warning in svg_warnings:
 				warnings_label.text += warning + "\n"
 	ok_button.grab_focus()
-	$VBoxContainer/Title.text = Translator.translate("Import Problems")
+	$VBoxContainer/TitleLabel.text = Translator.translate("Import Problems")
 	ok_button.text = Translator.translate("Import")
 	cancel_button.text = Translator.translate("Cancel")
 


### PR DESCRIPTION
Now the Import Warnings dialog emits a "canceled" signal regardless of how it was removed. Also fixes font size in another place.