### PR TITLE
Split out max FPS and unlimited FPS settings

### DIFF
--- a/src/autoload/Configs.gd
+++ b/src/autoload/Configs.gd
@@ -82,6 +82,7 @@ func post_load() -> void:
 	savedata.get_active_tab().activate()
 	sync_background_color()
 	sync_locale()
+	sync_max_fps()
 
 
 func generate_highlighter() -> SVGHighlighter:
@@ -107,3 +108,6 @@ func sync_locale() -> void:
 		savedata.language = "en"
 	else:
 		TranslationServer.set_locale(savedata.language)
+
+func sync_max_fps() -> void:
+	Engine.max_fps = 0 if savedata.uncapped_framerate else savedata.max_fps

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -39,7 +39,8 @@ func get_setting_default(setting: String) -> Variant:
 		"use_filename_for_window_title": return true
 		"handle_size": return 1.0 if OS.get_name() != "Android" else 2.0
 		"ui_scale": return ScalingApproach.AUTO
-		"max_fps": return 0
+		"uncapped_framerate": return false
+		"max_fps": return 60
 	return null
 
 func reset_to_default() -> void:
@@ -282,18 +283,26 @@ enum ScalingApproach {AUTO, CONSTANT_075, CONSTANT_100, CONSTANT_125, CONSTANT_1
 			emit_changed()
 			Configs.ui_scale_changed.emit()
 
+@export var uncapped_framerate := false:
+	set(new_value):
+		if uncapped_framerate != new_value:
+			uncapped_framerate = new_value
+			emit_changed()
+			Configs.sync_max_fps.call_deferred()
+
+const MAX_FPS_MIN = 24
 const MAX_FPS_MAX = 600
-const MAX_FPS_MIN = 20
-@export var max_fps := 0:
+@export var max_fps := 60:
 	set(new_value):
 		if is_nan(new_value):
-			max_fps = get_setting_default("max_fps")
+			new_value = get_setting_default("max_fps")
 		elif new_value != 0:
-			max_fps = clampi(new_value, MAX_FPS_MIN, MAX_FPS_MAX)
+			new_value = clampi(new_value, MAX_FPS_MIN, MAX_FPS_MAX)
 		
-		if new_value != max_fps:
+		if max_fps != new_value:
+			max_fps = new_value
 			emit_changed()
-			Engine.max_fps = max_fps
+			Configs.sync_max_fps.call_deferred()
 
 
 # Session

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -574,7 +574,27 @@ msgid "UI scale"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+msgid "Determines the scale factor for the interface."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -741,7 +761,7 @@ msgid ""
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+msgid "Determines the visual size and grabbing area of handles."
 msgstr ""
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -585,8 +585,28 @@ msgid "UI scale"
 msgstr "Мащаб на интерфейса"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
-msgstr "Увеличава мащаба на интерфейса."
+msgid "Determines the scale factor for the interface."
+msgstr "Определя мащаба на интерфейса."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr "Неограничени кадри в секунда"
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr "Определя дали кадрите да се изобразяват възможно най-бързо (може да увеличи консумацията на енергия и отделянето на топлина)"
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr "Максимални кадри в секунда"
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr "Ако кадрите в секунда са ограничени, тази стойност определя максимума."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -763,8 +783,8 @@ msgstr ""
 "настоящия файл."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
-msgstr "Увеличава размера и площта в която дръжките могат да бъдат хванати."
+msgid "Determines the visual size and grabbing area of handles."
+msgstr "Определя размера на дръжките и площта в която те могат да бъдат хванати."
 
 #: src/ui_parts/shortcut_panel.gd:
 msgid "Horizontal strip"

--- a/translations/de.po
+++ b/translations/de.po
@@ -588,8 +588,29 @@ msgid "UI scale"
 msgstr "Benutzeroberflächenskalierung"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Verändert den Skalierungsfaktor der Benutzeroberfläche."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -767,7 +788,8 @@ msgstr ""
 "die aktuelle Datei anzuzeigen."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Erhöht die visuelle Größe und den Interaktionsbereich von Griffen."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/en.po
+++ b/translations/en.po
@@ -575,7 +575,27 @@ msgid "UI scale"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+msgid "Determines the scale factor for the interface."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -742,7 +762,7 @@ msgid ""
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+msgid "Determines the visual size and grabbing area of handles."
 msgstr ""
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/es.po
+++ b/translations/es.po
@@ -584,8 +584,29 @@ msgid "UI scale"
 msgstr "Escala de la interfaz de usuario"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Cambia el factor de escala de la interfaz."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -763,7 +784,8 @@ msgstr ""
 "incluir el archivo actual."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Cambia el tamaño visual y el área de agarre de los controladores."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/et.po
+++ b/translations/et.po
@@ -584,8 +584,29 @@ msgid "UI scale"
 msgstr "Kasutajaliidese suurus"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Muudab kasutajaliidese suurust."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -760,7 +781,8 @@ msgstr ""
 "Väljalülitamisel jääb akna nimieks \"GodSVG\" sõltumata avatud failist."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Muudab pidemete nähtavat ja interaktiivse ala suurust."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -587,8 +587,29 @@ msgid "UI scale"
 msgstr "Échelle de l'interface"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Change le facteur d'échelle de l'interface."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -766,7 +787,8 @@ msgstr ""
 "soit le fichier actuel."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Change la taille visuelle et la zone de saisie des poignées"
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -588,8 +588,29 @@ msgid "UI scale"
 msgstr "Gebruiksinterface maat"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Verandert het maat-factor van de gebruikersinterface."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -766,7 +787,8 @@ msgstr ""
 "achteloos van het huidige bestand."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "verandert de visuele grootte en grijpgebieden van handvaten."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -587,8 +587,29 @@ msgid "UI scale"
 msgstr "Escala da interface"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Muda o fator de escala da interfaçe."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -764,7 +785,8 @@ msgstr ""
 "o nome do arquivo aberto."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Muda o tamanho e a área de agarramento das alças."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -587,8 +587,29 @@ msgid "UI scale"
 msgstr "Масштаб интерфейса"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Изменить масштаб пользовательского интерфейса."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -765,7 +786,8 @@ msgstr ""
 "файл."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Изменит визуальный размер и область захвата ручек редактирования."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -585,8 +585,29 @@ msgid "UI scale"
 msgstr "Масштаб інтерфейсу"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the scale factor for the interface."
+#, fuzzy
+msgid "Determines the scale factor for the interface."
 msgstr "Змінити масштаб інтерфейсу користувача."
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -767,7 +788,8 @@ msgstr ""
 "поточного файлу."
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "Змінює візуальний розмір та область захоплення для ручок."
 
 #: src/ui_parts/shortcut_panel.gd:

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -584,8 +584,28 @@ msgstr "UI 缩放"
 
 #: src/ui_parts/settings_menu.gd:
 #, fuzzy
-msgid "Changes the scale factor for the interface."
+msgid "Determines the scale factor for the interface."
 msgstr "改变用户界面的缩放尺寸。"
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Uncapped framerate"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"Determines if frames are rendered as fast as possible (may increase power "
+"consumption and heat)."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Custom maximum FPS"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid ""
+"If the framerate is capped, this value determines the maximum number of "
+"frames per second."
+msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Language"
@@ -758,7 +778,8 @@ msgid ""
 msgstr "如果禁用，不论当前打开的文件是什么，窗口标题都将固定为 “GodSVG”。"
 
 #: src/ui_parts/settings_menu.gd:
-msgid "Changes the visual size and grabbing area of handles."
+#, fuzzy
+msgid "Determines the visual size and grabbing area of handles."
 msgstr "改变拖拽框的视觉和操作区域大小。"
 
 #: src/ui_parts/shortcut_panel.gd:


### PR DESCRIPTION
Should probably be revised more later. Min values make sense to go even lower, but I wouldn't want to give users unlimited freedom that without some sort of warning system. And the whole thing could be changed back into one setting in the future, but number_dropdown would need a rework. I could take a look at this at a later date.