### PR TITLE
Poedit view source workaround

### DIFF
--- a/godot_only/scripts/update_translations.gd
+++ b/godot_only/scripts/update_translations.gd
@@ -84,10 +84,10 @@ func search_directory(dir: String) -> void:
 				for msg in messages:
 					if msg.msgid == msgid:
 						already_exists = true
-						msg.files.append(full_file_name)
+						msg.files.append(full_file_name + ":")
 						break
 				if not already_exists:
-					messages.append(Message.new(msgid, PackedStringArray([full_file_name])))
+					messages.append(Message.new(msgid, PackedStringArray([full_file_name + ":"])))
 
 
 func update_translations() -> void:

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -14,1287 +14,1287 @@ msgstr ""
 msgid "translation-credits"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr ""
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr ""
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr ""
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr ""
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr ""
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr ""
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr ""
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr ""
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr ""
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr ""
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr ""
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr ""
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr ""
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr ""
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr ""
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr ""
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
 msgstr ""
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr ""
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr ""
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr ""
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr ""
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr ""
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr ""
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr ""
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr ""
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr ""
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr ""
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr ""
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr ""
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr ""
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr ""
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr ""
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr ""
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr ""
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr ""
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr ""
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr ""
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr ""
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr ""
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr ""
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "MewPurPur <mew.pur.pur@gmail.com>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Затвори GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Наистина ли искаш да затвориш GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Затвори"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Провери за ъпдейти?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Това ще се свърже с github.com за да сравни числата на версиите. Не се "
 "събират или изпращат никакви други данни."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "Добре"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Искаш ли да продължиш?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Експортирай SVG-то"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Експортирай"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,43 +64,43 @@ msgstr ""
 "Графиката може да бъде експортирана само като SVG защото височината и "
 "широчината са твърде различни."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Графиката може да бъде експортирана само като SVG защото размерът не е "
 "определен."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Предупреждение!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Затвори раздела"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Възстанови"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Виж в инспектора"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Превърни в"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Вмъкни отпред"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "Последното състояние на този раздел не беше намерено."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -108,271 +108,271 @@ msgstr ""
 "Този раздел е свързан с пътеката {file_path}. Искаш ли да го възстановиш SVG-"
 "то от тази пътека?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Компактен"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Красив"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Винаги"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Всички освен контейнери"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Никога"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Когато е по-късо или еднакво дълго"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Когато е по-късо"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "Хекс с 3 или 6 цифри"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "Хекс с 6 цифри"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Празен"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Незаписан"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Коментар"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Текст"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} трябва да е във {allowed} за да има ефект."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Тази група няма елементи."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Тази група има само един елемент."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Не е дефиниран \"id\" атрибут."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Няма <stop> елемент под този градиент."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Този градиент е едноцветен."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Текстът не описва SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Несъвместими тагове."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Затвори"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Автори"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Дарители"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Лиценз"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Лицензи от трети партии"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Основател и мениджър на проекта"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Програмисти"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Преводачи"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Златни дарители"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Диамантени дарители"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Запиши SVG-то като…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Графики"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Размер на захващането"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Постави справочно изображение"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Линкове към платформи за дарение"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Отказ"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Добави елемент"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Измерения"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Размер"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Конфигурация на експорта"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Формат"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Без загуба на качество"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Качество"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Мащаб"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Широчина"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Височина"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Копирай"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "Размерът на визуализацията е ограничен до {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Оформление"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Виж запазените данни"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Отиди в родителската папка"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Обнови файловете"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Превключи видимостта на скритите файлове"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Търсене из файловете"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Запиши"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Избери"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Пътека"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Замени"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Създай нова папка"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Невалидно име за папка."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Папка с това име вече съществува."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Папката не можа да бъде създадена"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Отвори"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Копирай пътеката"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -380,345 +380,345 @@ msgstr ""
 "Файл с името \"{file_name}\" вече съществува. Заместването ще пренапише "
 "неговото съдържание!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Нова фигура"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Проблеми в импортирането"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Импортирай"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Непознат елемент"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Непознат атрибут"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Синтактична грешка"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Добави елемент"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Изключени"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Влачи и пусни за да промениш оформлението на интерфейса"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Файл"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Промени"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Инструмент"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Гледка"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Захващане"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Форматиране"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Палети"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Бързи клавиши"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Гама"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Лента с раздели"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Други"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Цветове на SVG текста"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Цвят на символите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Цвят на елементите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Цвят на атрибутите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Цвят на низовете"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Цвят на коментарите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Цвят на текста"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Цвят на CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Цвят на грешките"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Цвят на дръжките"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Вътрешен цвят"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Обикновен цвят"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Цвят под курсора"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Избран цвят"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Избран цвят под курсора"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Основни цветове"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Цвят на задния фон"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Цвят на решетката"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Цвят на валидният текст"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Цвят на предупрежденията"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Входни сигнали"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Затваряне на раздели със средното копче на мишката"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Обърни посоката на увеличение"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Превъртане на курсора"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Използвай CTRL за увеличение"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Разни"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Използвай местния файлов мениджър"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Синхронизирай името на прозореца с файла"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Размер на дръжките"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Мащаб на интерфейса"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Увеличава мащаба на интерфейса."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Език"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Импортирай XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Постави XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Добави палета"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Добави палета от XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Форматировач за приложението"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Форматировач за експортиране"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Помощ"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Възстанови всички до началната стойност"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Шаблон"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Запази коментарите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Запази непознатите XML структури"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Добави нов ред накрая"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Използвай кратък синтаксис за тагове"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Остави растояние преди наклонената черта на съкратени тагове"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Включи красивото форматиране"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Използвай интервали вместо табулации"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Брой интервали за отстъп"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Числа"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Премахни водещата нула"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Използвай експонент когато е по-кратко"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Цветове"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Използвай именувани цветове"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Първичен синтаксис"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Използвай главни хексадецимални букви"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Данни за пътека"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Смали числата"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Намали паузите"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Премахни паузите след флаговете"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Премахни последователните команди"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Поредици от трансформации"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Премахни ненужните параметри"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -726,11 +726,11 @@ msgstr ""
 "Когато е включено, натискането на раздел със средното копче на мишката "
 "затваря раздела. Ако е изключено, средното копче фокусира раздела."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Разменя посоките на влачене за намаляване и увеличаване"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -738,14 +738,14 @@ msgstr ""
 "Превърта курсора когато той достигне краищата на екрана докато влачи "
 "гледката."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Когато е включено, влаченето премества гледката. За увеличение, натисни CTRL "
 "докато влачиш."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -754,7 +754,7 @@ msgstr ""
 "операционна система. Ако е изключено, използва вградения файлов мениджър на "
 "GodSVG."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -762,563 +762,563 @@ msgstr ""
 "Когато е изключено, името на прозореца остава \"GodSVG\" без да включва "
 "настоящия файл."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Увеличава размера и площта в която дръжките могат да бъдат хванати."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Хоризонтална лента"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Вертикална лента"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Хоризонтален с два реда"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Настройки на панела с бързи клавиши"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Създай нов раздел"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Превърти назад"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Превърти напред"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Това SVG не е свързано с местоположение на компютъра."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Опитай отново"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Покажи предварителните издания"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Настояща версия"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Извлича се информацията..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Грешка в проверката за ъпдейти"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Разгледай всички издания"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG е актуален."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Налични са нови версии!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Създай"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Търсене на цвят"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Цветно колело"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Промени името на цвета"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Изтрий цвета"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Неименуван"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Ключови цветове"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Пипета"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Неименуваните палети няма да бъдат показани."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Не може няколко палети да имат едно и също име."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Тази палета има еднакво определетни цветове."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Преименувай"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Премести нагоре"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Премести надолу"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Приложи шаблон"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Премахни"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Копирай като XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Запиши като XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Относително"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Няма пътека"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Няма точки"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Използва се също от..."
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Възстанови началната стойност"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Неизползван"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Добави бърз клавиш"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Натисни клавиши…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Няма трансформации"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Приложи матрицата"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Вмъкни отзад"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Нова трансформация"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG не разпознава този атрибут"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr "Следните файлове бяха отхвърлени:"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr "{file_path} бе отхвърлен."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr "Отхвърлени файлове"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr "Продължи"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr "{file_path} не можа да бъде отворен."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Проверете дали файлът все още съществува на избраното място."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr "Продължи с импортирането на останалите файлове?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr "Продължи за всеки файл който не може да бъде отворен"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Записване на файла?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Искаш ли да запишеш този файл?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Записване на промените?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Промените ще бъдат изгубени ако не ги запишеш."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Не записвай"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "{file_path} вече се редактира в GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Ако искаш да премахнеш промените след последното записване, използвай "
 "{reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Искаш ли да запишеш промените върху {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Запиши SVG-то"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Запиши SVG-то като"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Затвори разделите отляво"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Затвори разделите отдясно"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Затвори другите раздели"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr "Затвори празните раздели"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr "Затвори записаните раздели"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Създай раздел"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Избери раздела отпред"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Избери раздела отзад"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Оптимизирай"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Оптимизирай SVG-то"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Копирай всичкия текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Копирай всичкия SVG текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Рестартирай SVG-то"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Отвори с външно приложение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Отвори SVG с външно приложение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Покажи във файловия мениджър"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Покажи SVG-то във файловия мениджър"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Върни назад"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Върни напред"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Постави"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Изрежи"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Избери всички"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Дублирай"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Изтрий селекцията"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Изтрий селекцията"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Премести нагоре"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Премести селекцията нагоре"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Премести надолу"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Премести селекцията надолу"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Намери"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Увеличи"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Намали"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Рестартирай мащаба"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Покажи решетката"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Покажи дръжките"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Покажи растеризиран SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Превключи захващането"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Зареди справочно изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Покажи справочното изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Насложи справочното изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Покажи дебъг информацията"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Отвори настройките"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Относно приложението…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Отвори информацията за приложението"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Направи дарение…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Отвори менюто за дарения"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Репозиторията на GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Отвори репозиторията на GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Уебсайта на GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Отвори уебсайта на GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Провери за ъпдейти"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Излизане от апликацията"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Превключване на пълен екран"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Премести до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Отсечка до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Хоризонтална отсечка до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Вертикална отсечка до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Затвори пътеката"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Елиптична дъга до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Квадратна крива на Безие до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Кратка квадратна крива на Безие до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Кубична крива на Безие до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Кратка кубична крива на Безие до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Абсолютно"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Редактор за код"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Инспектор"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Гледка"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr "Избери {format} файлове"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Избери изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Избери {format} файл"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Запази {format} файла"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr "Единствено {extension_list} файлове се поддържат от тази операция."

--- a/translations/de.po
+++ b/translations/de.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Kiisu-Master, Swarkin"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "GodSVG beenden"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Möchten Sie GodSVG beenden?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Beenden"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Nach Aktualisierungen suchen?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Dadurch wird eine Verbindung zu github.com hergestellt, um Versionsnummern "
 "zu vergleichen. Es werden keine weiteren Daten gesammelt oder übertragen."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "OK"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Möchten Sie fortfahren?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "SVG exportieren"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Exportieren"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,45 +64,45 @@ msgstr ""
 "Die Grafik kann nur als SVG exportiert werden, da ihre Proportionen zu "
 "extrem sind."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Die Grafik kann nur als SVG exportiert werden, da ihre Größe nicht definiert "
 "ist."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Achtung!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Registerkarte schließen"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Im Inspektor anzeigen"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Konvertieren zu"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Danach einsetzen"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr ""
 "Der letzte Bearbeitungsstand dieser Registerkarte konnte nicht gefunden "
 "werden."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -110,272 +110,272 @@ msgstr ""
 "Die Registerkarte ist an den Dateipfad {file_path} gebunden. Möchten Sie die "
 "SVG-Datei aus diesem Pfad wiederherstellen?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Kompakt"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Schön"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Immer"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Alle außer Behälter"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Nie"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Wenn kürzer oder gleich"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Wenn kürzer"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3-stelligen oder 6-stelligen Hex"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6-stelligen Hex"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Leer"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Ungespeichert"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Kommentar"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Text"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr ""
 "{element} muss sich innerhalb {allowed} befinden, um einen Effekt zu haben."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Diese Gruppe hat keine Elemente."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Diese Gruppe hat nur ein Element."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Kein \"id\" Attribut definiert."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Keine <stop> Elemente unter diesem Farbverlauf."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Dieser Farbverlauf ist einfarbig."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Beschreibt kein SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Ungültige Formatierung."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Schließen"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Autoren"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Spender"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Lizenz"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Drittanbieter-Lizenzen"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Projektgründer und Manager"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Entwickler"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Übersetzer"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Gold-Spender"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Diamant-Spender"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "SVG speichern als…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Visuelles"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Rastergröße"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Referenzbild einfügen"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Links zu Spendenplattformen"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Neues Element"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Dimensionen"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Größe"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Export-Konfiguration"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Format"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Verlustlos"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Qualität"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Skalieren"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Breite"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Höhe"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "Vorschaubildgröße ist auf {dimensions} limitiert."
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Layout"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Speicherdaten anzeigen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Zum übergeordneten Ordner gehen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Dateien aktualisieren"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Versteckte Dateien anzeigen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Datei suchen"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Speichern"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Auswählen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Pfad"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Ersetzen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Neuen Ordner erstellen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Ungültiger Ordnername."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Ein gleichnamiger Ordner existiert bereits."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Ordner konnte nicht erstellt werden."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Öffnen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Pfad kopieren"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -383,345 +383,345 @@ msgstr ""
 "Eine Datei mit dem Namen \"{file_name}\" existiert bereits. Ersetzen wird "
 "den Inhalt überschreiben!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Neue Form"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Probleme beim Importieren"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Importieren"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Unerkanntes Element"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Unerkanntes Attribut"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Syntaxfehler"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Element hinzufügen"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Ausgeschlossen"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Ziehen und Ablegen zum Ändern des Layouts"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Datei"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Werkzeuge"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Ansicht"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Einrasten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Formatierung"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Paletten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Tastenkombinationen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Farbschema"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Tableiste"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Anderes"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "SVG Textfarben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Symbolfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Elementfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Attributfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Zeichenkettenfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Kommentarfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Textfarbe"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "CDATA-Farbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Fehlerfarbe"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Grifffarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Innenfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Normalfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Farbe unter der Maus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Auswahlfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Ausgewählte Farbe unter der Maus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Allgemeine Farben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Hintergrundfarben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Rasterfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Gültige Farbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Warnfarbe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Eingabe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Registerkarten mit mittlerer Maustaste schließen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Zoomrichtung umkehren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Herumwickelndes Verschieben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Strg-Taste zum Zoomen benutzen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Verschiedenes"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Nativen Dateidialog verwenden"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Fenstertitel mit Dateinamen synchronisieren"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Griffgröße"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Benutzeroberflächenskalierung"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Verändert den Skalierungsfaktor der Benutzeroberfläche."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Sprache"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "XML importieren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "XML einfügen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Neue Palette"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Neue Palette aus XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Editor-Formatierer"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Export-Formatierer"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Hilfe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Alle auf Standardeinstellung zurücksetzen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Voreinstellung"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Kommentare beibehalten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Unbekannte XML Strukturen beibehalten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Nachfolgenden Zeilenumbruch hinzufügen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Kurzbezeichnung für Tags verwenden"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Leerzeichen zu dem Schrägstrich bei abgekürzten Tags hinzufügen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Schöne Formatierung verwenden"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Leerzeichen anstatt Tabulatorzeichen verwenden"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Anzahl der Tabulationsleerzeichen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Nummern"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Führende Null entfernen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Exponentialschreibweise benutzen wenn kürzer"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Farben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Farben mit Namen verwenden"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Primärsyntax"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Hexadezimale Buchstaben großschreiben"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Pfaddaten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Nummern komprimieren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Leerplatz minimieren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Leerplätze nach Eigenschaften (flag) entfernen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Aufeinanderfolgende Befehle entfernen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Transformationlisten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Unnötige Parameter entfernen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -730,11 +730,11 @@ msgstr ""
 "der mittleren Maustaste geschlossen. Wenn diese Option ausgeschaltet ist, "
 "wird die Registerkarte stattdessen fokussiert."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Tauscht die Scrollrichtung für das Rein- und Rauszoomen."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -742,14 +742,14 @@ msgstr ""
 "Teleportiert den Mauszeiger zur gegenüberliegenden Seite, soblald eine "
 "Bildschirmgrenze während des Verschiebens erreicht wird."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Wenn diese Option aktiviert ist, wird die Ansicht durch Scrollen verschoben. "
 "Um zu zoomen muss beim Scrollen die STRG-Taste gedrückt werden."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -758,7 +758,7 @@ msgstr ""
 "verwendet. Wenn diese Option deaktiviert ist, wird GodSVG's eingebauter "
 "Dateidialog verwendet."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -766,569 +766,569 @@ msgstr ""
 "Wenn diese Option deaktiviert ist, bleibt der Fenstertitel \"GodSVG\", ohne "
 "die aktuelle Datei anzuzeigen."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Erhöht die visuelle Größe und den Interaktionsbereich von Griffen."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Horizontaler Streifen"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Vertikaler Streifen"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horizontal mit zwei Reihen"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Kurzbefehlsmenü anpassen"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Neue Registerkarte erstellen"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Nach hinten scrollen"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Nach vorne scrollen"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Dieses SVG ist noch nicht an einen Dateiort gebunden."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Erneut versuchen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Vorschauversionen anzeigen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Aktuelle Version"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Abruf von Informationen..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Aktualisierungsprüfung fehlgeschlagen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Alle Veröffentlichungen anzeigen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG ist auf dem neuesten Stand."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Neue Versionen verfügbar!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Erstellen"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Farbe suchen"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Farbauswahl"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Farbnamen ändern"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Farbe löschen"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Unbenannt"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Farbschlüsselwörter"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Pipette"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Unbenannte Paletten werden nicht angezeigt."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Mehrere Paletten können nicht den gleichen Namen besitzen."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Diese Palette hat identisch definierte Farben."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Umbenennen"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Nach oben"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Nach unten"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Voreinstellung anwenden"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Löschen"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Kopieren als XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Speichern als XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Relativ"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Keine Pfaddaten"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Keine Punkte"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Auch genutzt von"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Zurücksetzen"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Unbenutzt"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Tastenkombination hinzufügen"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Drücke Tasten…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Keine Transformationen"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Die Matrix anwenden"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Davor einsetzen"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Neue Transformation"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG erkennt diese Attribute nicht"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} couldn't be opened."
 msgstr "Die Datei konnte nicht geöffnet werden."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Prüfen, ob die Datei im ausgewählten Dateipfad noch existiert."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Datei speichern?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Möchten Sie diese Datei speichern?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Die Änderungen speichern?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Ihre Änderungen gehen verloren, wenn sie nicht gespeichert werden."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Nicht speichern"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "Die importierte Datei wird bereits in GodSVG bearbeitet."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Wenn Sie Ihre Änderungen seit dem letzten Speichern rückgängig machen "
 "wollen, verwenden Sie {reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Möchten Sie die an {file_name} vorgenommenen Änderungen speichern?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "SVG speichern"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "SVG speichern als"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Alle Registerkarten links schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Alle Registerkarten rechts schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Alle anderen Registerkarten schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close empty tabs"
 msgstr "Registerkarte schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close saved tabs"
 msgstr "Alle anderen Registerkarten schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Registerkarte erstellen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Nächsten Tab auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Vorherigen Tab auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Optimieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "SVG optimieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Text kopieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "SVG-Text kopieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "SVG zurücksetzen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Extern öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "SVG extern öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Im Dateisystem anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "SVG im Dateisystem anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Rückgängig"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Wiederholen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Alle auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Duplizieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Auswahl duplizieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Auswahl löschen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Nach oben verschieben"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Auswahl nach oben verschieben"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Nach unten verschieben"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Auswahl nach unten verschieben"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Finden"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Hineinzoomen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Herauszoomen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Zoom zurücksetzen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Raster anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Griffe anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Rasterisiertes SVG anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Einrasten aktivieren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Referenzbild laden"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Referenzbild anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Referenzbild überblenden"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Debuginformationen anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Einstellungsmenü öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Über…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Infomenü anzeigen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Spenden…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Spendemenü öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "GodSVG Repository"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "GodSVG-Repository öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "GodSVG Webseite"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "GodSVG-Webseite öffnen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Nach Aktualisierungen suchen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Anwendung verlassen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Vollbildmodus umschalten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Bewege zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Linie zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Horizontale Linie zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Vertikale Linue zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Pfad schließen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Elliptischer Bogen zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Quadratischer Bezier zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Kurzhand-Quadratischer Bezier zu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Kubischer Bezier to"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Kurzhand-Kubischer Bezier to"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absolut"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Code-Editor"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Inspektor"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Ansichtsfenster"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select {format} files"
 msgstr "{format}-Datei auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Bild auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "{format}-Datei auswählen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Die {format}-Datei speichern"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/en.po
+++ b/translations/en.po
@@ -15,1287 +15,1287 @@ msgstr ""
 msgid "translation-credits"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr ""
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr ""
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr ""
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr ""
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr ""
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr ""
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr ""
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr ""
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr ""
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr ""
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr ""
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr ""
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr ""
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr ""
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr ""
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr ""
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr ""
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr ""
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr ""
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr ""
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr ""
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
 msgstr ""
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr ""
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr ""
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr ""
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr ""
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr ""
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr ""
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr ""
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr ""
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr ""
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr ""
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr ""
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr ""
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr ""
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr ""
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr ""
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr ""
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr ""
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr ""
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr ""
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr ""
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr ""
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr ""
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr ""
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr ""
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr ""
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr ""
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr ""
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr ""
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr ""
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Alejandro Moctezuma <moctezumaalejandro25@gmail.com>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Salir de GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "¿Quieres salir de GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Salir"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "¿Buscar actualizaciones?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Esto se conectará a github.com para comparar los números de versión. No se "
 "recopilan ni transmiten otros datos."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "OK"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "¿Quieres continuar?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Exportar SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Exportar"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,42 +64,42 @@ msgstr ""
 "El gráfico solo se puede exportar como SVG porque sus proporciones son "
 "demasiado extremas."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "El gráfico solo se puede exportar como SVG porque su tamaño no está definido."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "¡Advertencia!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Cerrar pestaña"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Restaurar"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Ver en el Inspector"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Convertir a"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Insertar después"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "No se pudo encontrar el último estado editado de esta pestaña."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -107,271 +107,271 @@ msgstr ""
 "La pestaña está vinculada a la ruta del archivo {file_path}. ¿Quieres "
 "restaurar el SVG desde esta ruta?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Compacto"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Chulo"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Siempre"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Todo excepto contenedores"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Nunca"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Cuando es más corto o igual que"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Cuando es más corto que"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "Hexadecimal de 3 o 6 dígitos"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "Hexadecimal de 6 dígitos"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Vacío"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Sin guardar"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Comentario"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Texto"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} debe estar dentro de {allowed} para tener algún efecto."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Este grupo no tiene elementos."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Este grupo solo tiene un elemento."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "No hay ningún atributo \"id\" definido."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "No hay elementos <stop> en este gradiente."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Este gradiente es un color sólido."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "No describe un SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Anidación inadecuada."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Autores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Donadores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Licencia"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Licencias de terceros"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Fundador y administrador del proyecto"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Desarrolladores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Traductores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Donadores dorados"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Donadores de diamante"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Guardar SVG como…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Visuales"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Tamaño de ajuste"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Pegar imagen de referencia"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Enlaces de las plataformas de donación"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Nuevo elemento"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Dimensiones"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Tamaño"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Exportar configuración"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Formato"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Sin pérdida"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Calidad"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Escala"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Ancho"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Alto"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "El tamaño de la imagen de vista previa está limitado a {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Diseño"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Ver datos guardados"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Ir a la carpeta contenedora"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Actualizar archivos"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Alternar visibilidad de archivos ocultos"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Buscar archivos"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Guardar"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Seleccionar"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Ruta"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Reemplazar"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Crear nueva carpeta"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Nombre inválido para una carpeta."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Ya existe una carpeta con este nombre."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Error al crear una carpeta."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Abrir"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Copiar ruta"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -379,345 +379,345 @@ msgstr ""
 "Ya existe un archivo llamado \"{file_name}\". ¡Reemplazarlo sobrescribirá su "
 "contenido!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Nueva forma"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Problemas de la importación"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Importar"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Elemento no reconocido"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Atributo no reconocido"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Error de sintaxis"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Añadir elemento"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Excluidos"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Arrastra y suelta para cambiar el diseño"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Archivo"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Editar"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Herramientas"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Ver"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Ajuste"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Formato"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Paletas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Atajos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Temas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Barra de pestañas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Otro"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Colores del texto de los SVG"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Color de los símbolos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Color de los elementos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Color de los atributos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Color de las cadenas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Color de los comentarios"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Color del texto"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Color de CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Color de los errores"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Colores de los controladores"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Color interno"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Color normal"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Color flotante"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Color seleccionado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Color flotante seleccionado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Colores básicos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Color del fondo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Color de la cuadrícula"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Color válido"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Color de las advertencias"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Entrada"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Cerrar pestañas con el botón central del ratón"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Invertir dirección de zoom"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Desplazamiento envolvente"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Usar Ctrl para hacer zoom"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Misceláneos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Usar diálogo de archivos nativo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Sincronizar título de la ventana con el nombre del archivo"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Tamaño de los controladores"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Escala de la interfaz de usuario"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Cambia el factor de escala de la interfaz."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Idioma"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Importar XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Pegar XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Nueva paleta"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Nueva paleta desde XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Formato del editor"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Formato de exportación"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Ayuda"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Restablecer todo a los valores predeterminados"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Preajuste"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Mantener comentarios"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Mantener estructuras XML no reconocidas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Agregar nueva línea final"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Usar la sintaxis de etiqueta abreviada"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Espaciar la barra diagonal de las etiquetas abreviadas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Usar formato chulo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Usar espacios en vez de pestañas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Número de espacios de sangría"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Números"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Eliminar ceros iniciales"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Usar exponenciales cuando sean más cortos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Colores"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Usar colores con nombre"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Sintaxis primaria"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Poner en mayúsculas las letras hexadecimales"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Datos de ruta"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Comprimir números"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Minimizar el espaciado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Eliminar espaciado después de banderas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Eliminar comandos consecutivos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Transformar listas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Eliminar parámetros innecesarios"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -725,11 +725,11 @@ msgstr ""
 "Si está activado, al hacer clic en una pestaña con el botón central del "
 "ratón, esta se cierra. Si está desactivado, se centra en la pestaña."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Intercambia las direcciones de desplazamiento para acercar y alejar."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -737,7 +737,7 @@ msgstr ""
 "Mueve el cursor hacia el lado opuesto cada vez que alcanza el límite de la "
 "ventana gráfica mientras se desplaza."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
@@ -745,7 +745,7 @@ msgstr ""
 "panorámica. Para hacer zoom, mantén presionada la tecla Ctrl mientras te "
 "desplazas."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -754,7 +754,7 @@ msgstr ""
 "operativo. Si está desactivado, usa el cuadro de diálogo de archivos "
 "integrado de GodSVG."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -762,570 +762,570 @@ msgstr ""
 "Si está desactivado, el título de la ventana permanece como \"GodSVG\" sin "
 "incluir el archivo actual."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Cambia el tamaño visual y el área de agarre de los controladores."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Franja horizontal"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Franja vertical"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horizontal con dos filas"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Configurar el panel de accesos directos"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Crear una nueva pestaña"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Desplazarse hacia atrás"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Desplazarse hacia adelante"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Este SVG aún no está vinculado a una ubicación de archivo."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Reintentar"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Mostrar prelanzamientos"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Versión actual"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Recuperando la información..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Error en la verificación de actualizaciones"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Ver todos los lanzamientos"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG está actualizado."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "¡Nuevas versiones disponibles!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Crear"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Buscar color"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Cuentagotas"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Editar nombre del color"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Eliminar color"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Sin nombre"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Palabras clave de colores"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Cuentagotas"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "No se mostrarán las paletas sin nombre."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Varias paletas no pueden tener el mismo nombre."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Esta paleta tiene colores definidos idénticamente."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Renombrar"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Mover hacia arriba"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Mover hacia abajo"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Aplicar preajuste"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Eliminar"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Copiar como XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Guardar como XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Relativo"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Sin datos de ruta"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Sin puntos"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "También usado por"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Reestablecer a los valores predeterminados"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "No usado"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Añadir atajo"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Presiona una tecla…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Sin transformaciones"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Aplicar la matriz"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Insertar antes"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Nueva transformación"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG no reconoce este atributo"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} couldn't be opened."
 msgstr "No se pudo abrir el archivo."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr ""
 "Compruebe si el archivo todavía existe en la ruta de archivo seleccionada."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "¿Guardar el archivo?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "¿Quieres guardar este archivo?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "¿Guardar los cambios?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Tus cambios se perderán si no los guardas."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "No guardar"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "El archivo importado ya se está editando dentro de GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Si deseas revertir las ediciones realizadas desde la última vez que se "
 "guardó, utiliza {reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "¿Quieres guardar los cambios realizados en {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Guardar SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Guardar SVG como"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Cerrar pestañas a la izquierda"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Cerrar pestañas a la derecha"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Cerrar todas las demás pestañas"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close empty tabs"
 msgstr "Cerrar pestaña"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close saved tabs"
 msgstr "Cerrar todas las demás pestañas"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Crear pestaña"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Seleccionar la siguiente pestaña"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Seleccionar la pestaña anterior"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Optimizar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Optimizar SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Copiar todo el texto"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Copiar todo el texto SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Reestablecer SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Abrir externamente"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Abrir SVG externamente"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Mostrar en Explorador de Archivos"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Mostrar SVG en Explorador de Archivos"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Deshacer"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Rehacer"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Seleccionar todo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Duplicar la selección"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Eliminar la selección"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Mover hacia arriba"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Mover la selección hacia arriba"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Mover hacia abajo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Mover la selección hacia abajo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Buscar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Acercarse"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Alejarse"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Reestablecer el zoom"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Mostrar cuadrícula"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Mostrar controladores"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Mostrar SVG rasterizado"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Alternar ajuste"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Cargar imagen de referencia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Mostrar imagen de referencia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Superponer imagen de referencia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Ver información de depuración"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Configuración"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Abrir el menú Configuración"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Acerca de…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Abrir el menú Acerca de"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Donar…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Abrir el menú Donar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Repositorio de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Abrir repositorio de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Sitio web de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Abrir sitio web de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Buscar actualizaciones"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Salir de la aplicación"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Alternar pantalla completa"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Mover a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Alinear a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Línea horizontal a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Línea vertical a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Cerrar trazo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Arco elíptico a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Bezier cuadrática a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Bezier cuadrática abreviada a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Bezier cúbica a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Beziers cúbica abreviada a"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absoluto"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Editor de código"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Inspector"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Ventana gráfica"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select {format} files"
 msgstr "Selecciona un archivo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Selecciona una imagen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Selecciona un archivo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Guardar el archivo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/et.po
+++ b/translations/et.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Kiisu-Master"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Sulge GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Kas te tahate sulgeda GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Sulge"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Otsi uuendusi?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "See ühendab github.com-i, et saada versioonide teabe. Muid andmeid ei koguta "
 "ega edastata."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "Okei"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Kas te tahate jätkata?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Ekspordi SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Ekspordi"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,42 +64,42 @@ msgstr ""
 "Graafika saab eksportida ainult SVG-na, sest selle proportsioonid on liiga "
 "ekstreemsed."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Graafika saab eksportida ainult SVG-na, sest selle suurus pole defineeritud."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Hoiatus!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Sulge vahekaart"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Taasta"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Näita inspektoris"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Konverteeri"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Sisesta pärast"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "Selle kaardi viimast seisu polnud võimalik leida."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -107,271 +107,271 @@ msgstr ""
 "See vahekaart on seotud failiga asukohas {file_path}. Kas te soovite "
 "taastada SVG sellest failist?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Kompaktne"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Ilus"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Alati"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Kõik, v.a. konteinerid"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Mitte kunagi"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Kui on lühem või võrdne"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Kui on lühem"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3- või 6-kohaline hex"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6-kohaline hex"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Tühi"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Salvestamata"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Kommentaar"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Tekst"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} peab olema {allowed} sees, et sellel oleks mõju."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Grupis pole ühtegi elementi."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Grupis on ainult üks element."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "\"id\" atribuut pole defineeritud."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Gradiendis puuduvad <stop> elemendid."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Gradient on ühevärviline."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Ei kirjelda SVGd."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Vigane pesitsus."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Sulge"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Autorid"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Annetajad"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Litsents"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Kolmandad litsentsid"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Projekti asutaja ja juht"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Arendajad"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Tõlkijad"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Kuldsed annetajad"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Teemant annetajad"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Salvesta SVG kui…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Visuaalid"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Joondamise mastaap"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Kleebi võrdluspilt"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Annetusplatvormide lingid"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Katkesta"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Uus element"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Dimensioonid"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Suurus"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Ekspordi konfiguratsioon"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Formaat"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Kadudeta"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Kvaliteet"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Skaala"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Laius"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Kõrgus"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Kopeeri"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "Eelvaade on piiratud suurusele {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Paigutus"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Kuva savedata"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Mine taseme võrra üles"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Värskenda failinimekiri"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Lülita peidetud failide kuvamine sisse"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Otsi faile"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Salvesta"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Vali"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Asukoht"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Asenda"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Loo uus kaust"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Vigane kausta nimi."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Kaust selle nimega on juba olemas."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Kausta loomine ebaõnnestus."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Ava"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Kopeeri asukoht"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -379,345 +379,345 @@ msgstr ""
 "Fail nimega \"{file_name}\" on juba olemas, asendamine kirjutab selle sisu "
 "üle!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Uus kujund"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Impordi probleemid"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Impordi"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Tundmatu element"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Tundmatu atribuut"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Süntaksiviga"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Lisa element"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Peidetud"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Lohista, et muuta paigutust"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Fail"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Redigeeri"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Tööriist"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Vaade"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Joonda"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Vorming"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Värvipaletid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Kiirklahvid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Teema"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Kaardiriba"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Muu"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "SVG teksti värvid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Sümboli värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Elemendi värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Atribuudi värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Sõne värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Kommentaari värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Teksti värv"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "CDATA värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Errori värv"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Pideme värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Seesmine värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Tavaline värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Esiletõstetud värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Valiku värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Esiletõstetud valiku värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Alusvärvid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Tausta värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Ruudustiku värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Kehtiva värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Hoiatuse värv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Sisend"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Sulge vahekaarte keskmise hiireklahviga"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Inverteeri suurendussuund"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Takistusteta vaate liigutamine"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Kasuta CTRL klahvi suurendamiseks"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Mitmesugust"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Kasuta süsteemi failidialoogi"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Sünkrooni akna tiitel avatud faili nimega"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Pidemete suurus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Kasutajaliidese suurus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Muudab kasutajaliidese suurust."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Keel"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Impordi XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Kleebi XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Uus palett"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Uus palett XML-ist"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Redaktori vormindus"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Ekspordi vormindus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Abi"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Lähtesta kõik vaikeväärtustele"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Eelseadistus"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Hoia kommentaarid alles"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Hoia tundmatud XML struktuurid alles"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Lisa tühi rida lõppu"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Kasuta tag-i lühisüntaksit"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Lisa tühikuid tag-i lühisüntaksi kaldkriipsu juurde"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Kasuta ilusat vormindust"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Kasuta tühikuid tab-i asemel"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Indenteerimise tühikute arv"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Numbrid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Eemalda üleliigsed nullid numbritest"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Kasuta eksponentvormindust kui see on lühem"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Värvid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Kasuta nimedega värve"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Esmane süntaks"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Kasuta heksadetsimaalnumbrites suurtähti"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Path andmed"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Tihenda numbrid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Minimeeri vahed"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Eemalda tühikud omaduste (flags) järelt"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Eemalda järjestikused samasugused käsud"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Teisendused"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Eemalda ebavajalikud parameetrid"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -725,11 +725,11 @@ msgstr ""
 "Sisselülitamisel sulgeb keskmise hiireklahviga kaardile vajutamine selle. "
 "Väljalülitamisel fokuseeriks see selle."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Vahetab kerimissuunad suurendamiseks ja vähendamiseks ümber."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -737,14 +737,14 @@ msgstr ""
 "Viib kursori akna vastaspoolele, kui see jõuab vaate liigutamise ajal selle "
 "servani, et see liikumist ei takistaks."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Sisselülitamisel kerimine liigutab vaadet. Suurendamiseks hoia CTRL klahvi "
 "kerimise ajal."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -752,571 +752,571 @@ msgstr ""
 "Sisselülitamisel kasutab süsteemi vaikefailidialoogi. Väljalülitamisel "
 "GodSVG sisseehitatud failidialoogi."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
 msgstr ""
 "Väljalülitamisel jääb akna nimieks \"GodSVG\" sõltumata avatud failist."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Muudab pidemete nähtavat ja interaktiivse ala suurust."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Horisontaalne riba"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Vertikaalne riba"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horisontaalne riba kahe reaga"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Kiirklahvida seadistamise paneel"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Loo uus vahekaart"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Keri tagasi"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Keri edasi"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "See SVG ei ole veel seotud failiasukohaga."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Proovi uuesti"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Näita eelväljaandeid"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Praegune versioon"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Informatsiooni saamine..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Uuenduste otsimine ebaõnnestus"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Näita kõiki väljaandeid"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG on ajakohane."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Uuem versioon on saadaval!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Loo"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Otsi värvi"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Värvivalija"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Muuda värvi nime"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Kustuta värv"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Nimetu"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Värvi võtmesõnad"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Värvipipett"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Nimetuid värvipalette ei kuvata."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Mitmel värvipaletil ei saa olla sama nimi."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Selles värvipalettis on sama värv juba olemas."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Nimeta ümber"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Liiguta üles"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Liiguta alla"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Rakenda eelseadistus"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Kustuta"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Kopeeri kui XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Salvesta kui XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Suhteline"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Puudub path andmed"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Puuduvad punktid"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Seda kasutab ka"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Lähtesta vaikeväärtusele"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Kasutamata"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Lisa kiirklahv"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Vajuta klahve…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Puudub teisendus"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Rakenda maatriks"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Sisesta enne"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Uus teisendus"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG ei tunne seda atribuuti"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr "Järgnevad failid hüljati:"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr "{file_path} hüljati."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr "Hüljatud failid"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr "Jätka"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr "{file_path} ei saanud avada."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Kontrollige, kas fail asub veel valitud asukohas."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr "Jätka ülejäänud failide importimisega?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr "Jätka kõikide failide jaoks, mida ei saa avada"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Salvesta fail?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Kas te soovite salvestada selle faili?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Salvesta muudatused?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Muudatused lähevad kaotsi, kui need ei salvestata."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Ära salvesta"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "{file_path} on juba avatud GodSVGs."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Kui te soovite taastada muudatused alates eelmise salvestamise hetkest, "
 "kasutage {reset_svg}-d."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Kas soovite salvestada {file_name} kallal tehtud muudatused?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Salvesta SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Salvesta SVG kui"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Sulge kaardid vasakul"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Sulge kaardid paremal"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Sulge teised kaardid"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr "Sulge tühjad kaardid"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr "Sulge salvestatud kaardid"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Uus vahekaart"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Vali järgmine vahekaart"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Vali eelmine vahekaart"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Optimeeri"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Optimeeri SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Kopeeri terve tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Kopeeri SVG tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Lähtesta SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Ava väliselt"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Ava SVG väliselt"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Kuva failihalduris"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Kuva SVG failihalduris"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Võta tagasi"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Tee uuesti"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Kleebi"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Lõika"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Vali kõik"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Dubleeri"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Dubleeri valik"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Kustuta valik"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Liiguta üles"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Liiguta valik üles"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Liiguta alla"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Liiguta valik alla"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Leia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Suurenda"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Vähenda"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Taasta suurendus"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Kuva ruudustik"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Kuva pidemeid"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Kuva rasterdatud SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Lülita joondamine sisse"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Lae võrdluspilt"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Kuva võrdluspilt"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Kata võrdluspildiga üle"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Kuva silumisinformatsioon"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Seaded"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Ava seadete menüü"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Teave…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Ava teabe menüü"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Anneta…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Ava annetuste menüü"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "GodSVG repositoorium"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Ava GodSVG repositoorium"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "GodSVG veebileht"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Ava GodSVG veebileht"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Otsi uuendusi"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Sulge rakendus"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Täisekraan"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Liigu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Joon"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Horisontaalne joon"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Vertikaalne joon"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Sulge path"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Elliptiline kaar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Kvadratiline Bezier"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Lihtne kvadratiline Bezier"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Kuubiline Bezier"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Lihtne kuubiline Bezier"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absoluutne"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Koodiredaktor"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Inspektor"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Vaade"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr "Vali {format} faile"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Vali pilt"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Vali {format} fail"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Salvesta {format} fail"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr "Ainult {extension_list} failid on toetatud selle tehingu jaoks."
 

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "thatoddshade <thatoddshade@proton.me>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Quitter GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Voulez-vous quitter GodSVG ?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Quitter"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Vérifier les mises à jour ?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Cette action effectuera une connexion à github.com pour comparer les numéros "
 "de version. Aucune autre information ne sera transmise ou collectée."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "OK"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Voulez-vous procéder ?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Exporter le SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Exporter"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,43 +64,43 @@ msgstr ""
 "Le graphique ne peut être exporté qu'en SVG car ses proportions sont trop "
 "extrêmes."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Le graphique ne peut être exporté qu'en SVG car sa taille n'est pas définie."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Alerte !"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Fermer l'onglet"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Restaurer"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 #, fuzzy
 msgid "View in Inspector"
 msgstr "Voir en liste"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Convertir en"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Insérer après"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "Le dernier état modifié de cet onglet n'a pas pu être trouvé."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -108,272 +108,272 @@ msgstr ""
 "L'onglet est lié au chemin d'accès {file_path}. Voulez-vous restaurer le SVG "
 "à partir de ce chemin ?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Compact"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Élégant"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Toujours"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Pour tout sauf les conteneurs"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Jamais"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Quand plus court ou équivalent"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Quand plus court"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "Héxadécimal de 3 ou 6 chiffres"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "Héxadécimal de 6 chiffres"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Vide"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Non enregistré"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Commentaire"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Texte"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} doit être à l'intérieur de {allowed} pour avoir un effet."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Ce groupe n'a aucun élément."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Ce groupe n'a qu'un seul élément."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Aucun attribut « id » défini."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Aucun élément <stop> en dessous de ce dégradé."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Ce dégradé est une couleur solide."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Ne décrit pas un SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Formatage incorrect."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Fermer"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Auteurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Donateurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Licence"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Licences tierces"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Fondateur et gestionnaire du projet"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Développeurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Traducteurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Donateurs Or"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Donateurs Diamant"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Sauvegarder le SVG sous…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Vue"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Taille d'aimantation"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 #, fuzzy
 msgid "Paste reference image"
 msgstr "Charger une image de référence"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Nouvel élément"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Taille"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Exporter la configuration"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Format"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Sans perte"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Qualité"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Échelle"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Largeur"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Hauteur"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Copier"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "La taille de l'image de prévisualisation est limitée à {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Disposition"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Voir les données de sauvegarde"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Aller au dossier parent"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Actualiser les fichiers"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Activer/Désactiver la visibilité des fichiers cachés"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Rechercher des fichiers"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Sélectionner"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Chemin"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Remplacer"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Créer un nouveau dossier"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Nom invalide pour un dossier."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Un dossier avec ce nom existe déjà."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Échec de création de dossier."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Ouvrir"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Copier le chemin"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -381,357 +381,357 @@ msgstr ""
 "Un fichier nommé « {file_name} » existe déjà. Le remplacer écrasera son "
 "contenu !"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Nouvelle forme"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Importer des problèmes"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Importer"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Élément non reconnu"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Attribut non reconnu"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Erreur de syntaxe"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Ajouter un élément"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr ""
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Fichier"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Édition"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Outils"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Affichage"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Aimanter"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Formatage"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Palettes"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Raccourcis"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Thèmes"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Autre"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Couleurs de texte SVG"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Couleur de symbole"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Couleur d'élément"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Couleur d'attribut"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Couleur de chaîne de caractères"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Couleur de commentaire"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Couleur de texte"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Couleur de CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Couleur d'erreur"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Couleurs des poignées"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Couleur d'intérieur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Couleur d'élément normal"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Couleur d'élément survolé"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Couleur d'élément selectionné"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Couleur d'élément selectionné survolé"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Couleurs basiques"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Couleur d'arrière-plan"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Grid color"
 msgstr "Couleur valide"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Couleur valide"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Couleur d'avertissement"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Entrée"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Inverser la direction du zoom"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Défilement bouclé"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Utiliser CTRL pour zoomer"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Divers"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Utiliser la boîte de dialogue de fichiers native"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Synchroniser le titre de la fenêtre au nom du fichier"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Taille des poignées"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Échelle de l'interface"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Change le facteur d'échelle de l'interface."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Langue"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Importer un fichier XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Coller du XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Nouvelle palette"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Nouvelle palette depuis du XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Formateur de l'éditeur"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Formateur d'exportation"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Aide"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Tout rénitialiser par défaut"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Préréglage"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Garder les commentaires"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Conserver les structures XML non reconnues"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Ajouter un saut de ligne final"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Utiliser la syntaxe de balise raccourcie"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Espacer le slash des balises raccourcies"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Utiliser le formatage élégant"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Utiliser des espaces plutôt que des tabulations"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Nombre d'espaces par indentation"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Nombres"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Retirer le zéro initial"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Noter en exponentiel si c'est plus court"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Couleurs"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Utiliser des couleurs nommées"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Syntaxe primaire"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Mettre en majuscule les nombres héxadécimaux"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Données de chemin d'accès"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Compresser les nombres"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Minimiser l'espacement"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Retirer l'espacement après les marqueurs"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Retirer les commandes consécutives"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Transformer les listes"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Retirer les paramètres inutiles"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr ""
 "Inverser les directions de défilement pour le zoom avant et le zoom arrière."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -739,7 +739,7 @@ msgstr ""
 "Téléporte le curseur de l'autre côté de la vue à chaque fois qu'il en "
 "atteind la limite."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
@@ -747,7 +747,7 @@ msgstr ""
 "Si activé, défiler fera balayer la vue. Pour zoomer, maintenez CTRL en "
 "défilant."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -756,7 +756,7 @@ msgstr ""
 "d'exploitation. Si désactivé, utilise la boîte de dialogue intégrée de "
 "GodSVG."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
@@ -765,579 +765,579 @@ msgstr ""
 "Si désactivé, le titre de la fenêtre restera simplement « GodSVG » quel que "
 "soit le fichier actuel."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Change la taille visuelle et la zone de saisie des poignées"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Rayure horizontale"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Rayure verticale"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horizontal avec deux rangées"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Configurer le panneau de raccourcis"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Créer un nouvel onglet"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Défiler en arrière"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Défiler en avant"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Ce SVG n'est pas encore lié à un emplacement de fichier."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Réessayer"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Inclure les versions préliminaires"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Version actuelle"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Récupération d'information en cours…"
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Échec de la vérification de mise à jour"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "View all releases"
 msgstr "Sélectionner tous les éléments"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG est à jour."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "New versions available!"
 msgstr "Nouvelles versions"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Créer"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Rechercher la couleur"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Pipette"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Éditer le nom de la couleur"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Supprimer la couleur"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Sans nom"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Colorier les mots-clés"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Pipette"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Les palettes sans nom ne seront pas affichées."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Plusieurs palettes ne peuvent pas avoir le même nom."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Cette palette a des couleurs définies identiquement."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Renommer"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Remonter"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Descendre"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Appliquer un préréglage"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Supprimer"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Copier en tant que XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Enregistrer en tant que XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Relatif"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Aucune donnée de chemin"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Aucun point"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Aussi utilisé par"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Rénitialiser par défaut"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Inutilisé"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Ajouter un raccourci"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Appuyez sur les touches…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Aucune transformation"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Appliquer la matrice"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Insérer avant"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Nouvelle transformation"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG ne reconnaît pas cet attribut"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} couldn't be opened."
 msgstr "Le fichier n'a pas pu être ouvert."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Vérifiez si le fichier existe encore au chemin selectionné."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Enregistrer le fichier ?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Voulez-vous enregistrer ce fichier ?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Enregistrer les changements?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Vos changements seront perdus si vous ne les enregistrés pas."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Ne pas enregistrer"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "Le fichier importé est déjà en cours de modification dans GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Si vous voulez rénitialiser vos changements au dernier enregistrement, "
 "utilisez {reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Voulez-vous enregistrer les modifications de {file_name} ?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Sauvegarder le SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save SVG as"
 msgstr "Sauvegarder le SVG sous…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Fermer les onglets sur la gauche"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Fermer les onglets sur la droite"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Fermer les autres onglets"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close empty tabs"
 msgstr "Fermer l'onglet"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close saved tabs"
 msgstr "Fermer les autres onglets"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Créer un onglet"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Sélectionner l'onglet suivant"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Sélectionner l'onglet précédent"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Optimiser"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Optimize SVG"
 msgstr "Optimiser"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Copier tout le texte"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Copy the SVG text"
 msgstr "Copier tout le texte"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Rénitialiser le SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Ouvrir externement"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Ouvrir le SVG externement"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Afficher dans l'explorateur de fichiers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Montrer le SVG dans l'explorateur de fichiers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Annuler"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Rétablir"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Coller"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Couper"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Tout sélectionner"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Dupliquer"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Dupliquer les éléments sélectionnés"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Supprimer les éléments sélectionnés"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move up"
 msgstr "Remonter"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Remonter les éléments sélectionnés"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move down"
 msgstr "Descendre"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Descendre les éléments sélectionnés"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Rechercher"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Zoom avant"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Zoom arrière"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Rénitialiser le zoom"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Afficher la grille"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Montrer les poignées"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Montrer le SVG rastérisé"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Activer/Désactiver l'aimantation"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Charger une image de référence"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Afficher l'image de référence"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Superposer l'image de référence"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Voir les informations de déboggage"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Paramètres"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Ouvrir le menu des paramètres"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "À propos…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Ouvrir le menu « À propos »"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Faire un don…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Ouvrir le menu « Faire un don »"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Dépôt de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Ouvrir le dépôt de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Site web de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Ouvrir le site web de GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Vérifier les mises à jour"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Quitter l'application"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Déplacer vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Ligne vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Ligne horizontale vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Ligne verticale vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Fermer le chemin"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Arc elliptique vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Courbe de Bézier quadratique vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Courbe de Bézier quadratique raccourcie vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Courbe de Bézier cubique vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Courbe de Bézier cubique raccourcie vers"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absolu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr ""
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Viewport"
 msgstr "Affichage"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select {format} files"
 msgstr "Sélectionner un fichier XML"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Sélectionner une image"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select an {format} file"
 msgstr "Sélectionner un fichier XML"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save the {format} file"
 msgstr "Enregistrer le fichier .\"{format}\""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Racer911dash1, jas31415"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "GodSVG afsluiten"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Wil je GodSVG afsluiten?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Afluiten"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Voor updates controleren?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Dit zal een verbinding maken naar github.com om de versienummers te "
 "vergelijken. Er wordt geen andere data verzameld of verzonden."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "OK"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Wil je voortgaan?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Exporteer SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Exporteren"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,44 +64,44 @@ msgstr ""
 "De afbeelding kan alleen maar als SVG geëxporteerd worden door zijn extreme "
 "verhoudingen."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "De afbeelding kan alleen maar als SVG geëxporteerd worden want zijn maat is "
 "niet gedefiniëerd."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Aandacht!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Tabblad sluiten"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Herstel"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 #, fuzzy
 msgid "View in Inspector"
 msgstr "Bekijken In Lijst"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Omzetten Naar"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Erna Invoegen"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "De laatst aangepaste stand van dit tabblad kon niet gevonden worden."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -109,272 +109,272 @@ msgstr ""
 "Het tablad is gebonden aan het bestandspad {file_path}. Wil je de SVG "
 "herstellen vanuit dit pad?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Compact"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Mooi"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Altijd"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Alles behalve containers"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Nooit"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Als korter of gelijk"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Als korter"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3-cijferig of 6-cijferige hex"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6-cijferige hex"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Leeg"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Niet opgeslagen"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Commentaar"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Tekst"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} moet aanwezig zijn in {allowed} om enig effect te hebben."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Deze groep bevat geen elementen."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Deze groep bevat maar één element."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Geen \"id\" attribuut gedefineerd."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Geen <stop> elementen onder deze kleurovergang."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Deze kleurovergang is een vaste kleur."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Beschrijft geen SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Onjuiste nesting."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Afluiten"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Auteurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Donateurs"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Licentie"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Derde partij Licenties"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Projectoprichter en Manager"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Ontwikkelaars"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Vertalers"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Gouden Donatuers"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Diamanten Donateurs"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "SVG opslaan als…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Visuelen"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Maat inknappen"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 #, fuzzy
 msgid "Paste reference image"
 msgstr "Referentiebeeld inladen"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Nieuw element"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Afmetingen"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Maat"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Export Configuratie"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Formaat"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Verliesvrij"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Kwaliteit"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Schaal"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Breedte"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Hoogte"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "Voorbeeldafbeelding maat is beperkt tot {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Indeling"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Bekijk opslaggegevens"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Ga naar bovenliggende map"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Bestanden vernieuwen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "De zichtbaarheit van verborgen bestanden omschakelen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Bestanden zoeken"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Opslaan"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Selecteren"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Pad"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Vervangen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Nieuwe map creëren"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Ongeldige naam voor een map."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Een map met deze naam bestaat al."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Aanmaken van een nieuwe map mislukt."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Openen"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Pad kopiëren"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -382,356 +382,356 @@ msgstr ""
 "Er bestaat al een bestand genaamt \"{file_name}\". Deze vervangen zal zijn "
 "inhoud aanpassen!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Nieuwe vorm"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Importproblemen"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Importeren"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Onherkende element"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Onherkende attribuut"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Syntaxfout"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Element toevoegen"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr ""
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Bestand"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Bewerken"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Gereedschap"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Zicht"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Knappen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Formattering"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Paletten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Snelkoppelingen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Thematiek"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Tabladbalk"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Overige"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "SVG tekstkleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Symboolkleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Elementkleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Attribuutkleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Stringkleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Commentaarkleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Textkleur"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "CDATA-kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Fout-kleur"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Handvatkleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Binnenkantkleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Normale kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Zweefde kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Gekozen kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Zweefde gekozen kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Basiskleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Achtergrondskleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Grid color"
 msgstr "Geldige kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Geldige kleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Waarschuwingskleur"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Invoer"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Sluit tabbladen met de middelste muisknop"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "inzoomrichting tegenstellen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Omwikkeld rondkijken"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Gebruik CTRL om in te zoomen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Overige"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Gebruik inheemse bestandendialoog"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Synchroniseer venstertitel naar bestandsnaam"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Handvat maat"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Gebruiksinterface maat"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Verandert het maat-factor van de gebruikersinterface."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Taal"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "XML Importeren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "XML Plakken"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Nieuw palette"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Nieuwe palette uit XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Editor-formatter"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Exportformatter"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Help"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Reset allen naar standaard"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Voorinstelling"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Houdt commentaar bij"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Houdt onherkende XML structuren bij"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Voeg achterliggende nieuwe regel toe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Gebruik afgekorte tag syntax"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Scheidt de schuine streep af van afgekorte tags"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Gebruik mooie formattering"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Gebruik spaties in plaats van tabs"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Aantal inspringingsspaties"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Nummers"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Verwijder voorafgande nul"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Gebruik exponentieel als korter"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Kleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Gebruik genoemde kleuren"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Primaire syntax"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Kapitaliseer hexadecimale letters"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Padgegevens"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Nummers samendrukken"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Minimaliseer afstand"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Verwijder afstand na vlaggen"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Verwijder opeenvolgende opdrachten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Transformeer lijsten"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Verwijder onnodige parameters"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Verwisselt de scroll richtingen voor inzoomen en uitzoomen."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -739,7 +739,7 @@ msgstr ""
 "Verplaatst de cursur naar de overkant wanneer het buiten de viewport gaat "
 "tijdens het rondkijken."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
@@ -747,7 +747,7 @@ msgstr ""
 "Als ingeschakeld, scrollen zal het weergave verschuiven. Om te zoomen,houd "
 "CTRL ingedrukt tijdens scrollen."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -756,7 +756,7 @@ msgstr ""
 "bestandendialoog. Wanneer uitgeschakeld, gebruikt GodSVG's ingebouwde "
 "bestandendialoog."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
@@ -765,579 +765,579 @@ msgstr ""
 "Als dit uitgeschakelt is, blijft de venstertitel simpelweg \"GodSVG\" "
 "achteloos van het huidige bestand."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "verandert de visuele grootte en grijpgebieden van handvaten."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Horizontale lijn"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Vertikale lijn"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horizontaal met twee rijen"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Configureer Snelkoppelingspaneel"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Een nieuw tabblad creëren"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Scroll achteruit"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Scroll vooruit"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Deze SVG is nog niet gebonden aan een bestandslocatie."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Opnieuw proberen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Laat prereleases zien"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Huidige versie"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Informatie aan het ophalen..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Updatecontrole mislukt"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "View all releases"
 msgstr "Selecteer alle elementen"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG is up-to-date."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "New versions available!"
 msgstr "Nieuwe versies"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Creëren"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Zoekkleur"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Kleurenplukker"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Kleurnaam bewerken"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Kleur verwijderen"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Onbenoemd"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "kleur trefwoorden"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Druppelaar"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Onbenoemde paletten zullen niet laten zien worden."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Meerdere paletten kunnen niet dezelfde naam hebben."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Dit palette heeft identiek gedefinieerde kleuren."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Hernoemen"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Naar Boven"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Naar Onder"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Voorinstelling toepassen"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Als XML kopiëren"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Als XML opslaan"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Relatief"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Geen padgegevens"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Geen punten"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Ook gebruikt door"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Reset naar standaard"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Ongebruikt"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Snelkoppeling toevoegen"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Druk op toetsen…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Geen transformaties"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Matrix toepassen"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Ervoor Bijvoegen"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Nieuwe transformatie"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG herkent deze attribuut niet"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} couldn't be opened."
 msgstr "Het bestand kon niet worden geopend."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Kijk na of het bestand nog steeds bestaat in het gekozen bestandspad"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "sla het bestand op?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Wil je dit bestand opslaan?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "sla de aanpassingen op?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Uw aanpassingen zullen verdwijnen als u ze niet opslaat."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Niet opslaan."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "Het geïmporteerde bestand is al geöpend in GodSVG"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Als u uw aanpassingen van de vorige opslag wilt ongedaanmaken, gebruik "
 "{reset_svg}"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Wilt u de aanpassingen opslaan als {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "SVG opslaan"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save SVG as"
 msgstr "SVG opslaan als…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Sluit linker tabbladen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Sluit rechter tabbladen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Kopiëer alle tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close empty tabs"
 msgstr "Tabblad sluiten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close saved tabs"
 msgstr "Kopiëer alle tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Tabblad creëren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Selecteer het volgende tabblad"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Selecteer het vorige tabblad"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Optimaliseren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Optimize SVG"
 msgstr "Optimaliseren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Kopiëer alle tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Copy the SVG text"
 msgstr "Kopiëer alle tekst"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "SVG Resetten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Extern openen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "SVG extern openen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Laat zien in Bestandsenverkenner"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Laat SVG zien in Bestandsverkenner"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Opnieuw doen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Knippen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Alles selecteren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Dupliceren"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Dupliceer de selectie"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Verwijder de selectie"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move up"
 msgstr "Naar Boven"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Beweeg de selectie omhoog"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move down"
 msgstr "Naar Onder"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Beweeg de selectie omlaag"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Vind"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Inzoomen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Uitzoomen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Zoom resetten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Raster weergeven"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Handvaten weergeven"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Gerasterd SVG weergeven"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Knappen omschakelen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Referentiebeeld inladen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Referentie afbeelding weergeven"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Referentie afbeelding overlappen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Bekijk debug informatie"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Instellingen"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Open Instellingenmenu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Betreffende…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Open het Betreffende menu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Doneren…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Open Doneermenu"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "GodSVG opslagplaats"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Open GodSVG opslagplaats"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "GodSVG website"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Open GodSVG website"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Nakijken voor updates"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Applicatie afsluiten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Verplaats naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Lijn naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Horizontale lijn naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Vertikale lijn naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Pad sluiten"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Elliptische Boog naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Kwadratische Bézier naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Afgekorte Kwadratische Bézier naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Kubieke Bézier naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Afgekorte Kubieke Bézier naar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absoluut"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr ""
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Viewport"
 msgstr "Zicht"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select {format} files"
 msgstr "Kies een XML bestand uit"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Kies een afbeedling"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select an {format} file"
 msgstr "Kies een XML bestand uit"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save the {format} file"
 msgstr "Bewaar het .\"{format}\" bestand"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Felipe Sena Costa <felipe.sena.work.contact@gmail.com>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Sair do GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Você deseja sair do GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Sair"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Verificar atualizações?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Isso irá conectar ao github.com para comparar o número de versionamento. "
 "Nenhum outro dado será colecionado ou transmitido."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "OK"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Você deseja prosseguir?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Exportar SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Exportar"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,43 +64,43 @@ msgstr ""
 "Esse gráfico pode ser exportado apenas como um SVG pois as suas proporções "
 "são extremas."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Esse gráfico pode ser exportado apenas como SVG pois o seu tamanho não foi "
 "definido."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Alerta!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Fechar aba"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Restaurar"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Ver no Inspetor"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Converter Para"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Inserir Após"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "O último estado editado desta guia não foi encontrado."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -108,273 +108,273 @@ msgstr ""
 "A guia está vinculada ao caminho do arquivo {file_path}. Você deseja "
 "restaurar o SVG deste caminho?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Compacto"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Bonito"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Sempre"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Tudo exceto containers"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Nunca"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Quando menor ou igual"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Quando menor"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "Hexadecimal de 3 dígitos ou 6 dígitos"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "Hexadecimal de 6 dígitos"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Vazio"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Não salvo"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Comentário"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Texto"
 
 # Needs to be tested in context
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} deve estar dentro de {allowed} para ter qualquer efeito."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Este grupo não possui elementos."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Este grupo possui apenas um elemento."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Nenhum atributo \"id\" definido."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Nenhum elemento <stop> sob / abaixo este gradiente."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Este gradiente é uma cor sólida."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Não descreve um SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Aninhamento inadequado."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Fechar"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Autores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Doadores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Licença"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Licenças de terceiros"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Fundador e Gerente do Projeto"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Desenvolvedores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Tradutores"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Doadores ouro"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Doadores diamante"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Salvar SVG como…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Visuais"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Tamanho de encaixe"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Carregar imagem de referência"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Links para plataforma de doação"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Novo elemento"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Dimensões"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Tamanho"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Configuração de exportação"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Formato"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Sem perdas"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Qualidade"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Escala"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Largura"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Altura"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr ""
 "O tamanho da visualização da prévia de imagem é limitado à {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Layout"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Ver dados salvos"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Ir para pasta pai"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Atualizar arquivos"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Alternar a visibilidade de arquivos escondidos"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Procurar arquivos"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Salvar"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Selecionar"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Caminho"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Substituir"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Criar nova pasta"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Nome inválido para uma pasta."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Uma pasta com esse nome já existe."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Falha ao criar uma pasta."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Abrir"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Copiar caminho"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -382,345 +382,345 @@ msgstr ""
 "Um arquivo nomeado \"{file_name}\" já existe. Substituir este arquivo irá "
 "sobrescrever os seus conteúdos!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Nova forma"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Problemas de Importação"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Importar"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Elemento não reconhecido"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Atributo não reconhecido"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Erro de sintaxe"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Adicionar elemento"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Excluídos"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Arraste e solte para modificar o layout"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Arquivo"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Editar"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Ferramenta"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Visualizar"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Encaixe"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Formatação"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Paletas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Atalhos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Temas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Barra de guias"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Outro"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Cores de texto SVG"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Cor de símbolo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Cor de elemento"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Cor de atributo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Cor de string"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Cor de comentário"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Cor de texto"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Cor de CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Cor de erro"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Cor de alça"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Cor interna"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Cor normal"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Cor de pairado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Cor de selecionado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Cor de pairado e selecionado"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Cores básicas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Cor do plano de fundo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Cor da grade"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Cor válida"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Cor de aviso"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Entrada"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Fechar guias com o botão do meio do mouse"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Inverter direção do zoom"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Movimentação envolvente"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Utilizar CTRL para zoom"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Variados"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Utilizar diálogo de arquivos nativo"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Sincronizar título de janela com o nome do arquivo"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Tamanho de alça"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Escala da interface"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Muda o fator de escala da interfaçe."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Idioma"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Importar XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Colar XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Nova paleta"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Nova paleta a partir de um XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Formatador do editor"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Formatador de exportação"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Ajuda"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Redefinir tudo para o padrão"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Predefinição"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Manter comentários"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Manter estrutura XML não reconhecida"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Adicionar nova linha à direita"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Utilizar sintaxe de tag abreviada"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Espaçar a barra de tags abreviadas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Utilizar formatação bonita"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Utilizar espaços ao invés de tabulações"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Número de espaços de identação"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Números"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Remover zero à esquerada"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Utilizar exponencial quando mais curto"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Cores"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Utilizar cores nomeadas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Sintaxe primária"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Letras de valores hexadecimais maiúsculas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Dados de caminho"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Comprimir números"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Minimizar espaçamento"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Remover espaçamento após sinalizadores"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Remover comandos consecutivos"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Transformar listas"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Remover parâmetros desnecessários"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -728,11 +728,11 @@ msgstr ""
 "Se ligado, clicar em uma guia com o botão do meio do mouse fechará a guia. "
 "Se desligado, irá focar na guia."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Troca as direções de rolagem para aumentar e diminuir o zoom."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -740,14 +740,14 @@ msgstr ""
 "Passa o cursor para o lado oposto da tela quando ele atinge uma borda da "
 "viewport quando movimentando a visualização."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Se habilitado, a rolagem do mouse irá movimentar a tela. Para realizar o "
 "zoom, pressione CTRL enquanto rola."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -755,7 +755,7 @@ msgstr ""
 "Se habilitado, usa o diálogo de arquivo nativo do sistema operacional. Se "
 "desabilitado, usa o diálogo de arquivo embutido no GodSVG."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -763,564 +763,564 @@ msgstr ""
 "Se desabilitado, o título da janela permanecerá como \"GodSVG\" sem incluir "
 "o nome do arquivo aberto."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Muda o tamanho e a área de agarramento das alças."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Faixa horizontal"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Faixa vertical"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Horizontal com duas linhas"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Configurar Painel de Atalhos"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Criar nova aba"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Rolar para trás"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Rolar para frente"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Esse SVG ainda não está vinculado a um local de arquivo."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Tentar novamente"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Incluir pré-lançamentos"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Versão Atual"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Pegando informação..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Verificação de atualização falhou"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Ver todos os lançamentos"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG está atualizado."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Novas versões disponíveis!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Criar"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Procurar cor"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Seletor de Cores"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Editar nome da cor"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Remover cor"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Sem nome"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Palavras-chave de cor"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Conta-gotas"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Paletas sem nome não serão mostradas."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Várias paletas não podem ter o mesmo nome."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Essa paleta tem cores definidas de forma idêntica."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Renomear"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Mover para acima"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Mover para abaixo"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Aplicar Predefinição"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Excluir"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Copiar como XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Salvar como XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Relativo"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Sem dados de caminho"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Sem pontos"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Também usado por"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Redefinir para o padrão"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Não utilizado"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Adicionar atalho"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Pressione as teclas…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Sem transformações"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Aplicar matriz"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Inserir Antes"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Nova transformação"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "O GodSVG não reconhece este atributo"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr "Os seguintes arquivos foram descartados:"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr "{file_path} foi descartado."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr "Arquivos descartados"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr "Proceder"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr "{file_path} não pode ser aberto."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Verificar se o arquivo ainda existe no local de arquivo selecionado."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr "Prosseguir com a importação do restante dos arquivos?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr "Prosseguir para todos os arquivos que não podem ser abertos"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Salvar o arquivo?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Você deseja salvar este arquivo?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Salvar as alterações?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Suas alterações serão perdidas se você não as salvar."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Não salvar"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "{file_path} já está sendo editado dentro do GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Se você deseja reverter as suas edições desde o último salvamento, use "
 "{reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Você deseja salvar as alterações feitas em {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Salvar SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Salvar SVG como"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Fechar abas à esquerda"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Fechar abas à direita"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Fechar todas as outras abas"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr "Fechar abas vazias"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr "Fechar abas salvas"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Criar aba"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Selecionar a próxima guia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Selecionar a guia anterior"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Otimizar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Otimizar SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Copiar todo texto"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Copiar todo texto do SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Redefinir SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Abrir externalmente"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Abrir SVG externalmente"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Mostrar no gerenciador de arquivos"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Mostrar SVG no Explorador de Arquivos"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Desfazer"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Refazer"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Colar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Cortar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Selecionar tudo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Duplicar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Duplicar a seleção"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Excluir a seleção"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Mover para acima"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Mover a seleção para cima"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Mover para abaixo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Mover a seleção para baixo"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Encontrar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Aumentar zoom"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Diminuir zoom"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Redefinir zoom"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Mostrar grade"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Mostrar alças"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Mostrar SVG rasterizado"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Alternar ajuste"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Carregar imagem de referência"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Mostrar imagem de referência"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Sobrepor imagem de referência"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Visualizar informação de depuração"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Configurações"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Abrir o menu Configurações"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Sobre…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Abrir o menu Sobre"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Doar…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Abrir o menu Doar"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Repositório do GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Abrir o repositório do GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Website do GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Abrir website do GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Verificar atualizações"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Fechar programa"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Alternar tela cheia"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Mover para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Linha para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Linha Horizontal para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Linha Vertical para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Fechar Caminho"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Arco Elíptico para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Bézier Quadrático para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Bézier Quadrático Abreviado para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Bézier Cúbico"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Bézier Cúbico Abreviado para"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Absoluto"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Editor de código"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Inspetor"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Canvas"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr "Selecionar arquivos do tipo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Selecionar uma imagem"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Selecionar um arquivo do tipo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Salvar o arquivo do tipo {format}"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""
 "A extensão de arquivo está vazia. Somente arquivos {extension_list} são "

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -16,23 +16,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "volkov, Gallifreyan <gallifreyan@protonmail.ch>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Выйти из GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Вы хотите выйти из GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Выйти"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Проверить обновления?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -40,24 +40,24 @@ msgstr ""
 "Требуется подключение к github.com, чтобы сравнить номер версии. Никакие "
 "другие данные не собираются и не передаются."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "Хорошо"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Продолжить?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Экспортировать SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Экспортовать"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -65,43 +65,43 @@ msgstr ""
 "Изображение можно экспортировать только как SVG, поскольку его пропорции "
 "слишком экстремальные."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Изображение можно экспортировать только как SVG, поскольку его размеры не "
 "заданы."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Внимание!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Закрыть вкладку"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Восстановить"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Просмотреть в инспектор"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Конвертировать в"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Вставить после"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "Последнее редактированное состояние этой вкладки невозможно найти."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -109,272 +109,272 @@ msgstr ""
 "Вкладка связана с путем к файлу {file_path}. Вы желаете восстановить SVG из "
 "этого пути?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Компактно"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Красиво"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Всегда"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Все кроме контейнеров"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Никогда"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Когда короче или равно"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Когда короче"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3 или 6 цифровое шестандацитиричное значение"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6 цифровое шестандцатяричное значение"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Пусто"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Не сохранено"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Комментарий"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Текст"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} должен быть внутри {allowed} чтобы это имело эффект."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "В этой групе нет элементов."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "В этой группе только один элемент."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Атрибут \"id\" не задан."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Нет <stop> элемента в этом градиенте."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Этот градиент описывает сплошной цвет."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Не является описанием SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Неправильное вложение."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Закрыть"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Авторы"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Благотворители"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Лицензия"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Лицензии третьих лиц"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Основатель и руководитель проекта"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Разработчики"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Переводчики"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Золотые благотворители"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Алмазные благотворители"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Сохранить SVG как…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Внешний вид"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Размер привязки"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Вставить референсое изображение"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Ссылки на платформы для пожертвований"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Отменить"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Новый элемент"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Размеры"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Размер"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Настройки экспорта"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Формат"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Без потерь"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Качество"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Масштаб"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Ширина"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Высота"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Скопировать"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr ""
 "Размер предварительного просмотра изображения ограничен до {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Макет"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Просмотреть даные сохранения"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Перейти к родительской папке"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Обновить файлы"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Переключить видимость скрытых файлов"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Искать файлы"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Сохранить"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Выбрать"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Путь"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Заменить"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Создать новую папку"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Неправильное название для папки."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Папка с таким именем уже существует."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Не удалось создать папку."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Открыть"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Скопировать путь"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -382,345 +382,345 @@ msgstr ""
 "Файл с названием \"{file_name}\" уже существует. Его замена перезапишет его "
 "содержимое!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Новая привязка"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Проблемы с импортированием"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Импортировать"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Неизвестный элемент"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Неизвестный атрибут"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Синтаксическая ошибка"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Добавить элемент"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Исключены"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Перетягивайте, чтобы изменить макет"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Файл"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Редактировать"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Инструмент"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Просмотр"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Привязка"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Форматирование"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Палитры"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Сочетания клавиш"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Тема"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Вкладки"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Другие"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Цвет SVG текста"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Цвет символа"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Цвет элемента"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Цвет атрибута"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Цвет строки"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Цвет комментария"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Цвет текста"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Цвет CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Цвет ошибки"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Цвет ручки редактирования"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Внутренний цвет"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Обычный цвет"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Цвет наведенного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Цвет выбранного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Цвет выделенного-наведенного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Базовый цвет"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Цвет фона"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Цвет сетки"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Цвет валидности"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Цвет предупреждения"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Устройства ввода"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Закрывать вкладки средней клавишей мыши"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Инвертировать направление масштабирования"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Захват курсора при прокрутке"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Использовать CTRL для масштабирования"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Разное"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Использовать родной файловый диалог системы"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Синхронизировать заголовок окна с названием файла"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Размер ручек"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Масштаб интерфейса"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Изменить масштаб пользовательского интерфейса."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Язык"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Импортировать XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Вставить XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Новая палитра"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Новая палитра из XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Форматер редактора"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Форматер экспорта"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Помощь"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Восстановить значения по умолчанию"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Пресет"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Сохранять коментарии"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Сохранять нераспознанные XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Добавлять новую строку в конце"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Использовать теги с сокращенным синтаксисом"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Ставить пробел после тега"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Использовать красивое форматирование"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Использовать пробелы вместо tab-ов"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Количество символов отступа"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Цифры"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Удалить начальный ноль"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Использовать экспоненту когда короче"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Цвета"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Использовать названия цветов"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Основной синтаксис"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Использовать заглавную букву для шестнадцатиричных букв"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Данные пути"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Сжать цифры"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Минимизировать интервалы"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Удалить интервалы после флагов"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Удалить последовательные команды"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Список трансформаций"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Удалить ненужные параметры"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -728,11 +728,11 @@ msgstr ""
 "Если включено - нажатие на вкладку средней кнопкой мыши закроет ее. Если "
 "выключено - вкладка получит фокус."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Поменяет местами направление прокрутки при масштабировании."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -740,14 +740,14 @@ msgstr ""
 "Курсор будет телепортироваться от одного до противоположного края на границе "
 "окна просмотра."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Если включено - прокрутка будет перемещать окно просмотра. Чтобы "
 "масштабировать зажмите CTRL при прокручивании."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -756,7 +756,7 @@ msgstr ""
 "операционной системы для выбора файлов. Если выключено, то будет "
 "использоваться встроенный файловый диалог."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -764,564 +764,564 @@ msgstr ""
 "Если выключено - заголовок окна будет просто \"GodSVG\", не включая текущий "
 "файл."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Изменит визуальный размер и область захвата ручек редактирования."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Горизонтальная полоса"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Вертикальная полоска"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Горизонтальная с двумя колонками"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Настроить в панели сочетаний клавиш"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Создать новую вкладку"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Прокрутить назад"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Прокрутить вперед"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Это SVG изображение еще не связано с расположением файла."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Попробовать еще раз"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Показывать тестовые сборки"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Текущая версия"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Загрузка информации..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Не удалось проверить обновления"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Показать все сборки"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "Установлена последняя версия GodSVG."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Доступна новая версия!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Создать"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Искать цвет"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Цветовая пипетка"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Редактировать название цвета"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Удалить цвет"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Без названия"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Ключевые слова цвета"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Пипетка"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Палитры без названия не будут отображаться."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Несколько палитр не могут иметь одно и тоже название."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "В этой палитре имеются цвета с идентичными названиями."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Переименовать"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Подвинуть вверх"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Подвинуть вниз"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Применить пресет"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Удалить"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Скопировать как XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Сохранить как XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Относительно"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Нет данных пути"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Нет точек"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Так же используется"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Восстановить значение по умолчанию"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Не используется"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Добавить сочетание клавиш"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Нажмите клавиши…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Нет трансформаций"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Применить матрицу"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Вставить до"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Новая трансформация"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG не может распознать этот атрибут"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr "Следующие файлы были отклонены:"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr "{file_path} был отклонен."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr "Отклоненные файлы"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr "Продолжить"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr "Невозможно открыть {file_path} файл."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Проверьте, что файл все еще существует по выбранному пути."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr "Продолжить импортировать остальные файлы?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr "Продолжить для всех файлов, которые не могут быть открыты"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Сохранить файл?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Вы хотите сохранить этот файл?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Сохранить изменения?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Ваши изменения будут утеряны если вы их не сохраните."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Не сохранять"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "Файл {file_path} уже редактируется внутри GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Если вы хотите отменить внесенные после после сохранения изменения, "
 "воспользуйтесь {reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Сохранить изменения в {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Сохранить SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Сохранить SVG как"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Закрыть вкладки слева"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Закрыть вкладки справа"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Закрыть все остальные вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr "Закрыть пустые вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr "Закрыть сохраненные вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Создать вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Выбрать следующую вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Выбрать предыдущую вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Оптимизировать"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Оптимизировать SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Скопировать весь текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Скопировать SVG текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Сбросить SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Открыть во внешней программе"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Открыть SVG в внешней программе"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Показать в файловом менеджере"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Показать SVG в файловом менеджере"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Отменить"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Вернуть"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Вырезать"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Выбрать все"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Дублировать"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Дублировать выбранное"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Удалить все выбранные теги"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Подвинуть вверх"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Подвинуть выбранное вверх"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Подвинуть вниз"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Подвинуть выбранное вниз"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Найти"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Увеличить масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Уменьшить масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Сбросить масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Показать сетку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Показать ручки редактирования"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Показать растеризованный SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Переключить привязку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Загрузить референс"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Показать референс-изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Наложить референс-изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Просмотреть информацию для отладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Настройки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Открыть меню настроек"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Про программу…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Открыть меню \"Про приложение\""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Сделать пожертвование…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Открыть меню благотворителей"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Репозиторий GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Открыть репозиторий GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Веб-сайт GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Открыть веб-сайт GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Проверить обновления"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Выйти из приложения"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Переключить полный экран"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Подвинуть до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Линия до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Горизонтальная линия до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Вертикальная линия до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Закрыть путь"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Эллиптическая дуга до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Квадратичная Безье до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Сокращенная квадратичная Безье до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Кубическая Безье до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Сокращенная кубическая Безье до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Абсолютно"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Редактор кода"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Инспектор"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Окно просмотра"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr "Выбрать {format} файлы"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Выбрать изображение"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Выбрать {format} файл"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Сохранить {format} файл"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""
 "Только файлы с расширениями {extension_list} поддерживаются для этой "

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -15,23 +15,23 @@ msgstr ""
 msgid "translation-credits"
 msgstr "volkov"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "Вийти із GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "Ви дійсно бажаєте вийти із GodSVG?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "Вийти"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "Перевірити оновлення?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
@@ -39,24 +39,24 @@ msgstr ""
 "Це потребує з'єднання з github.com, щоб порівняти цифри версії. Жодна інша "
 "інформація не збирається і не передається."
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "Добре"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to proceed?"
 msgstr "Ви дійсно бажаєте продовжити?"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "Експортувати SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "Експортувати"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
@@ -64,43 +64,43 @@ msgstr ""
 "Це зображення може бути експортоване тільки як SVG, оскільки його пропорції "
 "занадто екстремальні."
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 "Це зображення може бути експортоване тільки як SVG, оскільки його розмір не "
 "завданий."
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "Увага!"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 msgid "Close tab"
 msgstr "Закрити вкладку"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr "Відновити"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "View in Inspector"
 msgstr "Переглянути в інспекторі"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "Конвертувати в"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "Вставити після"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr "Останній редагований стан цієї вкладки не може бути знайдено."
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
@@ -108,271 +108,271 @@ msgstr ""
 "Ця вкладка пов'язана з шляхом до файлу {file_path}. Бажаєте відновити SVG з "
 "цього шляху?"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "Компактно"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "Гарно"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "Завжди"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "Усі крім контейнерів"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "Ніколи"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "Коли коротше або дорівнює"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "Коли коротше"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3 або 6 значне шістнадцятирічне число"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6 значне шістнадцятирічне число"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr "Порожньо"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr "Не збережено"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "Коментар"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "Текст"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} повинен бути всередині {allowed} щоб зміни вступили в силу."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "Ця група не має елементів."
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "Ця група має тільки один елемент."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "Не вказано \"id\" атрибуту."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "Немає <stop> елементів під цим градієнтом."
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "Цей градієнт це суцільний колір."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "Не є описом SVG."
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "Неправильне вкладення."
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "Закрити"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "Автори"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "Благодійники"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "Ліцензія"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "Ліцензії третіх осіб"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "Засновник і керівник проекту"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "Розробники"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "Перекладачі"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "Золоті благодійники"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "Діамантові благодійники"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 msgid "Save SVG as…"
 msgstr "Зберегти SVG як…"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "Зовнішній вигляд"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "Розмір прилипання"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Paste reference image"
 msgstr "Вставити еталонне зображення"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr "Посилання на платформи для пожертв"
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "Новий елемент"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "Розміри"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "Розмір"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "Налаштування експорту"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "Формат"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "Без втрат"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "Якість"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "Масштаб"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "Ширина"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "Висота"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "Розмір попереднього перегляду зображення обмежено до {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr "Макет"
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "Переглянути дані збереження"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "Перейти до батьківської теки"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "Оновити файли"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "Перемикнути видимість прихованих файлів"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "Пошук файлів"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "Зберегти"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "Обрати"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "Шлях"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "Замінити"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "Створити нову теку"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "Не правильна назва для теки."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "Тека з такою назвою вже існує."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "Не вдалося створити теку."
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "Відкрити"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "Скопіювати шлях"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
@@ -380,349 +380,349 @@ msgstr ""
 "Файл з назваою \"{file_name}\" вже існує. Його заміна призведе до перезапису "
 "його вмісту!"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "Нова форма"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "Проблема з імпортуванням"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "Імпортувати"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "Невідомий елемент"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "Невідомий атрибут"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "Синтаксична помилка"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "Додати елемент"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr "Виключені"
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr "Перетягніть і опустіть, щоб змінити макет"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "Файл"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "Редагування"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "Інструмент"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "Перегляд"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "Прилипання"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "Форматування"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "Палітри"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "Клавіатурні скорочення"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "Тема"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr "Вкладка"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "Інше"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "Колір SVG тексту"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "Колір символу"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "Колір елементу"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "Колір атрибуту"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "Колір строки"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "Колір коментаря"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "Колір тексту"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "Колір CDATA"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "Колір помилки"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "Колір ручки редагування"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "Внутрішній колір"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "Звичайний колір"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "Колір наведеного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "Колір обраного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "Колір наведено-виділеного"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "Базовий колір"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "Колір фону"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Grid color"
 msgstr "Колір ґратки"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "Колір валідності"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "Колір попередження"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "Пристрої вводу"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr "Закривати вкладки при натисканні середньої кнопки миші"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "Інвертувати напрямок масштабування"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr "Захопити курсор при гортанні"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "Використовувати CTRL для масштабування"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "Різне"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "Використовувати рідний файловий діалог"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "Синхронізувати заголовок вікна з назвою поточного файлу"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "Розмір ручок редагування"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "Масштаб інтерфейсу"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the scale factor for the interface."
 msgstr "Змінити масштаб інтерфейсу користувача."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "Мова"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "Імпортувати XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "Вставити XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "Нова палітра"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "Нова палітра з XML"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Editor formatter"
 msgstr "Форматер редактору"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Export formatter"
 msgstr "Форматер експорту"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "Допомога"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Reset all to default"
 msgstr "Скинути до замовчування"
 
 # не знаю
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Пресет"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "Зберігати коментарі"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "Зберігати не розпізнані структури XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "Додавати нову строку в кінці"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "Використовувати теги зі скороченим синтаксисом"
 
 # Шось...
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "Ставити пробіл перед скороченими тегами"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "Використовувати гарне форматування"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "Використовувати пробіли замість табуляції"
 
 # Взяв ідею для перекладу з гновоського текстового редактора
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "Кількість пробілів на табуляцію"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "Цифри"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "Видалити початковий нуль"
 
 # Ґа...
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "Використовувати експоненту коли коротше"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "Кольори"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "Використовувати назви кольорів"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "Основний синтаксис"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "Відображати шістнадцятирічні числа великими літери"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "Дані шляху"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "Стиснути цифри"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "Мінімізувати відстань"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "Видалити відстань після прапорців"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "Видалити послідовні команди"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "Список трансформацій"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "Видалити необов'язкові параметри"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
@@ -730,11 +730,11 @@ msgstr ""
 "Якщо увімкнено - клацання на вкладку середньою кнопкою миші закриє її. Якщо "
 "вимкнено - фокус буде замінено на неї."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr "Міняє напрям гортання при масштабуванні."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
@@ -742,14 +742,14 @@ msgstr ""
 "Курсор буде телепортуватися від одного краю до протилежного при пересуванні "
 "вікна перегляду."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr ""
 "Якщо увімкнено - гортання буде рухати вікно перегляду. Щоб масштабувати, "
 "затисніть CTRL доки гортаєте."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -758,7 +758,7 @@ msgstr ""
 "операційної системи для обирання файлів. Якщо вимкнено, то замість буде "
 "використовуватися вбудований файловий діалог."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
@@ -766,565 +766,565 @@ msgstr ""
 "Якщо вимкнено - заголовок вікна залишиться як \"GodSVG\", не включаючи назву "
 "поточного файлу."
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "Змінює візуальний розмір та область захоплення для ручок."
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"
 msgstr "Горизонтальна смужка"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Vertical strip"
 msgstr "Вертикальна смужка"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal with two rows"
 msgstr "Горизонтальна з двома рядками"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr "Налаштувати у панелі клавіатурних скорочень"
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 msgid "Create a new tab"
 msgstr "Створити нову вкладку"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr "Гортати назад"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr "Гортати вперед"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr "Це SVG зображення поки що не пов'язано з розташуванням файла."
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "Спробувати ще раз"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Show prereleases"
 msgstr "Показати тестові версії"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "Поточна версія"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "Отримуємо інформацію..."
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "Не вдалося перевірити оновлення"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "View all releases"
 msgstr "Показати усі версії"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG оновлено до останньої версії."
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "New versions available!"
 msgstr "Доступна нова версія!"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "Створити"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "Шукати колір"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "Кольорова піпетка"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "Редагувати назву кольору"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "Видалити колір"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "Без назви"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
 msgstr "Ключові слова кольорів"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr "Піпетка"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "Палітри без назв не будуть відображатися."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "Декілька палітр не можуть мати однакові назви."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "Ця палітра має ідентичні кольори."
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "Перейменувати"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "Пересунути вгору"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "Пересунути вниз"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "Застосувати пресет"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "Видалити"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "Скопіювати як XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Save as XML"
 msgstr "Зберегти як XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "Відносно"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "Немає даних шляху"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "Немає точок"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "Також використовується"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "Скинути значення до замовчування"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "Не використовується"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "Додати клавіатурне скорочення"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "Натисніть кнопки…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "Без трансформацій"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "Застосувати матрицю"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "Вставити до"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "Нова трансформація"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG не може розпізнати цей атрибут"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr "Наступні файли були відкинуті:"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr "{file_path} було відкинуто."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr "Відкинуті файли"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr "Продовжити"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} couldn't be opened."
 msgstr "Файл {file_path} неможливо відкрити."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "Перевірити, чи файл все щє існує по обраному шляху."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr "Продовжити імпортуючи інші файли?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr "Продовжити для усіх файлів, які неможливо відкрити"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the file?"
 msgstr "Зберегти файл?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save this file?"
 msgstr "Ви бажаєте зберегти цей файл?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr "Зберегти зміни?"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr "Ваші зміни буде втрачено, якщо ви не збережете їх."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr "Не зберігати"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr "Файл {file_path} вже редагується в GodSVG."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 "Якщо ви бажаєте повернути свої зміни з останнього збереження, використовуйте "
 "{reset_svg}."
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr "Чи бажаєте зберегти зміни в {file_name}?"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "Зберегти SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG as"
 msgstr "Зберегти SVG як"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr "Закрити усі вкладки зліва"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr "Закрити усі вкладки справа"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close all other tabs"
 msgstr "Закрити усі інші вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close empty tabs"
 msgstr "Закрити порожні вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close saved tabs"
 msgstr "Закрити збережені вкладки"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Create tab"
 msgstr "Створити вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr "Обрати наступну вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr "Обрати попередню вкладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "Оптимізувати"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize SVG"
 msgstr "Оптимізувати SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Скопіювати весь текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy the SVG text"
 msgstr "Скопіювати SVG текст"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "Скинути SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr "Відкрити у зовнішній програмі"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open SVG externally"
 msgstr "Відкрити SVG у зовнішній програмі"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr "Показати у файловому менеджері"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr "Показати SVG у файловому менеджері"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "Скасувати"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "Повернути"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "Вирізати"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select all"
 msgstr "Обрати усе"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "Дублювати"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate the selection"
 msgstr "Продублювати обране"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "Видалити усі обрані теги"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move up"
 msgstr "Пересунути вгору"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Пересунути обране вгору"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move down"
 msgstr "Пересунути вниз"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
 msgstr "Пересунути обране вниз"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "Знайти"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "Збільшити масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "Зменшити масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "Скинути масштаб"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "Показати ґратку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "Показати ручки редагування"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "Показати растеризуваний SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "Перемикнути прилипання"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "Завантажити еталонне зображення"
 
 # Нехай "reference image" буде "еталонне зображення", мені так гугл сказав
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "Показати еталонне зображення"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "Накласти еталонне зображення"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "Переглянути інформацію про відладку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "Налаштування"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "Відкрити меню налаштувань"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "Про додаток…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "Відкрити меню \"Про додаток\""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "Зробити пожертвування…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "Відкрити меню благодійників"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "Репозиторій GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "Відкрити репозиторій GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "Веб-сайт GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "Відкрити веб-сайт GodSVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "Перевірити оновлення"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "Вийти із додатку"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr "Перемикнути повноекранний режим"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "Пересунути до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "Лінія до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "Горизонтальна лінія до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "Вертикальна лінія до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "Закрити шлях"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "Еліптична дуга до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "Квадратичний Безьє до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "Скорочена квадратична Безьє"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "Кубічна Безьє до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "Скорочена кубічна Безьє до"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "Абсолютно"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr "Редактор коду"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr "Інспектор"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Viewport"
 msgstr "Вікно перегляду"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select {format} files"
 msgstr "Обрати {format} файли"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Обрати зображення"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an {format} file"
 msgstr "Обрати {format} файл"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save the {format} file"
 msgstr "Зберегти {format} файл"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Only {extension_list} files are supported for this operation."
 msgstr ""
 "Тільки файли з розширеннями {extension_list} підтримуються для цієї операції."

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -15,734 +15,734 @@ msgstr ""
 msgid "translation-credits"
 msgstr "Hamster5295 <hamster5295@163.com>, Mike Lei <mikelei@duck.com>"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit GodSVG"
 msgstr "退出 GodSVG"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Do you want to quit GodSVG?"
 msgstr "您确定要退出 GodSVG 吗？"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Quit"
 msgstr "退出"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Check for updates?"
 msgstr "检查更新？"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid ""
 "This will connect to github.com to compare version numbers. No other data is "
 "collected or transmitted."
 msgstr ""
 
-#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+#: src/autoload/HandlerGUI.gd: src/ui_widgets/alert_dialog.gd:
 msgid "OK"
 msgstr "确定"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 #, fuzzy
 msgid "Do you want to proceed?"
 msgstr "您确定要退出 GodSVG 吗？"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 msgid "Export SVG"
 msgstr "导出 SVG"
 
-#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
-#: src/utils/TranslationUtils.gd
+#: src/autoload/HandlerGUI.gd: src/ui_parts/export_menu.gd:
+#: src/utils/TranslationUtils.gd:
 msgid "Export"
 msgstr "导出"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 #, fuzzy
 msgid ""
 "The graphic can be exported only as SVG because its proportions are too "
 "extreme."
 msgstr "此图像只能以 SVG 格式导出，因为其大小未定义。您确定要继续吗？"
 
-#: src/autoload/HandlerGUI.gd
+#: src/autoload/HandlerGUI.gd:
 #, fuzzy
 msgid ""
 "The graphic can be exported only as SVG because its size is not defined."
 msgstr "此图像只能以 SVG 格式导出，因为其大小未定义。您确定要继续吗？"
 
-#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+#: src/autoload/State.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_widgets/alert_dialog.gd: src/utils/FileUtils.gd:
 msgid "Alert!"
 msgstr "警告！"
 
-#: src/autoload/State.gd src/utils/TranslationUtils.gd
+#: src/autoload/State.gd: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close tab"
 msgstr "闭合路径"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Restore"
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 #, fuzzy
 msgid "View in Inspector"
 msgstr "在列表中查看"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "Convert To"
 msgstr "转换为"
 
-#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+#: src/autoload/State.gd: src/ui_widgets/transform_popup.gd:
 msgid "Insert After"
 msgstr "在后方插入"
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid "The last edited state of this tab could not be found."
 msgstr ""
 
-#: src/autoload/State.gd
+#: src/autoload/State.gd:
 msgid ""
 "The tab is bound to the file path {file_path}. Do you want to restore the "
 "SVG from this path?"
 msgstr ""
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Compact"
 msgstr "压缩"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Pretty"
 msgstr "美化"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Always"
 msgstr "总是"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "All except containers"
 msgstr "除容器外所有"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "Never"
 msgstr "从不"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter or equal"
 msgstr "当更短或相等时"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "When shorter"
 msgstr "当更短时"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "3-digit or 6-digit hex"
 msgstr "3 位或 6 位十六进制"
 
-#: src/config_classes/Formatter.gd
+#: src/config_classes/Formatter.gd:
 msgid "6-digit hex"
 msgstr "6 位十六进制"
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Empty"
 msgstr ""
 
-#: src/config_classes/TabData.gd
+#: src/config_classes/TabData.gd:
 msgid "Unsaved"
 msgstr ""
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Comment"
 msgstr "注释"
 
-#: src/data_classes/BasicXNode.gd
+#: src/data_classes/BasicXNode.gd:
 msgid "Text"
 msgstr "文本"
 
-#: src/data_classes/Element.gd
+#: src/data_classes/Element.gd:
 msgid "{element} must be inside {allowed} to have any effect."
 msgstr "{element} 必须在 {allowed} 内才能产生作用。"
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has no elements."
 msgstr "此组内没有元素。"
 
-#: src/data_classes/ElementG.gd
+#: src/data_classes/ElementG.gd:
 msgid "This group has only one element."
 msgstr "此组内只有一个元素。"
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No \"id\" attribute defined."
 msgstr "\"id\" 属性未定义。"
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "No <stop> elements under this gradient."
 msgstr "此渐变下没有 <stop> 元素。"
 
-#: src/data_classes/GradientUtils.gd
+#: src/data_classes/GradientUtils.gd:
 msgid "This gradient is a solid color."
 msgstr "此渐变为单一颜色。"
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Doesn’t describe an SVG."
 msgstr "文本不是 SVG 格式。"
 
-#: src/data_classes/SVGParser.gd
+#: src/data_classes/SVGParser.gd:
 msgid "Improper nesting."
 msgstr "错误的嵌套。"
 
-#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
-#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/about_menu.gd: src/ui_parts/good_file_dialog.gd:
+#: src/ui_parts/settings_menu.gd: src/ui_parts/shortcut_panel_config.gd:
+#: src/ui_parts/update_menu.gd:
 msgid "Close"
 msgstr "关闭"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Authors"
 msgstr "作者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Donors"
 msgstr "捐赠者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "License"
 msgstr "协议"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Third-party licenses"
 msgstr "第三方协议"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Project Founder and Manager"
 msgstr "项目创立者与管理者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Developers"
 msgstr "开发者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Translators"
 msgstr "翻译者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Golden donors"
 msgstr "金牌捐赠者"
 
-#: src/ui_parts/about_menu.gd
+#: src/ui_parts/about_menu.gd:
 msgid "Diamond donors"
 msgstr "钻石捐赠者"
 
-#: src/ui_parts/current_file_button.gd
+#: src/ui_parts/current_file_button.gd:
 #, fuzzy
 msgid "Save SVG as…"
 msgstr "保存 SVG"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Visuals"
 msgstr "显示"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 msgid "Snap size"
 msgstr "吸附大小"
 
-#: src/ui_parts/display.gd
+#: src/ui_parts/display.gd:
 #, fuzzy
 msgid "Paste reference image"
 msgstr "加载参考图像"
 
-#: src/ui_parts/donate_menu.gd
+#: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
 msgstr ""
 
-#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
-#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
-#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+#: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
+#: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
+#: src/ui_widgets/confirm_dialog.gd: src/ui_widgets/options_dialog.gd:
 msgid "Cancel"
 msgstr "取消"
 
-#: src/ui_parts/element_container.gd
+#: src/ui_parts/element_container.gd:
 msgid "New element"
 msgstr "新元素"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Dimensions"
 msgstr "大小"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Size"
 msgstr "大小"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Export Configuration"
 msgstr "导出设置"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Format"
 msgstr "格式"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Lossless"
 msgstr "无损"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Quality"
 msgstr "质量"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Scale"
 msgstr "缩放"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Width"
 msgstr "宽度"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Height"
 msgstr "高度"
 
-#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/export_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Copy"
 msgstr "复制"
 
-#: src/ui_parts/export_menu.gd
+#: src/ui_parts/export_menu.gd:
 msgid "Preview image size is limited to {dimensions}"
 msgstr "预览图像大小被限制到 {dimensions}"
 
-#: src/ui_parts/global_actions.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/global_actions.gd: src/ui_parts/shortcut_panel_config.gd:
 msgid "Layout"
 msgstr ""
 
-#: src/ui_parts/global_actions.gd
+#: src/ui_parts/global_actions.gd:
 msgid "View savedata"
 msgstr "查看保存的数据"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Go to parent folder"
 msgstr "前往父文件夹"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Refresh files"
 msgstr "刷新文件"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Toggle the visibility of hidden files"
 msgstr "切换隐藏文件可见性"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Search files"
 msgstr "搜索文件"
 
-#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+#: src/ui_parts/good_file_dialog.gd: src/utils/FileUtils.gd:
 msgid "Save"
 msgstr "保存"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Select"
 msgstr "选择"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Path"
 msgstr "路径"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Replace"
 msgstr "替换"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Create new folder"
 msgstr "新建文件夹"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Invalid name for a folder."
 msgstr "无效的文件夹名。"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "A folder with this name already exists."
 msgstr "以此为名的文件夹已存在。"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Failed to create a folder."
 msgstr "创建文件夹失败。"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Open"
 msgstr "打开"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid "Copy path"
 msgstr "复制路径"
 
-#: src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/good_file_dialog.gd:
 msgid ""
 "A file named \"{file_name}\" already exists. Replacing will overwrite its "
 "contents!"
 msgstr "文件 “{file_name}” 已经存在。替换操作将会覆写它的内容！"
 
-#: src/ui_parts/handles_manager.gd
+#: src/ui_parts/handles_manager.gd:
 msgid "New shape"
 msgstr "新形状"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Import Problems"
 msgstr "导入出错"
 
-#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/import_warning_menu.gd: src/utils/TranslationUtils.gd:
 msgid "Import"
 msgstr "导入"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized element"
 msgstr "未知元素"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Unrecognized attribute"
 msgstr "未知属性"
 
-#: src/ui_parts/import_warning_menu.gd
+#: src/ui_parts/import_warning_menu.gd:
 msgid "Syntax error"
 msgstr "语法错误"
 
-#: src/ui_parts/inspector.gd
+#: src/ui_parts/inspector.gd:
 msgid "Add element"
 msgstr "添加元素"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Excluded"
 msgstr ""
 
-#: src/ui_parts/layout_popup.gd
+#: src/ui_parts/layout_popup.gd:
 msgid "Drag and drop to change the layout"
 msgstr ""
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "File"
 msgstr "文件"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Edit"
 msgstr "编辑"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "Tool"
 msgstr "工具"
 
-#: src/ui_parts/mac_menu.gd src/ui_parts/settings_menu.gd
+#: src/ui_parts/mac_menu.gd: src/ui_parts/settings_menu.gd:
 msgid "View"
 msgstr "视图"
 
-#: src/ui_parts/mac_menu.gd
+#: src/ui_parts/mac_menu.gd:
 msgid "Snap"
 msgstr "吸附"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Formatting"
 msgstr "格式化"
 
-#: src/ui_parts/settings_menu.gd src/ui_widgets/color_field_popup.gd
+#: src/ui_parts/settings_menu.gd: src/ui_widgets/color_field_popup.gd:
 msgid "Palettes"
 msgstr "调色盘"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Shortcuts"
 msgstr "快捷键"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Theming"
 msgstr "主题"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Tab bar"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Other"
 msgstr "其他"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "SVG Text colors"
 msgstr "SVG 文本颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
 msgstr "符号颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Element color"
 msgstr "元素颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Attribute color"
 msgstr "属性颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "String color"
 msgstr "字符串颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Comment color"
 msgstr "注释颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Text color"
 msgstr "文本颜色"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "CDATA color"
 msgstr "CDATA 颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Error color"
 msgstr "错误颜色"
 
 #. Refers to the colors of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle colors"
 msgstr "拖拽框颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Inside color"
 msgstr "内部颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Normal color"
 msgstr "普通颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered color"
 msgstr "鼠标悬停颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Selected color"
 msgstr "选中颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Hovered selected color"
 msgstr "悬停且选中颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Basic colors"
 msgstr "基本颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Background color"
 msgstr "背景颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Grid color"
 msgstr "正常颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Valid color"
 msgstr "正常颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Warning color"
 msgstr "警告颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Input"
 msgstr "输入"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Close tabs with middle mouse button"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Invert zoom direction"
 msgstr "反转缩放方向"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Wrap-around panning"
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use CTRL for zooming"
 msgstr "使用 CTRL 键缩放"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Miscellaneous"
 msgstr "杂项"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use native file dialog"
 msgstr "使用系统自带文件选择窗口"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Sync window title to file name"
 msgstr "同步窗口标题为文件名"
 
 #. Refers to the size of the draggable handles.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Handle size"
 msgstr "拖拽框大小"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "UI scale"
 msgstr "UI 缩放"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Changes the scale factor for the interface."
 msgstr "改变用户界面的缩放尺寸。"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Language"
 msgstr "语言"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Import XML"
 msgstr "导入 XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Paste XML"
 msgstr "粘贴 XML"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette"
 msgstr "新建调色盘"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "New palette from XML"
 msgstr "从 XML 创建新调色盘"
 
 #. Refers to the formatter used for GodSVG's code editor.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Editor formatter"
 msgstr "编辑器格式"
 
 #. Refers to the formatter used when exporting.
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Export formatter"
 msgstr "导出格式"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Help"
 msgstr "帮助"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Reset all to default"
 msgstr "恢复默认"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "预设"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"
 msgstr "保留注释"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Keep unrecognized XML structures"
 msgstr "保留未知 XML 结构"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Add trailing newline"
 msgstr "在文件末尾添加"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use shorthand tag syntax"
 msgstr "使用简写标签语法"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Space out the slash of shorthand tags"
 msgstr "在简写标签斜线前添加空格"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use pretty formatting"
 msgstr "使用美化格式"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use spaces instead of tabs"
 msgstr "使用空格而不是 tab"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Number of indentation spaces"
 msgstr "缩进空格数量"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Numbers"
 msgstr "数字"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove leading zero"
 msgstr "移除前面的 0"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use exponential when shorter"
 msgstr "当更短时使用指数形式"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Colors"
 msgstr "颜色"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Use named colors"
 msgstr "使用颜色名"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary syntax"
 msgstr "主语法"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Capitalize hexadecimal letters"
 msgstr "大写十六进制字母"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Pathdata"
 msgstr "路径数据"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Compress numbers"
 msgstr "压缩数字"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Minimize spacing"
 msgstr "最小化间距"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove spacing after flags"
 msgstr "移除标志后的空格"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove consecutive commands"
 msgstr "移除连续指令"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Transform lists"
 msgstr "变换列表"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Remove unnecessary parameters"
 msgstr "移除不必要的参数"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, clicking on a tab with the middle mouse button closes the tab. "
 "If turned off, it focuses the tab instead."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Swaps the scroll directions for zooming in and zooming out."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "Warps the cursor to the opposite side whenever it reaches a viewport "
 "boundary while panning."
 msgstr ""
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."
 msgstr "如果启用，滚动鼠标滚轮将移动视图。按住 CTRL 并滚动滚轮以缩放。"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid ""
 "If turned on, uses your operating system's native file dialog. If turned "
 "off, uses GodSVG's built-in file dialog."
@@ -750,599 +750,599 @@ msgstr ""
 "如果启用，将使用操作系统自带的文件选择窗口。反之，将使用 GodSVG 内置的文件选"
 "择窗口。"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid ""
 "If turned off, the window title remains as \"GodSVG\" without including the "
 "current file."
 msgstr "如果禁用，不论当前打开的文件是什么，窗口标题都将固定为 “GodSVG”。"
 
-#: src/ui_parts/settings_menu.gd
+#: src/ui_parts/settings_menu.gd:
 msgid "Changes the visual size and grabbing area of handles."
 msgstr "改变拖拽框的视觉和操作区域大小。"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 #, fuzzy
 msgid "Horizontal strip"
 msgstr "横线"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 #, fuzzy
 msgid "Vertical strip"
 msgstr "竖线"
 
-#: src/ui_parts/shortcut_panel.gd
+#: src/ui_parts/shortcut_panel.gd:
 #, fuzzy
 msgid "Horizontal with two rows"
 msgstr "横线"
 
-#: src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/shortcut_panel_config.gd:
 msgid "Configure Shortcut Panel"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+#: src/ui_parts/tab_bar.gd: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Create a new tab"
 msgstr "新建文件夹"
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll backwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "Scroll forwards"
 msgstr ""
 
-#: src/ui_parts/tab_bar.gd
+#: src/ui_parts/tab_bar.gd:
 msgid "This SVG is not bound to a file location yet."
 msgstr ""
 
-#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+#: src/ui_parts/update_menu.gd: src/utils/FileUtils.gd:
 msgid "Retry"
 msgstr "重试"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "Show prereleases"
 msgstr "包括预发布版本"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Current Version"
 msgstr "当前版本"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Retrieving information..."
 msgstr "正在获取信息…"
 
 #. When checking for updates.
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "Update check failed"
 msgstr "更新检查失败"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "View all releases"
 msgstr "选择所有元素"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG 是最新版本。"
 
-#: src/ui_parts/update_menu.gd
+#: src/ui_parts/update_menu.gd:
 #, fuzzy
 msgid "New versions available!"
 msgstr "新版本"
 
-#: src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
 msgstr "创建"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Search color"
 msgstr "搜索颜色"
 
-#: src/ui_widgets/color_field_popup.gd
+#: src/ui_widgets/color_field_popup.gd:
 msgid "Color Picker"
 msgstr "取色器"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Edit color name"
 msgstr "编辑颜色名称"
 
-#: src/ui_widgets/configure_color_popup.gd
+#: src/ui_widgets/configure_color_popup.gd:
 msgid "Delete color"
 msgstr "删除颜色"
 
-#: src/ui_widgets/configure_color_popup.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/configure_color_popup.gd: src/ui_widgets/palette_config.gd:
 msgid "Unnamed"
 msgstr "未命名"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 #, fuzzy
 msgid "Color keywords"
 msgstr "取色器"
 
-#: src/ui_widgets/good_color_picker.gd
+#: src/ui_widgets/good_color_picker.gd:
 msgid "Eyedropper"
 msgstr ""
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
 msgstr "未命名的调色盘不会被显示。"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Multiple palettes can't have the same name."
 msgstr "多个调色盘不能使用同一个名称。"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "This palette has identically defined colors."
 msgstr "此调色盘使用了完全相同的颜色定义。"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Rename"
 msgstr "重命名"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Up"
 msgstr "上移"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Move Down"
 msgstr "下移"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Apply Preset"
 msgstr "应用预设"
 
-#: src/ui_widgets/palette_config.gd src/ui_widgets/setting_shortcut.gd
-#: src/ui_widgets/transform_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/palette_config.gd: src/ui_widgets/setting_shortcut.gd:
+#: src/ui_widgets/transform_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Delete"
 msgstr "删除"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 msgid "Copy as XML"
 msgstr "复制为 XML"
 
-#: src/ui_widgets/palette_config.gd
+#: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Save as XML"
 msgstr "复制为 XML"
 
-#: src/ui_widgets/path_popup.gd src/utils/TranslationUtils.gd
+#: src/ui_widgets/path_popup.gd: src/utils/TranslationUtils.gd:
 msgid "Relative"
 msgstr "相对"
 
-#: src/ui_widgets/pathdata_field.gd
+#: src/ui_widgets/pathdata_field.gd:
 msgid "No path data"
 msgstr "没有路径数据"
 
-#: src/ui_widgets/points_field.gd
+#: src/ui_widgets/points_field.gd:
 msgid "No points"
 msgstr "没有点"
 
-#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/presented_shortcut.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Also used by"
 msgstr "还用于"
 
-#: src/ui_widgets/setting_frame.gd src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
 msgstr "恢复默认"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Unused"
 msgstr "未使用"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Add shortcut"
 msgstr "添加快捷键"
 
-#: src/ui_widgets/setting_shortcut.gd
+#: src/ui_widgets/setting_shortcut.gd:
 msgid "Press keys…"
 msgstr "按下按键…"
 
-#: src/ui_widgets/transform_field.gd
+#: src/ui_widgets/transform_field.gd:
 msgid "No transforms"
 msgstr "没有变换"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Apply the matrix"
 msgstr "应用矩阵"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "Insert Before"
 msgstr "在前方插入"
 
-#: src/ui_widgets/transform_popup.gd
+#: src/ui_widgets/transform_popup.gd:
 msgid "New transform"
 msgstr "新的变换"
 
-#: src/ui_widgets/unrecognized_field.gd
+#: src/ui_widgets/unrecognized_field.gd:
 msgid "GodSVG doesn’t recognize this attribute"
 msgstr "GodSVG 无法识别该属性"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} was discarded."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Discarded files"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "{file_path} couldn't be opened."
 msgstr "无法打开文件。"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
 msgstr "检查文件是否还存在于选中的路径。"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "Save the file?"
 msgstr "保存 .\"{format}\" 文件"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 #, fuzzy
 msgid "Do you want to save this file?"
 msgstr "您确定要退出 GodSVG 吗？"
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Save the changes?"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Your changes will be lost if you don't save them."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Don't save"
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "{file_path} is already being edited inside GodSVG."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
 msgstr ""
 
-#: src/utils/FileUtils.gd
+#: src/utils/FileUtils.gd:
 msgid "Do you want to save the changes made to {file_name}?"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Save SVG"
 msgstr "保存 SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save SVG as"
 msgstr "保存 SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the right"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close all other tabs"
 msgstr "复制所有文本"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close empty tabs"
 msgstr "闭合路径"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Close saved tabs"
 msgstr "复制所有文本"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Create tab"
 msgstr "创建"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the next tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select the previous tab"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Optimize"
 msgstr "优化"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Optimize SVG"
 msgstr "优化"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "复制所有文本"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Copy the SVG text"
 msgstr "复制所有文本"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
 msgstr "重置 SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open externally"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Open SVG externally"
 msgstr "打开 GodSVG 代码仓库"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show SVG in File Manager"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Undo"
 msgstr "撤销"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Redo"
 msgstr "恢复"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cut"
 msgstr "剪切"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select all"
 msgstr "选择"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Duplicate"
 msgstr "克隆"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Duplicate the selection"
 msgstr "删除所选项"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Delete the selection"
 msgstr "删除所选项"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move up"
 msgstr "上移"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move the selection up"
 msgstr "将选中的元素上移"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move down"
 msgstr "下移"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Move the selection down"
 msgstr "将选中的元素下移"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Find"
 msgstr "查找"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom in"
 msgstr "放大"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom out"
 msgstr "缩小"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Zoom reset"
 msgstr "重置缩放"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show grid"
 msgstr "显示网格"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show handles"
 msgstr "显示拖拽框"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
 msgstr "显示光栅化的 SVG"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle snapping"
 msgstr "切换吸附"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Load reference image"
 msgstr "加载参考图像"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Show reference image"
 msgstr "显示参考图像"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Overlay reference image"
 msgstr "置顶参考图像"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "View debug information"
 msgstr "查看调试信息"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Settings"
 msgstr "设置"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Settings menu"
 msgstr "打开设置菜单"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "About…"
 msgstr "关于…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open About menu"
 msgstr "打开关于菜单"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Donate…"
 msgstr "捐赠…"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open Donate menu"
 msgstr "打开捐赠菜单"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG repository"
 msgstr "GodSVG 代码仓库"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG repository"
 msgstr "打开 GodSVG 代码仓库"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "GodSVG website"
 msgstr "GodSVG 网站"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Open GodSVG website"
 msgstr "打开 GodSVG 网站"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Check for updates"
 msgstr "检查更新"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quit the application"
 msgstr "退出程序"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Move to"
 msgstr "移动到"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Line to"
 msgstr "直线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Horizontal Line to"
 msgstr "横线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Vertical Line to"
 msgstr "竖线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Close Path"
 msgstr "闭合路径"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Elliptical Arc to"
 msgstr "圆弧"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Quadratic Bezier to"
 msgstr "双点二次贝塞尔曲线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Quadratic Bezier to"
 msgstr "单点二次贝塞尔曲线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Cubic Bezier to"
 msgstr "三点三次贝塞尔曲线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Shorthand Cubic Bezier to"
 msgstr "两点三次贝塞尔曲线"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Absolute"
 msgstr "绝对"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Code editor"
 msgstr ""
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Inspector"
 msgstr ""
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Viewport"
 msgstr "视图"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select {format} files"
 msgstr "选择 XML 文件"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "选择图像"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Select an {format} file"
 msgstr "选择 XML 文件"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Save the {format} file"
 msgstr "保存 .\"{format}\" 文件"
 
-#: src/utils/TranslationUtils.gd
+#: src/utils/TranslationUtils.gd:
 #, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
 msgstr "文件扩展名为空。只有 {extension_list} 内的文件受支持。"


### PR DESCRIPTION
Adds a colon at the end of file paths so poedit allows viewing the source files directly.
It wont jump to the place the string is used, but the source view window has searching capability with ctrl+f so its easy to find the string.