### PR TITLE
Fix tab text not updating when language changes

### DIFF
--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -89,8 +89,13 @@ func update_layout() -> void:
 		for i in layout_parts.size():
 			var part := layout_parts[i]
 			var btn := Button.new()
+			# Make the text update when the language changes.
+			var set_btn_text_func := func() -> void:
+					btn.text = TranslationUtils.get_layout_part_name(part)
+			Configs.language_changed.connect(set_btn_text_func)
+			set_btn_text_func.call()
+			# Set up other button properties.
 			btn.toggle_mode = true
-			btn.text = TranslationUtils.get_layout_part_name(part)
 			btn.icon = Utils.get_layout_part_icon(part)
 			btn.theme_type_variation = "FlatButton"
 			btn.focus_mode = Control.FOCUS_NONE

--- a/src/ui_widgets/BetterLineEdit.gd
+++ b/src/ui_widgets/BetterLineEdit.gd
@@ -106,6 +106,7 @@ func _gui_input(event: InputEvent) -> void:
 	
 	if event.is_action_pressed("ui_cancel"):
 		release_focus()
+		accept_event()
 		return
 	
 	mouse_filter = Utils.mouse_filter_pass_non_drag_events(event)


### PR DESCRIPTION
Also fixes an issue in BetterLineEdit where Esc wouldn't be absorbed.