### PR TITLE
Fix `TabBar::_make_custom_tooltip()` not retrieving `hovered_tab` (#1391)

### DIFF
--- a/src/ui_parts/tab_bar.gd
+++ b/src/ui_parts/tab_bar.gd
@@ -421,7 +421,7 @@ func _get_tooltip(at_position: Vector2) -> String:
 	else:
 		# Return tab index as metadata so _make_custom_tooltip can determine the tab
 		# even if the mouse moves.
-		return str(hovered_tab_idx)
+		return String.num_int64(hovered_tab_idx)
 
 func _make_custom_tooltip(for_text: String) -> Object:
 	if not for_text.is_valid_int():


### PR DESCRIPTION
Fixes #1391 

This PR refactors `TabBar::_make_custom_tooltip()` and `TabBar::_get_tooltip()` so that `_make_custom_tooltip()` does not need to lookup the hovered tab based on mouse position.

**Changes:**
1. `_get_tooltip()` now returns the index of the hovered tab.
2. `_make_custom_tooltip()` now uses the tab index from the tooltip to determine the hovered tab.