### PR TITLE
Fix CTRL + MMB zooming not keeping center at starting location

### DIFF
--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -140,7 +140,9 @@ func _unhandled_input(event: InputEvent) -> void:
 	
 	else:
 		if not event.is_echo():
-			_zoom_to = Vector2.ZERO  # Reset Ctrl + MMB zoom position if released.
+			# Filter out fake mouse movement events.
+			if not (event is InputEventMouseMotion and event.relative == Vector2.ZERO):
+				_zoom_to = Vector2.ZERO  # Reset Ctrl + MMB zoom position if released.
 
 
 func _on_zoom_changed(new_zoom_level: float, offset: Vector2) -> void:


### PR DESCRIPTION
This was broken since the addition of fake mouse movement events