### PR TITLE
Add better exporting/saving for Chromium-based browsers

### DIFF
--- a/src/config_classes/TabData.gd
+++ b/src/config_classes/TabData.gd
@@ -91,6 +91,18 @@ func setup_svg_text(new_text: String, fully_load := true) -> void:
 func get_svg_text() -> String:
 	return _svg_text
 
+## Gets the default name of the tab.
+## Should also be used to get the file name for save dialogs.
+func get_tab_name(styled := false) -> String:
+	var save_name := svg_file_path.get_file()
+	if save_name.is_empty():
+		var default := ""
+		if is_empty():
+			default = Translator.translate("Empty")
+		elif not is_saved():
+			default = Translator.translate("Unsaved")
+		return default if not styled else ("[ %s ]" % default)
+	return save_name
 
 @export var svg_file_path: String:
 	set(new_value):
@@ -149,14 +161,8 @@ func _sync() -> void:
 	if not _sync_pending:
 		return
 	_sync_pending = false
-	
 	if is_saved():
-		# The extension is included in the presented name too.
-		# It's always in the end anyway so it can't hide useless info.
-		# And also, it prevents ".svg" from being presented as an empty string.
-		presented_name = svg_file_path.get_file()
 		empty_unsaved = false
-		
 		if not fully_loaded:
 			marked_unsaved = false
 		else:
@@ -168,16 +174,14 @@ func _sync() -> void:
 						SVGParser.root_to_export_text(edited_text_parse_result.svg)
 			else:
 				marked_unsaved = true
-	
 	elif not FileAccess.file_exists(get_edited_file_path()) or\
 	SVGParser.text_check_is_root_empty(get_true_svg_text()):
 		empty_unsaved = true
 		marked_unsaved = false
-		presented_name = "[ %s ]" % Translator.translate("Empty")
 	else:
 		empty_unsaved = false
 		marked_unsaved = false
-		presented_name = "[ %s ]" % Translator.translate("Unsaved")
+	presented_name = get_tab_name(true)
 
 
 func activate() -> void:

--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -655,6 +655,7 @@ static func _web_on_file_saved(args: Array, currently_saving: int, quick_export:
 			push_error("Unable to find tab %s by its ID" % currently_saving)
 			return
 		active_tab.svg_file_path = file_handle.name
+		active_tab.empty_unsaved = false
 		active_tab.marked_unsaved = false
 		if file_handle != null:
 			active_tab.web_file_handle = file_handle
@@ -678,13 +679,7 @@ static func web_save(buffer: PackedByteArray, format: String, ignore_handles: bo
 	var window := JavaScriptBridge.get_interface("window")
 	
 	var active_tab := Configs.savedata.get_active_tab()
-	var file_path = active_tab.svg_file_path
-	if file_path.is_empty():
-		if not active_tab.presented_name.is_empty() and not quick_export:
-			file_path = active_tab.presented_name
-		else:
-			file_path = "export." + format
-	var file_name := Utils.get_file_name(file_path)
+	var file_name = active_tab.get_tab_name()
 	var format_type := ImageExportData.image_types_dict[format]
 	
 	# Currently, only Chromium-based browsers support the new file picker system.
@@ -727,7 +722,7 @@ static func web_save(buffer: PackedByteArray, format: String, ignore_handles: bo
 	
 	# Options
 	var picker_options := {
-		"suggestedName": file_name + "." + format,
+		"suggestedName": file_name,
 		"startIn": "pictures",
 		"types": [
 			{


### PR DESCRIPTION
This uses the new web filesystem access APis, making GodSVG no longer save a new file to the downloads folder.

This instead prompts the user once to save a file and stores a handle to that file that we can later write to all we want.

There are some limitations; Mainly, the handle for each file has to be requested again any time the user loads up GodSVG again, as well as the first time the user saves after loading a brand new file, but this isn't problematic and it still beats saving as a new file every time.

This PR works on my machine; I've tested saving/loading files, multiple tabs, and exporting. I haven't tested this thoroughly however and I'd appreciate if someone would before merging _(Especially the XML colour palette saving? Not sure what that is about)_

See also: https://developer.chrome.com/docs/capabilities/web-apis/file-system-access