### PR TITLE
Add setting to limit FPS to any value

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -38,9 +38,8 @@ func get_setting_default(setting: String) -> Variant:
 		"use_native_file_dialog": return true
 		"use_filename_for_window_title": return true
 		"handle_size": return 1.0 if OS.get_name() != "Android" else 2.0
-		"scale": return ScalingApproach.AUTO
+		"ui_scale": return ScalingApproach.AUTO
 		"max_fps": return 0
-		"custom_scale": return true
 	return null
 
 func reset_to_default() -> void:

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -39,6 +39,7 @@ func get_setting_default(setting: String) -> Variant:
 		"use_filename_for_window_title": return true
 		"handle_size": return 1.0 if OS.get_name() != "Android" else 2.0
 		"ui_scale": return ScalingApproach.AUTO
+		"ui_max_fps": return 0
 		"custom_ui_scale": return true
 	return null
 
@@ -281,6 +282,17 @@ enum ScalingApproach {AUTO, CONSTANT_075, CONSTANT_100, CONSTANT_125, CONSTANT_1
 			ui_scale = new_value
 			emit_changed()
 			Configs.ui_scale_changed.emit()
+
+const UI_MAX_FPS_MAX = 320
+const UI_MAX_FPS_MIN = 0
+@export var ui_max_fps := 0:
+	set(new_value):
+		if is_nan(new_value):
+			ui_max_fps = get_setting_default("ui_max_fps")
+		elif new_value != ui_max_fps:
+			ui_max_fps = clampi(new_value,UI_MAX_FPS_MIN, UI_MAX_FPS_MAX)
+			emit_changed()
+		Engine.max_fps = ui_max_fps
 
 
 # Session

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -38,9 +38,9 @@ func get_setting_default(setting: String) -> Variant:
 		"use_native_file_dialog": return true
 		"use_filename_for_window_title": return true
 		"handle_size": return 1.0 if OS.get_name() != "Android" else 2.0
-		"ui_scale": return ScalingApproach.AUTO
-		"ui_max_fps": return 0
-		"custom_ui_scale": return true
+		"scale": return ScalingApproach.AUTO
+		"max_fps": return 0
+		"custom_scale": return true
 	return null
 
 func reset_to_default() -> void:
@@ -283,16 +283,18 @@ enum ScalingApproach {AUTO, CONSTANT_075, CONSTANT_100, CONSTANT_125, CONSTANT_1
 			emit_changed()
 			Configs.ui_scale_changed.emit()
 
-const UI_MAX_FPS_MAX = 1337
-const UI_MAX_FPS_MIN = 0
-@export var ui_max_fps := 0:
+const MAX_FPS_MAX = 600
+const MAX_FPS_MIN = 20
+@export var max_fps := 0:
 	set(new_value):
 		if is_nan(new_value):
-			ui_max_fps = get_setting_default("ui_max_fps")
-		elif new_value != ui_max_fps:
-			ui_max_fps = clampi(new_value,UI_MAX_FPS_MIN, UI_MAX_FPS_MAX)
+			max_fps = get_setting_default("max_fps")
+		elif new_value != 0:
+			max_fps = clampi(new_value, MAX_FPS_MIN, MAX_FPS_MAX)
+		
+		if new_value != max_fps:
 			emit_changed()
-		Engine.max_fps = ui_max_fps
+			Engine.max_fps = max_fps
 
 
 # Session

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -283,7 +283,7 @@ enum ScalingApproach {AUTO, CONSTANT_075, CONSTANT_100, CONSTANT_125, CONSTANT_1
 			emit_changed()
 			Configs.ui_scale_changed.emit()
 
-const UI_MAX_FPS_MAX = 320
+const UI_MAX_FPS_MAX = 1337
 const UI_MAX_FPS_MIN = 0
 @export var ui_max_fps := 0:
 	set(new_value):

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -286,6 +286,13 @@ func setup_content() -> void:
 			add_dropdown(Translator.translate("UI scale"), dropdown_values, dropdown_map)
 			add_advice(Translator.translate("Changes the scale factor for the interface."))
 			
+			current_setup_setting = "ui_max_fps"
+			add_number_dropdown(Translator.translate("Max FPS"),
+					[0, 30, 60, 120, 240], true, false,
+					SaveData.UI_MAX_FPS_MIN, SaveData.UI_MAX_FPS_MAX)
+			add_advice(Translator.translate(
+					"Limits the framerate of the user interface. If set to 0, the framerate will be unlimited"))
+			
 			# Disable mouse wrap if not available.
 			if not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE_WARP):
 				wraparound_panning.permanent_disable_checkbox(false)

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -291,7 +291,7 @@ func setup_content() -> void:
 					[0, 30, 60, 120, 240], true, false,
 					SaveData.UI_MAX_FPS_MIN, SaveData.UI_MAX_FPS_MAX)
 			add_advice(Translator.translate(
-					"Limits the framerate of the user interface. If set to 0, the framerate will be unlimited"))
+					"Limits the framerate of the user interface. If set to 0, the framerate will be unlimited."))
 			
 			# Disable mouse wrap if not available.
 			if not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE_WARP):

--- a/src/ui_widgets/number_dropdown.gd
+++ b/src/ui_widgets/number_dropdown.gd
@@ -20,7 +20,7 @@ func set_value(new_value: String) -> void:
 		proposed_num = roundi(proposed_num)
 	if not restricted and not proposed_num in values:
 		proposed_num = clampf(proposed_num, min_value, max_value)
-	if not is_equal_approx(current_num, proposed_num):
+	if not is_equal_approx(current_num, proposed_num) or _value.is_empty():
 		_value = to_str(proposed_num)
 		value_changed.emit(_value)
 	if is_instance_valid(line_edit):

--- a/src/ui_widgets/number_dropdown.gd
+++ b/src/ui_widgets/number_dropdown.gd
@@ -20,9 +20,11 @@ func set_value(new_value: String) -> void:
 		proposed_num = roundi(proposed_num)
 	if not restricted and not proposed_num in values:
 		proposed_num = clampf(proposed_num, min_value, max_value)
-	if not is_equal_approx(current_num, proposed_num) or _value.is_empty():
+	if not is_equal_approx(current_num, proposed_num):
 		_value = to_str(proposed_num)
 		value_changed.emit(_value)
+	elif _value.is_empty():
+		_value = to_str(proposed_num)
 	if is_instance_valid(line_edit):
 		line_edit.text = _value
 


### PR DESCRIPTION
Closes #1342 

~~Currently there's a bug where the default value 0 doesn't show in the UI when opening the settings.~~(I tried to fix it by checking if the currently displayed string is empty)

The FPS limit doesn't apply until you press enter.