### PR TITLE
Fix tab staying empty on first open

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -366,4 +366,3 @@ locale/translations=PackedStringArray("res://translations/bg.po", "res://transla
 
 renderer/rendering_method="gl_compatibility"
 textures/vram_compression/import_etc2_astc=true
-environment/defaults/default_clear_color=Color(0.12, 0.132, 0.2, 1)

--- a/src/autoload/Configs.gd
+++ b/src/autoload/Configs.gd
@@ -66,9 +66,7 @@ func load_config() -> void:
 		reset_settings()
 		return
 	
-	savedata.get_active_tab().activate()
-	change_background_color()
-	change_locale()
+	post_load()
 
 
 func reset_settings() -> void:
@@ -78,6 +76,12 @@ func reset_settings() -> void:
 	savedata.set_shortcut_panel_slots({ 0: "ui_undo", 1: "ui_redo" })
 	savedata.set_palettes([Palette.new("Pure", Palette.Preset.PURE)])
 	save()
+	post_load()
+
+func post_load() -> void:
+	savedata.get_active_tab().activate()
+	sync_background_color()
+	sync_locale()
 
 
 func generate_highlighter() -> SVGHighlighter:
@@ -95,10 +99,10 @@ func generate_highlighter() -> SVGHighlighter:
 
 # Global effects from settings. Some of them should also be used on launch.
 
-func change_background_color() -> void:
+func sync_background_color() -> void:
 	RenderingServer.set_default_clear_color(savedata.background_color)
 
-func change_locale() -> void:
+func sync_locale() -> void:
 	if not savedata.language in TranslationServer.get_loaded_locales():
 		savedata.language = "en"
 	else:

--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -529,8 +529,9 @@ func throw_mouse_motion_event() -> void:
 	var window := get_window()
 	# Must multiply by the final transform because the InputEvent is not yet parsed.
 	var mouse_position = window.get_mouse_position()
-	# TODO This is a workaround because the returned mouse position is sometimes 0, likely a Godot issue.
-	# This has been reproduced on Android and on Web. Reproducing on web is especially easy with zoom at something like 110%.
+	# TODO This is a workaround because the returned mouse position is sometimes (0, 0),
+	# likely a Godot issue. This has been reproduced on Android and on Web.
+	# Reproducing on web is especially easy with zoom at something like 110% on Web.
 	if mouse_position == Vector2.ZERO:
 		return
 	

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -67,7 +67,7 @@ func validate() -> void:
 		if _layout.has(location) and not _layout[location].is_empty():
 			return
 	_layout = {
-		LayoutLocation.TOP_LEFT: [Utils.LayoutPart.CODE_EDITOR, Utils.LayoutPart.INSPECTOR]
+		LayoutLocation.TOP_LEFT: [Utils.LayoutPart.INSPECTOR, Utils.LayoutPart.CODE_EDITOR]
 	}
 
 
@@ -83,7 +83,7 @@ const CURRENT_VERSION = 1
 		if language != new_value:
 			language = new_value
 			emit_changed()
-			Configs.change_locale.call_deferred()
+			Configs.sync_locale.call_deferred()
 			Configs.language_changed.emit.call_deferred()
 
 # Theming
@@ -183,7 +183,7 @@ const CURRENT_VERSION = 1
 		if background_color != new_value:
 			background_color = new_value
 			emit_changed()
-			Configs.change_background_color.call_deferred()
+			Configs.sync_background_color.call_deferred()
 
 @export var grid_color := Color(0.5, 0.5, 0.5):
 	set(new_value):


### PR DESCRIPTION
Also changes the default layout to make the inspector the first tab. This was an oversight.