### PR TITLE
Fix opening SVGs via the CLI crashing GodSVG

### DIFF
--- a/src/autoload/State.gd
+++ b/src/autoload/State.gd
@@ -77,12 +77,27 @@ func _enter_tree() -> void:
 	Configs.active_tab_changed.connect(setup_from_tab)
 	setup_from_tab.call_deferred()  # Let everything load before emitting signals.
 	
+	#region Loading SVGs from CLI
 	var cmdline_args := OS.get_cmdline_args()
-	if not (OS.is_debug_build() and not OS.has_feature("template")) and\
-	cmdline_args.size() >= 1:
-		await get_tree().ready  # Ensures we can add warning panels.
-		FileUtils.apply_svg_from_path(cmdline_args[0])
-
+	
+	# The first argument passed is always a path to the scene file when in-editor
+	if (OS.is_debug_build() and not OS.has_feature("template")) and cmdline_args.size() >= 1:
+		cmdline_args.remove_at(0)
+	
+	# Ensure we can add warning panels by waiting until everything has loaded, then load the SVGs
+	if cmdline_args.size() >= 1:
+		await get_tree().process_frame  # SAFETY: Godot readies all nodes before the next frame
+		
+		# Temporarily caching an array of tabs from last session, improves recursion performance
+		var tab_paths := PackedStringArray()
+		for tab in Configs.savedata.get_tabs():
+			tab_paths.append(tab.svg_file_path)
+		
+		for path in cmdline_args:
+			if path.get_extension() != "svg": continue
+			if path not in tab_paths:
+				FileUtils.apply_svg_from_path(path)
+	#endregion
 
 func setup_from_tab() -> void:
 	var active_tab := Configs.savedata.get_active_tab()

--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -204,9 +204,9 @@ allowed_extensions: PackedStringArray) -> Error:
 	var file := FileAccess.open(file_path, FileAccess.READ)
 	var error := ""
 	var file_extension := file_path.get_extension()
-
+	
 	Configs.savedata.add_recent_dir(file_path.get_base_dir())
-
+	
 	if not file_extension in allowed_extensions:
 		error = TranslationUtils.get_bad_extension_alert_text(file_extension,
 				allowed_extensions)

--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -204,15 +204,9 @@ allowed_extensions: PackedStringArray) -> Error:
 	var file := FileAccess.open(file_path, FileAccess.READ)
 	var error := ""
 	var file_extension := file_path.get_extension()
-	
+
 	Configs.savedata.add_recent_dir(file_path.get_base_dir())
-	
-	if file_extension == "tscn":
-		# I asked kiisu about why he wrote this special case. He said:
-		# "I think when running from the editor it would give the specific scene
-		# run as first argument",
-		# TODO understand what he meant and if it's still relevant.
-		return ERR_FILE_CANT_OPEN
+
 	if not file_extension in allowed_extensions:
 		error = TranslationUtils.get_bad_extension_alert_text(file_extension,
 				allowed_extensions)


### PR DESCRIPTION
Opening SVGs via the CLI before this PR makes GodSVG crash due to `get_tree().ready` not being found.

This also additionally adds support for opening multiple SVGs at once via CLI, and removes weird unnecessary if statements / guards that stopped you from passing in SVGs through CLI when in-editor or in a debug build of GodSVG.

If you are running in the editor, it will automatically remove the first element when parsing CLI arguments, as Godot always provides a path to the scene file as the first element which is unnecessary.

Selecting GodSVG as your default app for `svg` files will also work now/again as all major operating systems pass in files as CLI arguments, though it won't generate file thumbnails for SVG files unlike Inkscape _(another SVG editor)_.
A button in the settings to automatically register the current GodSVG executable as the default SVG editor/viewer could be added in the future _(similar to Blender's)_ but it's outside the scope of this PR.
