### PR TITLE
Move Highlighter Preset preset picker in its category

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -287,14 +287,14 @@ const CURRENT_VERSION = 1
 			emit_changed()
 			Configs.highlighting_colors_changed.emit()
 
-@export var highlighting_comment_color := Color("cdcfd280"):
+@export var highlighting_comment_color := Color("d4d6d980"):
 	set(new_value):
 		if highlighting_comment_color != new_value:
 			highlighting_comment_color = new_value
 			emit_changed()
 			Configs.highlighting_colors_changed.emit()
 
-@export var highlighting_text_color := Color("cdcfeaac"):
+@export var highlighting_text_color := Color("d5d7f2aa"):
 	set(new_value):
 		if highlighting_text_color != new_value:
 			highlighting_text_color = new_value
@@ -308,7 +308,7 @@ const CURRENT_VERSION = 1
 			emit_changed()
 			Configs.highlighting_colors_changed.emit()
 
-@export var highlighting_error_color := Color("ff866b"):
+@export var highlighting_error_color := Color("f55"):
 	set(new_value):
 		if highlighting_error_color != new_value:
 			highlighting_error_color = new_value
@@ -445,14 +445,14 @@ const MAX_SELECTION_RECTANGLE_DASH_LENGTH = 600.0
 			emit_changed()
 			Configs.selection_rectangle_visuals_changed.emit()
 
-@export var canvas_color := Color(0.12, 0.132, 0.2, 1):
+@export var canvas_color := Color("1f2233"):
 	set(new_value):
 		if canvas_color != new_value:
 			canvas_color = new_value
 			emit_changed()
 			external_call(Configs.sync_canvas_color)
 
-@export var grid_color := Color(0.5, 0.5, 0.5):
+@export var grid_color := Color("808080"):
 	set(new_value):
 		if grid_color != new_value:
 			grid_color = new_value

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -170,13 +170,13 @@ func setup_content(reset_scroll := true) -> void:
 			current_setup_setting = "accent_color"
 			add_color_edit(Translator.translate("Accent color"), false)
 			
+			add_section(Translator.translate("SVG Text colors"))
 			current_setup_setting = "highlighter_preset"
 			add_profile_picker(Translator.translate("Highlighter preset"),
 					current_setup_resource.reset_highlighting_items_to_default,
 					SaveData.HighlighterPreset.size(),
 					SaveData.get_highlighter_preset_value_text_map(),
 					current_setup_resource.is_highlighting_default)
-			add_section(Translator.translate("SVG Text colors"))
 			current_setup_setting = "highlighting_symbol_color"
 			add_color_edit(Translator.translate("Symbol color"))
 			current_setup_setting = "highlighting_element_color"
@@ -376,7 +376,7 @@ value_text_map: Dictionary, disabled_check_callback: Callable) -> void:
 	frame.value_changed.connect.call_deferred(setup_content.bind(false))
 	frame.defaults_applied.connect(application_callback)
 	frame.defaults_applied.connect(setup_content.bind(false))
-	setting_container.add_child(frame)
+	add_frame(frame)
 	
 	resource_permanent_ref.changed_deferred.connect(frame.button_update_disabled)
 	frame.tree_exited.connect(resource_permanent_ref.changed_deferred.disconnect.bind(
@@ -433,7 +433,10 @@ func setup_frame(frame: Control) -> void:
 	frame.mouse_exited.connect(hide_advice.bind(current_setup_setting))
 
 func add_frame(frame: Control) -> void:
-	setting_container.get_child(-1).add_child(frame)
+	if setting_container.get_child_count() > 0:
+		setting_container.get_child(-1).add_child(frame)
+	else:
+		setting_container.add_child(frame)
 
 func add_advice(text: String) -> void:
 	advice[current_setup_setting] = text

--- a/src/ui_widgets/profile_frame.gd
+++ b/src/ui_widgets/profile_frame.gd
@@ -27,7 +27,8 @@ func setup_dropdown(values: Array, value_text_map: Dictionary) -> void:
 	dropdown.value_text_map = value_text_map
 
 func _ready() -> void:
-	button.text = Translator.translate("Apply defaults")
+	button.text = Translator.translate("Apply")
+	button.tooltip_text = Translator.translate("Apply all of this preset's defaults")
 	control.add_child(dropdown)
 	dropdown.value_changed.connect(_dropdown_modification)
 	mouse_entered.connect(_on_mouse_entered)

--- a/src/ui_widgets/profile_frame.tscn
+++ b/src/ui_widgets/profile_frame.tscn
@@ -19,7 +19,7 @@ layout_mode = 2
 [node name="Control" type="Control" parent="HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-size_flags_stretch_ratio = 1.5
+size_flags_stretch_ratio = 3.0
 mouse_filter = 2
 
 [node name="Button" type="Button" parent="HBoxContainer"]


### PR DESCRIPTION
Fixes some settings' defaults. Allows for profile pickers to be defined inside sections. Tweaks the design of the widget a little bit to make it more spacious and prone to less localization bottlenecks.