### PR TITLE
Improve dropdown widget usability on mobile

### DIFF
--- a/src/ui_widgets/dropdown.gd
+++ b/src/ui_widgets/dropdown.gd
@@ -15,6 +15,8 @@ extends HBoxContainer
 signal value_changed(new_value: Variant)
 var _value: Variant
 
+var tap_start_time := 0.0
+
 func set_value(new_value: Variant, emit_changed := true) -> void:
 	if _value != new_value:
 		_value = new_value
@@ -26,6 +28,7 @@ func set_value(new_value: Variant, emit_changed := true) -> void:
 func _ready() -> void:
 	if not editing_enabled:
 		line_edit.editable = false
+		line_edit.gui_input.connect(_on_line_edit_gui_input)
 	line_edit.text_changed.connect(_on_text_changed)
 	line_edit.text_submitted.connect(_on_text_submitted)
 	_sync_line_edit()
@@ -36,6 +39,16 @@ func _ready() -> void:
 				HORIZONTAL_ALIGNMENT_LEFT, -1, line_edit.get_theme_font_size("font_size")).x),
 				max_width)
 	line_edit.size.x = max_width + 4
+
+func _on_line_edit_gui_input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		if event.pressed:
+			tap_start_time = Time.get_ticks_msec()
+		else:
+			var tap_duration := Time.get_ticks_msec() - tap_start_time
+			if tap_duration <= 200:
+				line_edit.release_focus()
+				_on_button_pressed()
 
 func _on_button_pressed() -> void:
 	var btn_arr: Array[Button] = []


### PR DESCRIPTION
If internal `line_edit` is disabled, clicking on it would open dropdown menu.