### PR TITLE
Collapsible Inspector Elements

### DIFF
--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -9,6 +9,8 @@ signal descendant_attribute_changed(name: String)
 var _child_elements: Array[XNode]
 var _attributes: Dictionary[String, Attribute]
 
+var meta_collapsed: bool
+
 func _init() -> void:
 	attribute_changed.connect(_on_attribute_changed)
 	ancestor_attribute_changed.connect(_on_ancestor_attribute_changed)

--- a/src/ui_widgets/element_frame.gd
+++ b/src/ui_widgets/element_frame.gd
@@ -77,6 +77,9 @@ func _ready() -> void:
 		main_container.add_child(child_xnodes_container)
 		for xnode_editor in XNodeChildrenBuilder.create(element):
 			child_xnodes_container.add_child(xnode_editor)
+	
+	for child in main_container.get_children():
+		child.visible = not element.meta_collapsed
 
 func _exit_tree() -> void:
 	RenderingServer.free_rid(surface)
@@ -106,6 +109,13 @@ func _on_title_button_pressed() -> void:
 	HandlerGUI.popup_under_rect_center(State.get_selection_context(
 			HandlerGUI.popup_under_rect_center.bind(rect, viewport),
 			Utils.LayoutPart.INSPECTOR), rect, viewport)
+
+
+func _on_collapse_button_pressed() -> void:
+	State.normal_select(element.xid)
+	element.meta_collapsed = not element.meta_collapsed
+	for child: Control in main_container.get_children():
+		child.visible = not element.meta_collapsed
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -142,7 +152,17 @@ func _on_mouse_entered() -> void:
 	var half_bar_width := title_bar.size.x / 2
 	var title_width := ThemeUtils.mono_font.get_string_size(element.name,
 			HORIZONTAL_ALIGNMENT_LEFT, 180, 12).x
-	# Add button.
+	# Add collapse button
+	var collapse_button := Button.new()
+	collapse_button.focus_mode = Control.FOCUS_NONE
+	collapse_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	collapse_button.mouse_filter = Control.MOUSE_FILTER_PASS
+	collapse_button.theme_type_variation = "FlatButton"
+	collapse_button.size = Vector2(title_bar.size.x, title_bar.size.y)
+	title_bar.add_child(collapse_button)
+	collapse_button.pressed.connect(_on_collapse_button_pressed)
+	mouse_exited.connect(collapse_button.queue_free)
+	# Add title button.
 	var title_button := Button.new()
 	title_button.focus_mode = Control.FOCUS_NONE
 	title_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND


### PR DESCRIPTION
(Leaving this in draft until I finish further testing and get a better feel for how the UI is)

**Description:** Initial implementation of #1315. Allows user to hide the attributes and children of an element in the inspector by clicking its title bar.
**Motivation:** Collapsing groups is very helpful when working on more complex files.

**Details:** All children of `main_container` in `element_frame`s are hidden if the new `Element.meta_collapsed` field is true for their `element`.

**Limitations:** What elements are collapsed is **NOT** saved, but I think this is an acceptable tradeoff for not having separate meta file. If there is demand for this in the future, then that could be implemented independently of this PR.