### PR TITLE
CI: Always build android release template

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -406,7 +406,7 @@ jobs:
           mv ./bin/android_debug.apk ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/android_debug.apk
           mv ./bin/android_source.zip ~/.local/share/godot/export_templates/${GODOT_VERSION}.${GODOT_RELEASE}/android_source.zip
 
-      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' && github.event_name == 'workflow_dispatch' }}
+      - if: ${{ steps.cache-template.outputs.cache-hit != 'true' }}
         name: Build Godot release template for Android
         run: |
           cd godot


### PR DESCRIPTION
Currently, the new Android release template is not automatically rebuilt when workflow changes occur. This can lead to issues where changes take effect, but the Android release template remains outdated. To prevent this, we have to manually clear the cache before each release -- a step that could be easily overlooked.

This PR ensures that the release template is also rebuilt whenever the workflow changes, eliminating the need to manually clear the cache before a release.