### PR TITLE
Fix some issues with shortcuts

### DIFF
--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -254,15 +254,54 @@ func _unhandled_input(event: InputEvent) -> void:
 	get_viewport().gui_is_dragging():
 		return
 	
-	const CONST_ARR: PackedStringArray = ["ui_redo", "ui_undo", "ui_cancel", "delete",
+	const CONST_ARR: PackedStringArray = ["ui_undo", "ui_redo", "ui_cancel", "delete",
 			"move_up", "move_down", "duplicate", "select_all"]
 	for action in CONST_ARR:
 		if ShortcutUtils.is_action_pressed(event, action):
 			get_viewport().set_input_as_handled()
 			ShortcutUtils.fn_call(action)
 			return
-	if event is InputEventKey:
-		State.respond_to_key_input(event)
+	
+	if ShortcutUtils.is_action_pressed(event, "move_absolute"):
+		State.respond_to_key_input("M")
+	elif ShortcutUtils.is_action_pressed(event, "move_relative"):
+		State.respond_to_key_input("m")
+	elif ShortcutUtils.is_action_pressed(event, "line_absolute"):
+		State.respond_to_key_input("L")
+	elif ShortcutUtils.is_action_pressed(event, "line_relative"):
+		State.respond_to_key_input("l")
+	elif ShortcutUtils.is_action_pressed(event, "horizontal_line_absolute"):
+		State.respond_to_key_input("H")
+	elif ShortcutUtils.is_action_pressed(event, "horizontal_line_relative"):
+		State.respond_to_key_input("h")
+	elif ShortcutUtils.is_action_pressed(event, "vertical_line_absolute"):
+		State.respond_to_key_input("V")
+	elif ShortcutUtils.is_action_pressed(event, "vertical_line_relative"):
+		State.respond_to_key_input("v")
+	elif ShortcutUtils.is_action_pressed(event, "close_path_absolute"):
+		State.respond_to_key_input("Z")
+	elif ShortcutUtils.is_action_pressed(event, "close_path_relative"):
+		State.respond_to_key_input("z")
+	elif ShortcutUtils.is_action_pressed(event, "elliptical_arc_absolute"):
+		State.respond_to_key_input("A")
+	elif ShortcutUtils.is_action_pressed(event, "elliptical_arc_relative"):
+		State.respond_to_key_input("a")
+	elif ShortcutUtils.is_action_pressed(event, "cubic_bezier_absolute"):
+		State.respond_to_key_input("C")
+	elif ShortcutUtils.is_action_pressed(event, "cubic_bezier_relative"):
+		State.respond_to_key_input("c")
+	elif ShortcutUtils.is_action_pressed(event, "shorthand_cubic_bezier_absolute"):
+		State.respond_to_key_input("S")
+	elif ShortcutUtils.is_action_pressed(event, "shorthand_cubic_bezier_relative"):
+		State.respond_to_key_input("s")
+	elif ShortcutUtils.is_action_pressed(event, "quadratic_bezier_absolute"):
+		State.respond_to_key_input("Q")
+	elif ShortcutUtils.is_action_pressed(event, "quadratic_bezier_relative"):
+		State.respond_to_key_input("q")
+	elif ShortcutUtils.is_action_pressed(event, "shorthand_quadratic_bezier_absolute"):
+		State.respond_to_key_input("T")
+	elif ShortcutUtils.is_action_pressed(event, "shorthand_quadratic_bezier_relative"):
+		State.respond_to_key_input("t")
 
 
 func get_window_default_size() -> Vector2i:

--- a/src/ui_parts/tab_bar.gd
+++ b/src/ui_parts/tab_bar.gd
@@ -422,7 +422,7 @@ func _get_tooltip(at_position: Vector2) -> String:
 	# We have to pass some metadata to the tooltip.
 	# Since "*" isn't valid in filepaths, we use it as a delimiter.
 	elif hovered_tab_idx == Configs.savedata.get_active_tab_index():
-		return "%s*hovered" % current_tab.get_presented_svg_file_path()
+		return "%s*active" % current_tab.get_presented_svg_file_path()
 	
 	return "%s*%d" % [current_tab.get_presented_svg_file_path(), current_tab.id]
 
@@ -439,8 +439,9 @@ func _make_custom_tooltip(for_text: String) -> Object:
 	label.text = path
 	Utils.set_max_text_width(label, 192.0, 4.0)
 	
+	# If the tab is active, no need for an SVG preview.
 	var metadata := for_text.right(-asterisk_pos - 1)
-	if metadata == "hovered":
+	if metadata == "active":
 		return label
 	
 	var id := metadata.to_int()

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -181,4 +181,5 @@ static func is_action_pressed(event: InputEvent, action: String) -> bool:
 	# is the correct one... But it should be handled gracefully.
 	if event is InputEventAction:
 		event = InputMap.action_get_events(event.action)[event.event_index]
-	return event.is_action_pressed(action) and Configs.savedata.is_shortcut_valid(event)
+	return event.is_action_pressed(action, false, true) and\
+			Configs.savedata.is_shortcut_valid(event)


### PR DESCRIPTION
Fixes #1097. Not completely, but the remaining things should have separate issues opened for them.

> Shortcuts can collide and get emitted simultaneously

Fixed

> With default shortcuts, when you have a whole path element selected, Ctrl+Shift+H creates a new H path command.

Fixed