### PR TITLE
Add fx and fy attributes, improve gradient previews, and move to 4.5 beta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Download the version you want from [the list of GodSVG releases](https://github.
 
 Link to the web editor: https://godsvg.com/editor
 
-To run the latest unreleased version, you can download Godot from https://godotengine.org (development is currently happening in the latest v4.5 beta). After getting the repository files on your machine, you must open Godot, click on the "Import" button, and import the `project.godot` folder.
+To run the latest unreleased version, you can download Godot from https://godotengine.org (development is currently happening in v4.5 beta 2). After getting the repository files on your machine, you must open Godot, click on the "Import" button, and import the `project.godot` folder.
 
 Another way to run the latest dev build is to open a recent commit and download its artifacts (Checks > export-optimized > Summary > Artifacts). You need to log into Github for that.
 

--- a/godot_only/scripts/update_translations.gd
+++ b/godot_only/scripts/update_translations.gd
@@ -12,8 +12,6 @@ const COMMENTS_DICT = {
 	"Excluded": "Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.",
 	"Update check failed": "When checking for updates.",
 	"Project Founder and Manager": "If the language has different gendered versions, prefer the most neutral-sounding one, i.e., the one used when you don't know the person's gender. If that's not possible, use feminine.",
-	"RGB": "If your language doesn't have a well-known 3-letter abbreviation, keep as \"RGB\".",
-	"HSV": "If your language doesn't have a well-known 3-letter abbreviation, keep as \"HSV\".",
 }
 
 const TRANSLATIONS_DIR = "translations"

--- a/src/autoload/Configs.gd
+++ b/src/autoload/Configs.gd
@@ -1,38 +1,24 @@
 # This singleton handles session data and settings.
 extends Node
 
-@warning_ignore("unused_signal")
+@warning_ignore_start("unused_signal")
 signal highlighting_colors_changed
-@warning_ignore("unused_signal")
 signal snap_changed
-@warning_ignore("unused_signal")
 signal language_changed
-@warning_ignore("unused_signal")
 signal ui_scale_changed
-@warning_ignore("unused_signal")
 signal theme_changed
-@warning_ignore("unused_signal")
 signal shortcuts_changed
-@warning_ignore("unused_signal")
 signal basic_colors_changed
-@warning_ignore("unused_signal")
 signal handle_visuals_changed
-@warning_ignore("unused_signal")
 signal selection_rectangle_visuals_changed
-@warning_ignore("unused_signal")
 signal grid_color_changed
-@warning_ignore("unused_signal")
 signal shortcut_panel_changed
-@warning_ignore("unused_signal")
 signal active_tab_status_changed
-@warning_ignore("unused_signal")
 signal active_tab_reference_changed
-@warning_ignore("unused_signal")
 signal active_tab_changed
-@warning_ignore("unused_signal")
 signal tabs_changed
-@warning_ignore("unused_signal")
 signal layout_changed
+@warning_ignore_restore("unused_signal")
 
 const savedata_path = "user://savedata.tres"
 var savedata: SaveData:

--- a/src/config_classes/ConfigResource.gd
+++ b/src/config_classes/ConfigResource.gd
@@ -1,5 +1,5 @@
 # Implements a very useful signal.
-abstract class_name ConfigResource extends Resource
+@abstract class_name ConfigResource extends Resource
 
 signal changed_deferred
 

--- a/src/data_classes/ColorParser.gd
+++ b/src/data_classes/ColorParser.gd
@@ -1,4 +1,4 @@
-abstract class_name ColorParser
+@abstract class_name ColorParser
 
 
 static func add_hash_if_hex(color: String) -> String:

--- a/src/data_classes/DB.gd
+++ b/src/data_classes/DB.gd
@@ -1,4 +1,4 @@
-abstract class_name DB
+@abstract class_name DB
 
 enum AttributeType {NUMERIC, COLOR, LIST, PATHDATA, ENUM, TRANSFORM_LIST, ID, HREF, UNKNOWN}
 enum PercentageHandling {FRACTION, HORIZONTAL, VERTICAL, NORMALIZED}
@@ -43,7 +43,7 @@ const recognized_attributes: Dictionary[String, Array] = {
 	"linearGradient": ["id", "gradientTransform", "gradientUnits", "spreadMethod",
 			"x1", "y1", "x2", "y2"],
 	"radialGradient": ["id", "gradientTransform", "gradientUnits", "spreadMethod",
-			"cx", "cy", "r"],
+			"cx", "cy", "r", "fx", "fy"],
 	"circle": ["transform", "opacity", "fill", "fill-opacity", "stroke", "stroke-opacity",
 			"stroke-width", "cx", "cy", "r"],
 	"ellipse": ["transform", "opacity", "fill", "fill-opacity", "stroke", "stroke-opacity",
@@ -98,6 +98,8 @@ const _attribute_types: Dictionary[String, AttributeType] = {
 	"r": AttributeType.NUMERIC,
 	"rx": AttributeType.NUMERIC,
 	"ry": AttributeType.NUMERIC,
+	"fx": AttributeType.NUMERIC,
+	"fy": AttributeType.NUMERIC,
 	"opacity": AttributeType.NUMERIC,
 	"fill": AttributeType.COLOR,
 	"fill-opacity": AttributeType.NUMERIC,
@@ -141,6 +143,8 @@ const attribute_number_range: Dictionary[String, NumberRange] = {
 	"r": NumberRange.POSITIVE,
 	"rx": NumberRange.POSITIVE,
 	"ry": NumberRange.POSITIVE,
+	"fx": NumberRange.ARBITRARY,
+	"fy": NumberRange.ARBITRARY,
 	"opacity": NumberRange.UNIT,
 	"fill-opacity": NumberRange.UNIT,
 	"stroke-opacity": NumberRange.UNIT,
@@ -200,6 +204,8 @@ attribute_name: String) -> PercentageHandling:
 		"y2": return PercentageHandling.VERTICAL
 		"cx": return PercentageHandling.HORIZONTAL
 		"cy": return PercentageHandling.VERTICAL
+		"fx": return PercentageHandling.HORIZONTAL
+		"fy": return PercentageHandling.VERTICAL
 		"r": return PercentageHandling.NORMALIZED
 		_: return PercentageHandling.FRACTION
 
@@ -237,8 +243,3 @@ static func attribute(name: String, value: String) -> Attribute:
 		DB.AttributeType.ID: return AttributeID.new(name, value)
 		DB.AttributeType.HREF: return AttributeHref.new(name, value)
 		_: return Attribute.new(name, value)
-
-
-static func is_element_gradient(checked_element: Element) -> bool:
-	return checked_element != null and (checked_element is ElementLinearGradient or\
-			checked_element is ElementRadialGradient)

--- a/src/data_classes/Element.gd
+++ b/src/data_classes/Element.gd
@@ -1,6 +1,5 @@
-# An abstract class representing an element, either standalone (<element/>) or container
-# (<element>...</element>).
-abstract class_name Element extends XNode
+# Represents an element, either standalone (<element/>) or container (<element>...</element>).
+@abstract class_name Element extends XNode
 
 signal attribute_changed(name: String)
 signal ancestor_attribute_changed(name: String)

--- a/src/data_classes/ElementBaseGradient.gd
+++ b/src/data_classes/ElementBaseGradient.gd
@@ -1,41 +1,12 @@
-abstract class_name GradientUtils
+@abstract class_name ElementBaseGradient extends Element
 
-static func generate_gradient(element: Element) -> Gradient:
-	if not (element is ElementLinearGradient or element is ElementRadialGradient):
-		return null
-	
-	var gradient := Gradient.new()
-	gradient.remove_point(0)
-	
-	var current_offset := 0.0
-	var is_gradient_empty := true
-	
-	for child in element.get_children():
-		if not child is ElementStop:
-			continue
-		
-		current_offset = clamp(child.get_attribute_num("offset"), current_offset, 1.0)
-		gradient.add_point(current_offset,
-				Color(ColorParser.text_to_color(child.get_attribute_true_color("stop-color")),
-				child.get_attribute_num("stop-opacity")))
-		
-		if is_gradient_empty:
-			is_gradient_empty = false
-			gradient.remove_point(0)
-	
-	if is_gradient_empty:
-		gradient.set_color(0, Color.TRANSPARENT)
-	
-	return gradient
+const possible_conversions: PackedStringArray = []
 
 
-static func get_gradient_warnings(element: Element) -> PackedStringArray:
-	if not (element is ElementLinearGradient or element is ElementRadialGradient):
-		return PackedStringArray()
+func get_config_warnings() -> PackedStringArray:
+	var warnings := super()
 	
-	var warnings := PackedStringArray()
-	
-	if not element.has_attribute("id"):
+	if not has_attribute("id"):
 		warnings.append(Translator.translate("No \"id\" attribute defined."))
 	
 	var prev_offset := -1.0
@@ -43,7 +14,7 @@ static func get_gradient_warnings(element: Element) -> PackedStringArray:
 	var initial_opacity := -1.0
 	var has_effective_transition := false
 	
-	for child in element.get_children():
+	for child in get_children():
 		if not child is ElementStop:
 			continue
 		
@@ -77,3 +48,6 @@ static func get_gradient_warnings(element: Element) -> PackedStringArray:
 		warnings.append(Translator.translate("This gradient is a solid color."))
 	
 	return warnings
+
+
+@abstract func generate_texture() -> SVGTexture

--- a/src/data_classes/ElementBaseGradient.gd.uid
+++ b/src/data_classes/ElementBaseGradient.gd.uid
@@ -1,0 +1,1 @@
+uid://cqpplak413bai

--- a/src/data_classes/ElementCircle.gd
+++ b/src/data_classes/ElementCircle.gd
@@ -2,7 +2,7 @@
 class_name ElementCircle extends Element
 
 const name = "circle"
-const possible_conversions: Array[String] = ["ellipse", "rect", "path"]
+const possible_conversions: PackedStringArray = ["ellipse", "rect", "path"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	set_attribute("r", 1.0)

--- a/src/data_classes/ElementEllipse.gd
+++ b/src/data_classes/ElementEllipse.gd
@@ -2,7 +2,7 @@
 class_name ElementEllipse extends Element
 
 const name = "ellipse"
-const possible_conversions: Array[String] = ["circle", "rect", "path"]
+const possible_conversions: PackedStringArray = ["circle", "rect", "path"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	set_attribute("rx", 1.0)

--- a/src/data_classes/ElementG.gd
+++ b/src/data_classes/ElementG.gd
@@ -2,27 +2,12 @@
 class_name ElementG extends Element
 
 const name = "g"
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"opacity": return "1"
 		_: return ""
-
-# TODO: It's not enough to merge up with the bounding boxes of the children.
-# If they are transformed it would be wrong.
-func get_bounding_box() -> Rect2:
-	var bounding_box := Rect2()
-	#var established_bb := false
-	#for child in get_children():
-		#if DB.is_attribute_recognized(child.name, "transform"):
-			#var cbb: Rect2 = child.get_transformed_bounding_box()
-			#if not established_bb:
-				#bounding_box = cbb
-				#established_bb = true
-			#else:
-				#bounding_box = bounding_box.merge(cbb)
-	return bounding_box
 
 func get_config_warnings() -> PackedStringArray:
 	var warnings := super()

--- a/src/data_classes/ElementLine.gd
+++ b/src/data_classes/ElementLine.gd
@@ -2,7 +2,7 @@
 class_name ElementLine extends Element
 
 const name = "line"
-const possible_conversions: Array[String] = ["path", "polyline"]
+const possible_conversions: PackedStringArray = ["path", "polyline"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	if precise_pos != PackedFloat64Array([0.0, 0.0]):

--- a/src/data_classes/ElementLinearGradient.gd
+++ b/src/data_classes/ElementLinearGradient.gd
@@ -1,8 +1,7 @@
 # A <linearGradient> element.
-class_name ElementLinearGradient extends Element
+class_name ElementLinearGradient extends ElementBaseGradient
 
 const name = "linearGradient"
-const possible_conversions: Array[String] = []
 
 func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
@@ -19,23 +18,53 @@ func get_percentage_handling(attribute_name: String) -> DB.PercentageHandling:
 	else:
 		return super(attribute_name)
 
-func get_config_warnings() -> PackedStringArray:
-	var warnings := super()
-	warnings += GradientUtils.get_gradient_warnings(self)
-	return warnings
-
-func generate_texture() -> GradientTexture2D:
-	var texture := GradientTexture2D.new()
-	texture.gradient = GradientUtils.generate_gradient(self)
-	texture.fill_from = Vector2(get_attribute_num("x1"), get_attribute_num("y1"))
-	texture.fill_to = Vector2(get_attribute_num("x2"), get_attribute_num("y2"))
+func generate_texture() -> SVGTexture:
+	var svg_texture_text := """<svg width="64" height="64"
+			xmlns="http://www.w3.org/2000/svg"><linearGradient id="a" """
 	
-	if get_attribute_value("gradientUnits") == "userSpaceOnUse":
-		texture.fill_from /= svg.get_size()
-		texture.fill_to /= svg.get_size()
+	var scaling := Vector2(64.0, 64.0) / svg.get_size()
+	var is_user_space_on_use := (get_attribute_value("gradientUnits") == "userSpaceOnUse")
 	
-	match get_attribute_value("spreadMethod"):
-		"repeat": texture.repeat = GradientTexture2D.REPEAT
-		"reflect": texture.repeat = GradientTexture2D.REPEAT_MIRROR
+	for attrib in ["x1", "x2"]:
+		if has_attribute(attrib):
+			var attrib_num := get_attribute_num(attrib)
+			if is_user_space_on_use:
+				attrib_num *= scaling.x
+			svg_texture_text += """%s="%f" """ % [attrib, attrib_num]
 	
-	return texture
+	for attrib in ["y1", "y2"]:
+		if has_attribute(attrib):
+			var attrib_num := get_attribute_num(attrib)
+			if is_user_space_on_use:
+				attrib_num *= scaling.y
+			svg_texture_text += """%s="%f" """ % [attrib, attrib_num]
+	
+	if has_attribute("gradientTransform"):
+		if is_user_space_on_use:
+			svg_texture_text += """gradientTransform="scale(%f %f) %s scale(%f %f)" """ %\
+					[scaling.x, scaling.y, get_attribute_value("gradientTransform"), 1/scaling.x, 1/scaling.y]
+		else:
+			svg_texture_text += """gradientTransform="%s" """ %\
+					get_attribute_value("gradientTransform")
+	
+	for attrib in ["spreadMethod", "gradientUnits"]:
+		if has_attribute(attrib):
+			svg_texture_text += """%s="%s" """ % [attrib, get_attribute_value(attrib)]
+	
+	svg_texture_text += ">"
+	
+	for child in get_children():
+		if not child is ElementStop:
+			continue
+		
+		svg_texture_text += "<stop "
+		for attribute: Attribute in child.get_all_attributes():
+			var value := attribute.get_value()
+			if not '"' in value:
+				svg_texture_text += ' %s="%s"' % [attribute.name, value]
+			else:
+				svg_texture_text += " %s='%s'" % [attribute.name, value]
+		svg_texture_text += "/>"
+	
+	svg_texture_text += """</linearGradient><rect fill="url(#a)" width="100%%" height="100%%"/></svg>"""
+	return SVGTexture.create_from_string(svg_texture_text)

--- a/src/data_classes/ElementPath.gd
+++ b/src/data_classes/ElementPath.gd
@@ -2,7 +2,7 @@
 class_name ElementPath extends Element
 
 const name = "path"
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	if precise_pos != PackedFloat64Array([0.0, 0.0]):

--- a/src/data_classes/ElementPolygon.gd
+++ b/src/data_classes/ElementPolygon.gd
@@ -2,7 +2,7 @@
 class_name ElementPolygon extends Element
 
 const name = "polygon"
-const possible_conversions: Array[String] = ["path", "rect"]
+const possible_conversions: PackedStringArray = ["path", "rect"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	if precise_pos != PackedFloat64Array([0.0, 0.0]):

--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -2,7 +2,7 @@
 class_name ElementPolyline extends Element
 
 const name = "polyline"
-const possible_conversions: Array[String] = ["path", "line"]
+const possible_conversions: PackedStringArray = ["path", "line"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	if precise_pos != PackedFloat64Array([0.0, 0.0]):

--- a/src/data_classes/ElementRadialGradient.gd
+++ b/src/data_classes/ElementRadialGradient.gd
@@ -1,42 +1,77 @@
 # A <radialGradient> element.
-class_name ElementRadialGradient extends Element
+class_name ElementRadialGradient extends ElementBaseGradient
 
 const name = "radialGradient"
-const possible_conversions: Array[String] = []
 
 func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:
 		"cx", "cy", "r": return "50%"
+		"fx": return get_implied_attribute_value("cx")
+		"fy": return get_implied_attribute_value("cy")
 		"gradientUnits": return "objectBoundingBox"
 		"spreadMethod": return "pad"
 		_: return ""
 
 func get_percentage_handling(attribute_name: String) -> DB.PercentageHandling:
 	if get_attribute_value("gradientUnits") in ["objectBoundingBox", ""] and\
-	attribute_name in ["cx", "cy", "r"]:
+	attribute_name in ["cx", "cy", "r", "fx", "fy"]:
 		return DB.PercentageHandling.FRACTION
 	else:
 		return super(attribute_name)
 
-func get_config_warnings() -> PackedStringArray:
-	var warnings := super()
-	warnings += GradientUtils.get_gradient_warnings(self)
-	return warnings
-
-func generate_texture() -> GradientTexture2D:
-	var texture := GradientTexture2D.new()
-	texture.gradient = GradientUtils.generate_gradient(self)
-	texture.fill = GradientTexture2D.FILL_RADIAL
-	texture.fill_from = Vector2(get_attribute_num("cx"), get_attribute_num("cy"))
-	texture.fill_to = Vector2(get_attribute_num("cx") + get_attribute_num("r"),
-			get_attribute_num("cy"))
+func generate_texture() -> SVGTexture:
+	var svg_texture_text := """<svg width="64" height="64"
+			xmlns="http://www.w3.org/2000/svg"><radialGradient id="a" """
 	
-	if get_attribute_value("gradientUnits") == "userSpaceOnUse":
-		texture.fill_from /= svg.get_size()
-		texture.fill_to /= svg.get_size()
+	var scaling := Vector2(64.0, 64.0) / svg.get_size()
+	var is_user_space_on_use := (get_attribute_value("gradientUnits") == "userSpaceOnUse")
 	
-	match get_attribute_value("spreadMethod"):
-		"repeat": texture.repeat = GradientTexture2D.REPEAT
-		"reflect": texture.repeat = GradientTexture2D.REPEAT_MIRROR
+	for attrib in ["cx", "fx"]:
+		if has_attribute(attrib):
+			var attrib_num := get_attribute_num(attrib)
+			if is_user_space_on_use:
+				attrib_num *= scaling.x
+			svg_texture_text += """%s="%f" """ % [attrib, attrib_num]
 	
-	return texture
+	for attrib in ["cy", "fy"]:
+		if has_attribute(attrib):
+			var attrib_num := get_attribute_num(attrib)
+			if is_user_space_on_use:
+				attrib_num *= scaling.y
+			svg_texture_text += """%s="%f" """ % [attrib, attrib_num]
+	
+	if has_attribute("r"):
+		var attrib_num := get_attribute_num("r")
+		if is_user_space_on_use:
+			attrib_num *= scaling.length() / sqrt(2)
+		svg_texture_text += """r="%f" """ % attrib_num
+	
+	if has_attribute("gradientTransform"):
+		if is_user_space_on_use:
+			svg_texture_text += """gradientTransform="scale(%f %f) %s scale(%f %f)" """ %\
+					[scaling.x, scaling.y, get_attribute_value("gradientTransform"), 1/scaling.x, 1/scaling.y]
+		else:
+			svg_texture_text += """gradientTransform="%s" """ %\
+					get_attribute_value("gradientTransform")
+	
+	for attrib in ["spreadMethod", "gradientUnits"]:
+		if has_attribute(attrib):
+			svg_texture_text += """%s="%s" """ % [attrib, get_attribute_value(attrib)]
+	
+	svg_texture_text += ">"
+	
+	for child in get_children():
+		if not child is ElementStop:
+			continue
+		
+		svg_texture_text += "<stop "
+		for attribute: Attribute in child.get_all_attributes():
+			var value := attribute.get_value()
+			if not '"' in value:
+				svg_texture_text += ' %s="%s"' % [attribute.name, value]
+			else:
+				svg_texture_text += " %s='%s'" % [attribute.name, value]
+		svg_texture_text += "/>"
+	
+	svg_texture_text += """</radialGradient><rect fill="url(#a)" width="100%%" height="100%%"/></svg>"""
+	return SVGTexture.create_from_string(svg_texture_text)

--- a/src/data_classes/ElementRect.gd
+++ b/src/data_classes/ElementRect.gd
@@ -2,7 +2,7 @@
 class_name ElementRect extends Element
 
 const name = "rect"
-const possible_conversions: Array[String] = ["circle", "ellipse", "polygon", "path"]
+const possible_conversions: PackedStringArray = ["circle", "ellipse", "polygon", "path"]
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	set_attribute("width", 1.0)

--- a/src/data_classes/ElementSVG.gd
+++ b/src/data_classes/ElementSVG.gd
@@ -13,7 +13,7 @@ var canvas_precise_transform: PackedFloat64Array:
 		canvas_transform = Utils64Bit.get_transform(canvas_precise_transform)
 
 const name = "svg"
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func _init() -> void:
 	canvas_precise_transform = PackedFloat64Array([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])

--- a/src/data_classes/ElementStop.gd
+++ b/src/data_classes/ElementStop.gd
@@ -2,7 +2,7 @@
 class_name ElementStop extends Element
 
 const name = "stop"
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:

--- a/src/data_classes/ElementUnrecognized.gd
+++ b/src/data_classes/ElementUnrecognized.gd
@@ -2,7 +2,7 @@
 class_name ElementUnrecognized extends Element
 
 var name: String
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func _init(new_name: String) -> void:
 	name = new_name

--- a/src/data_classes/ElementUse.gd
+++ b/src/data_classes/ElementUse.gd
@@ -2,15 +2,12 @@
 class_name ElementUse extends Element
 
 const name = "use"
-const possible_conversions: Array[String] = []
+const possible_conversions: PackedStringArray = []
 
 func user_setup(precise_pos := PackedFloat64Array([0.0, 0.0])) -> void:
 	if precise_pos != PackedFloat64Array([0.0, 0.0]):
 		set_attribute("x", precise_pos[0])
 		set_attribute("y", precise_pos[1])
-
-func get_bounding_box() -> Rect2:
-	return Rect2()
 
 func _get_own_default(attribute_name: String) -> String:
 	match attribute_name:

--- a/src/data_classes/GradientUtils.gd.uid
+++ b/src/data_classes/GradientUtils.gd.uid
@@ -1,1 +1,0 @@
-uid://bcprbwp8itu4

--- a/src/data_classes/ListParser.gd
+++ b/src/data_classes/ListParser.gd
@@ -1,5 +1,5 @@
 # A parser to turn AttributeList's list into other useful things.
-abstract class_name ListParser
+@abstract class_name ListParser
 
 static func rect_to_list(rect: Rect2) -> PackedFloat64Array:
 	return PackedFloat64Array([rect.position.x, rect.position.y, rect.size.x, rect.size.y])

--- a/src/data_classes/NumberParser.gd
+++ b/src/data_classes/NumberParser.gd
@@ -1,5 +1,5 @@
 # Common parser for AttributeNumeric and AttributeList
-abstract class_name NumberParser
+@abstract class_name NumberParser
 
 static func num_to_text(number: float, formatter: Formatter) -> String:
 	if not is_finite(number):

--- a/src/data_classes/PathCommand.gd
+++ b/src/data_classes/PathCommand.gd
@@ -1,5 +1,5 @@
 # A native class that represents a path command and its parameters.
-abstract class_name PathCommand
+@abstract class_name PathCommand
 
 const translation_dict: Dictionary[String, GDScript] = {
 	"M": MoveCommand, "L": LineCommand, "H": HorizontalLineCommand,

--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -1,4 +1,4 @@
-abstract class_name SVGParser
+@abstract class_name SVGParser
 
 # For checking if an SVG is empty. If the text errors out, it's as if the SVG is empty.
 static func text_check_is_root_empty(text: String) -> bool:

--- a/src/data_classes/Transform.gd
+++ b/src/data_classes/Transform.gd
@@ -1,4 +1,4 @@
-abstract class_name Transform
+@abstract class_name Transform
 
 class TransformMatrix extends Transform:
 	var x1: float

--- a/src/data_classes/XNode.gd
+++ b/src/data_classes/XNode.gd
@@ -1,5 +1,5 @@
 # Abstract base class for XML nodes.
-abstract class_name XNode
+@abstract class_name XNode
 
 var xid: PackedInt32Array
 

--- a/src/ui_widgets/Handle.gd
+++ b/src/ui_widgets/Handle.gd
@@ -1,5 +1,5 @@
 # Base class for handles.
-abstract class_name Handle
+@abstract class_name Handle
 
 enum Display {BIG, SMALL}
 var display_mode := Display.BIG

--- a/src/ui_widgets/TitledPanel.gd
+++ b/src/ui_widgets/TitledPanel.gd
@@ -1,6 +1,6 @@
 # Titled panels have two children: The first is on top and it's the title,
 # the second one is on the bottom and it's the panel.
-abstract class_name TitledPanel extends Container
+@abstract class_name TitledPanel extends Container
 
 @export var border_width: int
 @export var corner_radius_top_left: int

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -19,7 +19,7 @@ const ColorFieldPopupScene = preload("res://src/ui_widgets/color_field_popup.tsc
 const checkerboard = preload("res://assets/icons/backgrounds/ColorButtonBG.svg")
 
 var color_popup: ColorFieldPopup
-var gradient_texture: GradientTexture2D
+var gradient_texture: SVGTexture
 
 func set_value(new_value: String, save := false) -> void:
 	if not new_value.is_empty():
@@ -113,7 +113,7 @@ func _draw() -> void:
 	if cached_allow_url and ColorParser.is_valid_url(color_value):
 		var id := color_value.substr(5, color_value.length() - 6)
 		var gradient_element := State.root_element.get_element_by_id(id)
-		if DB.is_element_gradient(gradient_element):
+		if is_instance_valid(gradient_element) and gradient_element is ElementBaseGradient:
 			# Complex drawing logic, because StyleBoxTexture isn't advanced enough.
 			var points := PackedVector2Array()
 			var colors := PackedColorArray()
@@ -179,7 +179,7 @@ func update_gradient_texture() -> void:
 	if ColorParser.is_valid_url(color_value):
 		var id := color_value.substr(5, color_value.length() - 6)
 		var gradient_element := State.root_element.get_element_by_id(id)
-		if DB.is_element_gradient(gradient_element):
+		if is_instance_valid(gradient_element) and gradient_element is ElementBaseGradient:
 			gradient_texture = gradient_element.generate_texture()
 	else:
 		gradient_texture = null

--- a/src/ui_widgets/color_swatch.gd
+++ b/src/ui_widgets/color_swatch.gd
@@ -8,7 +8,7 @@ var color: String
 var color_name: String
 
 var ci := get_canvas_item()
-var gradient_texture: GradientTexture2D
+var gradient_texture: SVGTexture
 
 var current_color := Color.BLACK
 
@@ -18,7 +18,7 @@ func _ready() -> void:
 	if ColorParser.is_valid_url(color):
 		var id := color.substr(5, color.length() - 6)
 		var gradient_element := State.root_element.get_element_by_id(id)
-		if DB.is_element_gradient(gradient_element):
+		if is_instance_valid(gradient_element) and gradient_element is ElementBaseGradient:
 			gradient_texture = gradient_element.generate_texture()
 
 func _draw() -> void:

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -41,6 +41,9 @@ func _ready() -> void:
 	element.attribute_changed.connect(_on_element_attribute_changed)
 	if attribute_name in DB.propagated_attributes:
 		element.ancestor_attribute_changed.connect(_on_element_ancestor_attribute_changed)
+	# These default attributes can change when cx and cy change.
+	if element is ElementRadialGradient and attribute_name in ["fx", "fy"]:
+		element.attribute_changed.connect(_on_element_other_attribute_changed)
 	tooltip_text = attribute_name
 	text_submitted.connect(set_value.bind(true))
 	text_change_canceled.connect(sync)
@@ -51,6 +54,12 @@ func _ready() -> void:
 func _on_element_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:
 		set_value(element.get_attribute_value(attribute_name))
+
+func _on_element_other_attribute_changed(attribute_changed: String) -> void:
+	if (attribute_name == "fx" and attribute_changed == "cx") or\
+	(attribute_name == "fy" and attribute_changed == "cy"):
+		setup_placeholder()
+		sync()
 
 func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 	if attribute_name == attribute_changed:

--- a/src/utils/AttributeFieldBuilder.gd
+++ b/src/utils/AttributeFieldBuilder.gd
@@ -1,4 +1,4 @@
-abstract class_name AttributeFieldBuilder
+@abstract class_name AttributeFieldBuilder
 
 const TransformFieldScene = preload("res://src/ui_widgets/transform_field.tscn")
 const NumberFieldScene = preload("res://src/ui_widgets/number_field.tscn")

--- a/src/utils/ClipboardUtils.gd
+++ b/src/utils/ClipboardUtils.gd
@@ -1,5 +1,5 @@
 # This class adds support for copying images. Currently not supported by Godot.
-abstract class_name ClipboardUtils
+@abstract class_name ClipboardUtils
 
 ## Returns true if this clipboard util is supported on the current platform.
 static func is_supported(format: String) -> bool:

--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -1,5 +1,5 @@
 # This class has functionality for importing, exporting, and saving files.
-abstract class_name FileUtils
+@abstract class_name FileUtils
 
 enum FileState {SAME, DIFFERENT, DOES_NOT_EXIST}
 enum TabCloseMode {SINGLE, ALL_OTHERS, TO_LEFT, TO_RIGHT, EMPTY, SAVED}

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -1,4 +1,4 @@
-abstract class_name ShortcutUtils
+@abstract class_name ShortcutUtils
 
 # Can be activated in all contexts.
 const UNIVERSAL_ACTIONS: PackedStringArray = ["quit", "toggle_fullscreen", "about_info",

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -1,4 +1,4 @@
-abstract class_name ThemeUtils
+@abstract class_name ThemeUtils
 
 const regular_font = preload("res://assets/fonts/Font.ttf")
 const bold_font = preload("res://assets/fonts/FontBold.ttf")

--- a/src/utils/TranslationUtils.gd
+++ b/src/utils/TranslationUtils.gd
@@ -1,4 +1,4 @@
-abstract class_name TranslationUtils
+@abstract class_name TranslationUtils
 
 static func _get_locale_name(locale: String) -> String:
 	match locale:

--- a/src/utils/Translator.gd
+++ b/src/utils/Translator.gd
@@ -1,6 +1,6 @@
 # A wrapper around basic TranslationServer methods. There is an update_translations script
 # which checks all Translator methods used across the codebase to collect their strings.
-abstract class_name Translator
+@abstract class_name Translator
 
 static func translate(string: String) -> String:
 	return TranslationServer.translate(string)

--- a/src/utils/Utils.gd
+++ b/src/utils/Utils.gd
@@ -1,4 +1,4 @@
-abstract class_name Utils
+@abstract class_name Utils
 
 const MAX_NUMERIC_PRECISION = 6
 const MAX_ANGLE_PRECISION = 4

--- a/src/utils/Utils64Bit.gd
+++ b/src/utils/Utils64Bit.gd
@@ -1,7 +1,7 @@
 # Vector2 and Transform2D aren't precise enough to have their numbers used directly
 # in the SVG, as they are 32-bit. GodSVG uses PackedFloat64Array to mock them
 # and this class implements the necessary functionality to make them work.
-abstract class_name Utils64Bit
+@abstract class_name Utils64Bit
 
 static func get_vector(vector: PackedFloat64Array) -> Vector2:
 	return Vector2(vector[0], vector[1])

--- a/src/utils/XIDUtils.gd
+++ b/src/utils/XIDUtils.gd
@@ -1,4 +1,4 @@
-abstract class_name XIDUtils
+@abstract class_name XIDUtils
 
 # [1] > [1, 2] > [1, 0] > [0]
 static func compare(xid1: PackedInt32Array, xid2: PackedInt32Array) -> bool:

--- a/src/utils/XNodeChildrenBuilder.gd
+++ b/src/utils/XNodeChildrenBuilder.gd
@@ -1,4 +1,4 @@
-abstract class_name XNodeChildrenBuilder
+@abstract class_name XNodeChildrenBuilder
 
 const ElementFrameScene = preload("res://src/ui_widgets/element_frame.tscn")
 const BasicXNodeFrameScene = preload("res://src/ui_widgets/basic_xnode_frame.tscn")


### PR DESCRIPTION
A lot of things for one PR... ah welp.

- Texture generation is reworked to use an intermediate 64x64 SVG as a texture showcase. This also turned out well for performance. Fixes #1380
- The mass warning ignores in Configs are now just one block. I don't know how new it is, but it's quite handy and I found out about it just now.
- Changes `abstract` use to `@abstract` as per 4.5.beta2's change.
- Implements `fx` and `fy` in radialGradient.
- Replaces GradientUtils with a base abstract ElementBaseGradient class. The `is_gradient()` utility method in DB is removed in favor of just checking this.