### PR TITLE
Remove unused modules from third party components

### DIFF
--- a/app_info.json
+++ b/app_info.json
@@ -6,6 +6,7 @@
 		"aladvs",
 		"Alex2782",
 		"DevPoodle",
+		"FlooferLand",
 		"ilikefrogs101",
 		"itycodes",
 		"Kiisu-Master",


### PR DESCRIPTION
I think it's weird that you'd open third-party components curious about what GodSVG is using, and you see a bunch of physics-related things, even though the export template is completely stripped from those modules. I've added a bit of logic to remove them, which should also reduce the lag spike of loading the text.