### PR TITLE
Fix edge case in palette rename warning color

### DIFF
--- a/src/ui_widgets/palette_config.gd
+++ b/src/ui_widgets/palette_config.gd
@@ -122,9 +122,13 @@ func _on_name_edit_text_changed(new_text: String) -> void:
 	name_edit.begin_bulk_theme_override()
 	const CONST_ARR: PackedStringArray = ["font_color", "font_hover_color"]
 	for theme_type in CONST_ARR:
+		# If the new text matches the current title, show warning color
+		# if the palette is currently invalid. If the new text is different,
+		# check if it's unused, i.e., would be a valid title.
 		name_edit.add_theme_color_override(theme_type,
-				Configs.savedata.get_validity_color(false, new_text != palette.title and\
-				not Configs.savedata.is_palette_title_unused(new_text)))
+				Configs.savedata.get_validity_color(false, (new_text != palette.title and\
+				not Configs.savedata.is_palette_title_unused(new_text)) or\
+				(new_text == palette.title and Configs.savedata.is_palette_valid(palette))))
 	name_edit.end_bulk_theme_override()
 
 func _on_name_edit_text_submitted(new_title: String) -> void:


### PR DESCRIPTION
If the new text is the same as before, it's invalid if the palette is currently invalid. Check this edge case now.