### PR TITLE
Tweak checkbox constants

### DIFF
--- a/src/autoload/State.gd
+++ b/src/autoload/State.gd
@@ -767,8 +767,9 @@ func get_selection_context(popup_method: Callable, context: Context) -> ContextP
 				"duplicate"))
 		
 		var xnode := root_element.get_xnode(selected_xids[0])
-		if selected_xids.size() == 1 and (not xnode.is_element() or\
-		(xnode.is_element() and not xnode.possible_conversions.is_empty())):
+		if selected_xids.size() == 1 and ((not xnode.is_element() and\
+		xnode.get_type() != BasicXNode.NodeType.UNKNOWN) or (xnode.is_element() and\
+		not xnode.possible_conversions.is_empty())):
 			btn_arr.append(ContextPopup.create_button(
 					Translator.translate("Convert To"),
 					popup_convert_to_context.bind(popup_method), false,

--- a/src/data_classes/AttributeNumeric.gd
+++ b/src/data_classes/AttributeNumeric.gd
@@ -31,7 +31,7 @@ func num_to_text(number: float, formatter := Configs.savedata.editor_formatter) 
 	return NumberParser.num_to_text(number, formatter)
 
 static func text_to_num(text: String) -> float:
-	text = text.strip_edges()
+	text = text.strip_edges(false, true)
 	if text.is_empty():
 		return NAN
 	if text.ends_with("%"):
@@ -39,5 +39,4 @@ static func text_to_num(text: String) -> float:
 	return text.to_float()
 
 static func text_check_percentage(text: String) -> bool:
-	# Only the right side needs to be stripped to check for %.
 	return text.strip_edges(false, true).ends_with("%")

--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -9,11 +9,11 @@ static func add_hash_if_hex(color: String) -> String:
 
 static func is_valid(color: String, allow_alpha := false, allow_url := false,
 allow_none := false, allow_current_color := false) -> bool:
-	color = color.strip_edges()
 	return is_valid_hex(color, allow_alpha) or is_valid_rgb(color, allow_alpha) or\
 			is_valid_hsl(color, allow_alpha) or is_valid_named(color, allow_alpha) or\
-			(allow_url and is_valid_url(color)) or (allow_none and color == "none") or\
-			(allow_current_color and color == "currentColor")
+			(allow_url and is_valid_url(color)) or (allow_none and\
+			color.strip_edges() == "none") or (allow_current_color and\
+			color.strip_edges() == "currentColor")
 
 static func is_valid_hex(color: String, allow_alpha := false) -> bool:
 	color = color.strip_edges()
@@ -116,16 +116,16 @@ allow_alpha := false) -> Color:
 		if not (args.size() == 3 or (args.size() == 4 and allow_alpha)):
 			return backup
 		
-		var a0 := args[0].strip_edges()
-		var a1 := args[1].strip_edges()
-		var a2 := args[2].strip_edges()
+		var a0 := args[0].strip_edges(false, true)
+		var a1 := args[1].strip_edges(false, true)
+		var a2 := args[2].strip_edges(false, true)
 		var r := a0.to_int() if _is_valid_number(a0) else int(a0.left(-1).to_float() * 2.55)
 		var g := a1.to_int() if _is_valid_number(a1) else int(a1.left(-1).to_float() * 2.55)
 		var b := a2.to_int() if _is_valid_number(a2) else int(a2.left(-1).to_float() * 2.55)
 		if args.size() == 3:
 			return Color.from_rgba8(clampi(r, 0, 255), clampi(g, 0, 255), clampi(b, 0, 255))
 		else:
-			var a3 := args[3].strip_edges()
+			var a3 := args[3].strip_edges(false, true)
 			var a := int(a3.to_float() * 255) if _is_valid_number(a3) else\
 					int(a3.left(-1).to_float() * 2.55)
 			return Color.from_rgba8(clampi(r, 0, 255), clampi(g, 0, 255), clampi(b, 0, 255),
@@ -136,13 +136,13 @@ allow_alpha := false) -> Color:
 		if not (args.size() == 3 or (args.size() == 4 and allow_alpha)):
 			return backup
 		
-		var h := posmod(args[0].strip_edges().to_int(), 360)
-		var s := clampf(int(args[1].strip_edges().left(-1).to_float()) * 0.01, 0.0, 1.0)
-		var l := clampf(int(args[2].strip_edges().left(-1).to_float()) * 0.01, 0.0, 1.0)
+		var h := posmod(args[0].to_int(), 360)
+		var s := clampf(int(args[1].strip_edges(false, true).left(-1).to_float()) * 0.01, 0.0, 1.0)
+		var l := clampf(int(args[2].strip_edges(false, true).left(-1).to_float()) * 0.01, 0.0, 1.0)
 		if args.size() == 3:
 			return Color.from_rgba8(hsl_get_r(h, s, l), hsl_get_g(h, s, l), hsl_get_b(h, s, l))
 		else:
-			var a3 := args[3].strip_edges()
+			var a3 := args[3].strip_edges(false, true)
 			var a := int(a3.to_float() * 255) if _is_valid_number(a3) else\
 					int(a3.left(-1).to_float() * 2.55)
 			return Color.from_rgba8(hsl_get_r(h, s, l), hsl_get_g(h, s, l), hsl_get_b(h, s, l),

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -17,7 +17,6 @@ var cached_max_value: float
 
 func set_value(new_value: String, save := false) -> void:
 	if not new_value.is_empty():
-		new_value = new_value.strip_edges()
 		if not AttributeNumeric.text_check_percentage(new_value):
 			var numeric_value := NumstringParser.evaluate(new_value)
 			# Validate the value.

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -11,8 +11,7 @@ const MAX_VALUE := 1.0
 
 func set_value(new_value: String, save := false) -> void:
 	if not new_value.is_empty():
-		new_value = new_value.strip_edges()
-		if not new_value.ends_with("%"):
+		if not AttributeNumeric.text_check_percentage(new_value):
 			var numeric_value := NumstringParser.evaluate(new_value)
 			# Validate the value.
 			if !is_finite(numeric_value):

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -199,7 +199,7 @@ static func _setup_panelcontainer(theme: Theme) -> void:
 
 static func _setup_button(theme: Theme) -> void:
 	theme.add_type("Button")
-	theme.set_constant("h_separation", "Button", 6)
+	theme.set_constant("h_separation", "Button", 5)
 	theme.set_color("font_color", "Button", common_text_color)
 	theme.set_color("font_disabled_color", "Button", common_subtle_text_color)
 	theme.set_color("font_focus_color", "Button", common_highlighted_text_color)
@@ -540,6 +540,8 @@ static func _setup_button(theme: Theme) -> void:
 
 static func _setup_checkbox(theme: Theme) -> void:
 	theme.add_type("CheckBox")
+	theme.set_constant("h_separation", "CheckBox", 5)
+	theme.set_color("font_color", "CheckBox", common_text_color)
 	theme.set_color("font_color", "CheckBox", common_text_color)
 	theme.set_color("font_disabled_color", "CheckBox", common_subtle_text_color)
 	theme.set_color("font_focus_color", "CheckBox", common_highlighted_text_color)
@@ -555,14 +557,14 @@ static func _setup_checkbox(theme: Theme) -> void:
 	checkbox_stylebox.set_corner_radius_all(4)
 	checkbox_stylebox.content_margin_bottom = 2.0
 	checkbox_stylebox.content_margin_top = 2.0
-	checkbox_stylebox.content_margin_left = 4.0
-	checkbox_stylebox.content_margin_right = 4.0
+	checkbox_stylebox.content_margin_left = 3.0
+	checkbox_stylebox.content_margin_right = 3.0
 	
 	var empty_checkbox_stylebox := StyleBoxEmpty.new()
 	empty_checkbox_stylebox.content_margin_bottom = 2.0
 	empty_checkbox_stylebox.content_margin_top = 2.0
-	empty_checkbox_stylebox.content_margin_left = 4.0
-	empty_checkbox_stylebox.content_margin_right = 4.0
+	empty_checkbox_stylebox.content_margin_left = 3.0
+	empty_checkbox_stylebox.content_margin_right = 3.0
 	theme.set_stylebox("normal", "CheckBox", empty_checkbox_stylebox)
 	theme.set_stylebox("pressed", "CheckBox", empty_checkbox_stylebox)
 	


### PR DESCRIPTION
Removes "Convert To" option from unrecognized XML nodes
Makes all instances of strip_edges() only strip the necessary side.
Tweaks checkbox theming to match buttons with icons.