### PR TITLE
Settings menu rework pt. 1

### DIFF
--- a/src/autoload/Configs.gd
+++ b/src/autoload/Configs.gd
@@ -73,19 +73,6 @@ func post_load() -> void:
 	sync_theme()
 
 
-func generate_highlighter() -> SVGHighlighter:
-	var new_highlighter := SVGHighlighter.new()
-	new_highlighter.symbol_color = Configs.savedata.highlighting_symbol_color
-	new_highlighter.element_color = Configs.savedata.highlighting_element_color
-	new_highlighter.attribute_color = Configs.savedata.highlighting_attribute_color
-	new_highlighter.string_color = Configs.savedata.highlighting_string_color
-	new_highlighter.comment_color = Configs.savedata.highlighting_comment_color
-	new_highlighter.text_color = Configs.savedata.highlighting_text_color
-	new_highlighter.cdata_color = Configs.savedata.highlighting_cdata_color
-	new_highlighter.error_color = Configs.savedata.highlighting_error_color
-	return new_highlighter
-
-
 # Global effects from settings. Some of them should also be used on launch.
 
 func sync_canvas_color() -> void:

--- a/src/config_classes/SVGHighlighter.gd
+++ b/src/config_classes/SVGHighlighter.gd
@@ -20,6 +20,16 @@ var attribute_color := Color("bce0ff"):
 		unrecognized_attribute_color = Color(new_value, new_value.a * 0.7)
 
 
+func _init() -> void:
+	symbol_color = Configs.savedata.highlighting_symbol_color
+	element_color = Configs.savedata.highlighting_element_color
+	attribute_color = Configs.savedata.highlighting_attribute_color
+	string_color = Configs.savedata.highlighting_string_color
+	comment_color = Configs.savedata.highlighting_comment_color
+	text_color = Configs.savedata.highlighting_text_color
+	cdata_color = Configs.savedata.highlighting_cdata_color
+	error_color = Configs.savedata.highlighting_error_color
+
 func _get_line_syntax_highlighting(line: int) -> Dictionary:
 	var svg_text := get_text_edit().get_line(line)
 	if svg_text.is_empty():

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -19,8 +19,8 @@ func get_setting_default(setting: String) -> Variant:
 				ThemePreset.BLACK: return Color("000")
 		"accent_color":
 			match theme_preset:
-				ThemePreset.DARK: return Color("668cff")
-				ThemePreset.LIGHT: return Color("0830a6ff")
+				ThemePreset.DARK: return Color("6191f2")
+				ThemePreset.LIGHT: return Color("0830a6")
 				ThemePreset.BLACK: return Color("7c8dbf")
 		"highlighter_preset":
 			match theme_preset:
@@ -110,9 +110,11 @@ func reset_to_default() -> void:
 		set(setting, get_setting_default(setting))
 
 func reset_theme_items_to_default() -> void:
+	var old_highlighter_preset_value := highlighter_preset
 	for setting in theme_items:
 		set(setting, get_setting_default(setting))
-	reset_highlighting_items_to_default()
+	if old_highlighter_preset_value != highlighter_preset:
+		reset_highlighting_items_to_default()
 
 func reset_highlighting_items_to_default() -> void:
 	for setting in highlighting_items:
@@ -242,7 +244,7 @@ const CURRENT_VERSION = 1
 			emit_changed()
 			external_call(Configs.sync_theme)
 
-@export var accent_color := Color("668cff"):
+@export var accent_color := Color("6191f2"):
 	set(new_value):
 		if accent_color != new_value:
 			accent_color = new_value

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -116,4 +116,4 @@ func _on_options_button_pressed() -> void:
 
 func update_syntax_highlighter() -> void:
 	if is_instance_valid(code_edit):
-		code_edit.syntax_highlighter = Configs.generate_highlighter()
+		code_edit.syntax_highlighter = SVGHighlighter.new()

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -16,13 +16,23 @@ const reset_icon = preload("res://assets/icons/Reload.svg")
 @onready var tabs: VBoxContainer = %Tabs
 @onready var close_button: Button = $VBoxContainer/CloseButton
 @onready var advice_panel: PanelContainer = $VBoxContainer/AdvicePanel
-@onready var advice_label: Label = $VBoxContainer/AdvicePanel/AdviceLabel
 
 var focused_tab := ""
 var current_setup_setting := ""
 var current_setup_resource: ConfigResource
 var setting_container: VBoxContainer
-var advice: Dictionary[String, String] = {}
+
+class SettingTextShowcase:
+	var text: String
+	func _init(new_text: String) -> void:
+		text = new_text
+
+class SettingCodeShowcase:
+	var text: String
+	func _init(new_text: String) -> void:
+		text = new_text
+
+var advice: Dictionary[String, RefCounted] = {}
 
 func _ready() -> void:
 	close_button.pressed.connect(queue_free)
@@ -96,7 +106,7 @@ func setup_content(reset_scroll := true) -> void:
 	
 	match focused_tab:
 		"formatting":
-			advice_panel.hide()
+			advice_panel.show()
 			var vbox := VBoxContainer.new()
 			vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 			vbox.add_theme_constant_override("separation", 6)
@@ -152,7 +162,7 @@ func setup_content(reset_scroll := true) -> void:
 			categories.get_child(0).button_pressed = true
 			categories.get_child(0).pressed.emit()
 		"theming":
-			advice_panel.hide()
+			advice_panel.show()
 			create_setting_container()
 			content_container.add_child(setting_container)
 			
@@ -163,6 +173,8 @@ func setup_content(reset_scroll := true) -> void:
 					current_setup_resource.reset_theme_items_to_default,
 					SaveData.ThemePreset.size(), SaveData.get_theme_preset_value_text_map(),
 					current_setup_resource.is_theming_default)
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Determines the default values of theming-related settings, including the highlighter preset.")))
 			
 			add_section(Translator.translate("Primary theme colors"))
 			current_setup_setting = "base_color"
@@ -177,22 +189,40 @@ func setup_content(reset_scroll := true) -> void:
 					SaveData.HighlighterPreset.size(),
 					SaveData.get_highlighter_preset_value_text_map(),
 					current_setup_resource.is_highlighting_default)
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Determines the default values of SVG highlighter settings.")))
 			current_setup_setting = "highlighting_symbol_color"
 			add_color_edit(Translator.translate("Symbol color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<circle cx="6" cy="8" r="4" fill="gold" />"""))
 			current_setup_setting = "highlighting_element_color"
 			add_color_edit(Translator.translate("Element color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<circle cx="6" cy="8" r="4" fill="gold" />"""))
 			current_setup_setting = "highlighting_attribute_color"
 			add_color_edit(Translator.translate("Attribute color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<circle cx="6" cy="8" r="4" fill="gold" />"""))
 			current_setup_setting = "highlighting_string_color"
 			add_color_edit(Translator.translate("String color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<circle cx="6" cy="8" r="4" fill="gold" />"""))
 			current_setup_setting = "highlighting_comment_color"
 			add_color_edit(Translator.translate("Comment color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<!-- Comment --> <text> Basic text <![CDATA[ < > & " ' ]]> </text>"""))
 			current_setup_setting = "highlighting_text_color"
 			add_color_edit(Translator.translate("Text color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<!-- Comment --> <text> Basic text <![CDATA[ < > & " ' ]]> </text>"""))
 			current_setup_setting = "highlighting_cdata_color"
 			add_color_edit(Translator.translate("CDATA color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<!-- Comment --> <text> Basic text <![CDATA[ < > & " ' ]]> </text>"""))
 			current_setup_setting = "highlighting_error_color"
 			add_color_edit(Translator.translate("Error color"))
+			add_advice(SettingCodeShowcase.new(
+					"""<circle cx="6" cy="8" ==syntax error"""))
 			
 			add_section(Translator.translate("Handles"))
 			current_setup_setting = "handle_size"
@@ -249,7 +279,8 @@ func setup_content(reset_scroll := true) -> void:
 			add_section(Translator.translate("Input"))
 			current_setup_setting = "tab_mmb_close"
 			add_checkbox(Translator.translate("Close tabs with middle mouse button"))
-			add_advice(Translator.translate("If turned on, clicking on a tab with the middle mouse button closes the tab. If turned off, it focuses the tab instead."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("If turned on, clicking on a tab with the middle mouse button closes the tab. If turned off, it focuses the tab instead.")))
 		"other":
 			advice_panel.show()
 			create_setting_container()
@@ -259,13 +290,16 @@ func setup_content(reset_scroll := true) -> void:
 			add_section(Translator.translate("Input"))
 			current_setup_setting = "invert_zoom"
 			add_checkbox(Translator.translate("Invert zoom direction"))
-			add_advice(Translator.translate("Swaps the scroll directions for zooming in and zooming out."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Swaps the scroll directions for zooming in and zooming out.")))
 			current_setup_setting = "wraparound_panning"
 			var wraparound_panning := add_checkbox(Translator.translate("Wrap-around panning"))
-			add_advice(Translator.translate("Warps the cursor to the opposite side whenever it reaches a viewport boundary while panning."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Warps the cursor to the opposite side whenever it reaches a viewport boundary while panning.")))
 			current_setup_setting = "use_ctrl_for_zoom"
 			add_checkbox(Translator.translate("Use CTRL for zooming"))
-			add_advice(Translator.translate("If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("If turned on, scrolling pans the view. To zoom, hold CTRL while scrolling.")))
 			
 			add_section(Translator.translate("Display"))
 			# Prepare parameters for the UI scale setting.
@@ -309,23 +343,28 @@ func setup_content(reset_scroll := true) -> void:
 			
 			current_setup_setting = "ui_scale"
 			add_dropdown(Translator.translate("UI scale"), dropdown_values, dropdown_map)
-			add_advice(Translator.translate("Determines the scale factor for the interface."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Determines the scale factor for the interface.")))
 			
 			current_setup_setting = "vsync"
 			add_checkbox(Translator.translate("V-Sync"))
-			add_advice(Translator.translate("Synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. May increase input lag slightly."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. May increase input lag slightly.")))
 			
 			current_setup_setting = "max_fps"
 			add_fps_limit_dropdown(Translator.translate("Maximum FPS"))
-			add_advice(Translator.translate("Determines the maximum number of frames per second."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("Determines the maximum number of frames per second.")))
 			
 			add_section(Translator.translate("Miscellaneous"))
 			current_setup_setting = "use_native_file_dialog"
 			var use_native_file_dialog := add_checkbox(Translator.translate("Use native file dialog"))
-			add_advice(Translator.translate("If turned on, uses your operating system's native file dialog. If turned off, uses GodSVG's built-in file dialog."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("If turned on, uses your operating system's native file dialog. If turned off, uses GodSVG's built-in file dialog.")))
 			current_setup_setting = "use_filename_for_window_title"
 			add_checkbox(Translator.translate("Sync window title to file name"))
-			add_advice(Translator.translate("If turned off, the window title remains as \"GodSVG\" without including the current file."))
+			add_advice(SettingTextShowcase.new(
+					Translator.translate("If turned off, the window title remains as \"GodSVG\" without including the current file.")))
 			
 			# Disable mouse wrap if not available.
 			if not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE_WARP):
@@ -362,6 +401,8 @@ value_text_map: Dictionary, disabled_check_callback: Callable) -> void:
 	var resource_permanent_ref := current_setup_resource
 	frame.setter = func(p: Variant) -> void:
 			resource_permanent_ref.set(bind, p)
+	frame.mouse_entered.connect(show_advice.bind(current_setup_setting))
+	frame.mouse_exited.connect(hide_advice.bind(current_setup_setting))
 	frame.text = text
 	frame.disabled_check_callback = disabled_check_callback
 	frame.value_changed.connect.call_deferred(setup_content.bind(false))
@@ -438,22 +479,54 @@ func add_frame(frame: Control) -> void:
 	else:
 		setting_container.add_child(frame)
 
-func add_advice(text: String) -> void:
-	advice[current_setup_setting] = text
 
+func add_advice(showcase: RefCounted) -> void:
+	advice[current_setup_setting] = showcase
 
 func show_advice(setting: String) -> void:
 	if advice.has(setting):
-		advice_label.text = advice[setting]
-		advice_label.remove_theme_font_size_override("font_size")
-		var advice_font_size := get_theme_font_size("font_size", "Label")
-		while advice_label.get_line_count() > 2:
-			advice_font_size -= 1
-			advice_label.add_theme_font_size_override("font_size", advice_font_size)
+		var showcase := advice[setting]
+		if showcase is SettingTextShowcase:
+			var margin_container := MarginContainer.new()
+			margin_container.add_theme_constant_override("margin_left", 6)
+			margin_container.add_theme_constant_override("margin_right", 6)
+			margin_container.add_theme_constant_override("margin_top", 2)
+			margin_container.add_theme_constant_override("margin_bottom", 4)
+			var label := Label.new()
+			label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+			label.size_flags_vertical = Control.SIZE_EXPAND_FILL
+			label.add_theme_constant_override("line_spacing", 2)
+			label.text = showcase.text
+			var advice_font_size := get_theme_font_size("font_size", "Label")
+			while label.get_line_count() > 2:
+				advice_font_size -= 1
+				label.add_theme_font_size_override("font_size", advice_font_size)
+			margin_container.add_child(label)
+			advice_panel.add_child(margin_container)
+		elif showcase is SettingCodeShowcase:
+			var code_preview := TextEdit.new()
+			code_preview.editable = false
+			var update_highlighter := func() -> void:
+					code_preview.syntax_highlighter = SVGHighlighter.new()
+			code_preview.add_theme_color_override("font_readonly_color", Color.WHITE)
+			
+			var text_edit_default_stylebox := code_preview.get_theme_stylebox("normal")
+			var empty_stylebox := StyleBoxEmpty.new()
+			empty_stylebox.content_margin_left = text_edit_default_stylebox.content_margin_left
+			empty_stylebox.content_margin_right = text_edit_default_stylebox.content_margin_right
+			empty_stylebox.content_margin_top = text_edit_default_stylebox.content_margin_top
+			empty_stylebox.content_margin_bottom = text_edit_default_stylebox.content_margin_bottom
+			code_preview.add_theme_stylebox_override("normal", empty_stylebox)
+			code_preview.add_theme_stylebox_override("read_only", empty_stylebox)
+			code_preview.text = showcase.text
+			Configs.highlighting_colors_changed.connect(update_highlighter)
+			update_highlighter.call()
+			advice_panel.add_child(code_preview)
 
 func hide_advice(setting: String) -> void:
-	if advice.has(setting) and advice_label.text == advice[setting]:
-		advice_label.text = ""
+	if advice.has(setting):
+		for child in advice_panel.get_children():
+			child.hide()
 
 
 func _on_language_pressed() -> void:
@@ -595,6 +668,8 @@ func show_formatter(category: String) -> void:
 	add_profile_picker(Translator.translate("Preset"),
 			current_setup_resource.reset_to_default, Formatter.Preset.size(),
 			Formatter.get_preset_value_text_map(), current_setup_resource.is_everything_default)
+	add_advice(SettingTextShowcase.new(
+					Translator.translate("Determines the default values of the formatter configs.")))
 	
 	add_section("XML")
 	current_setup_setting = "xml_keep_comments"

--- a/src/ui_parts/settings_menu.tscn
+++ b/src/ui_parts/settings_menu.tscn
@@ -66,15 +66,9 @@ theme_override_constants/margin_right = 2
 theme_override_constants/margin_bottom = 4
 
 [node name="AdvicePanel" type="PanelContainer" parent="VBoxContainer"]
-custom_minimum_size = Vector2(0, 45)
+custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 theme_type_variation = &"TextBox"
-
-[node name="AdviceLabel" type="Label" parent="VBoxContainer/AdvicePanel"]
-layout_mode = 2
-size_flags_vertical = 1
-theme_override_constants/line_spacing = 2
-autowrap_mode = 3
 
 [node name="CloseButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2

--- a/src/ui_widgets/BetterTextEdit.gd
+++ b/src/ui_widgets/BetterTextEdit.gd
@@ -60,8 +60,7 @@ func _redraw_caret() -> void:
 	if not has_focus():
 		return
 	
-	var char_size := ThemeUtils.mono_font.get_char_size(69,
-			get_theme_font_size("font_size"))
+	var char_size := ThemeUtils.mono_font.get_char_size(69, get_theme_font_size("font_size"))
 	for caret in get_caret_count():
 		var caret_pos := Vector2.ZERO
 		var caret_column := get_caret_column(caret)
@@ -79,11 +78,12 @@ func _redraw_caret() -> void:
 				var i := 0
 				while true:
 					var c := line[i]
-					if c != '\t' and c != ' ':
+					if c == ' ':
+						caret_pos.x += char_size.x
+					elif c == '\t':
+						caret_pos.x += char_size.x * get_tab_size()
+					else:
 						break
-					
-					caret_pos.x += ThemeUtils.mono_font.get_char_size(ord(c),
-							get_theme_font_size("font_size")).x
 					i += 1
 			# Workaround for ligatures.
 			if (caret_column >= line.length() or line[caret_column] != '\t') and\

--- a/src/ui_widgets/profile_frame.gd
+++ b/src/ui_widgets/profile_frame.gd
@@ -27,6 +27,8 @@ func setup_dropdown(values: Array, value_text_map: Dictionary) -> void:
 	dropdown.value_text_map = value_text_map
 
 func _ready() -> void:
+	Configs.theme_changed.connect(update_theme)
+	update_theme()
 	button.text = Translator.translate("Apply")
 	button.tooltip_text = Translator.translate("Apply all of this preset's defaults")
 	control.add_child(dropdown)
@@ -40,6 +42,14 @@ func _ready() -> void:
 	control.resized.connect(setup_size.call_deferred)
 	setup_size.call_deferred()
 
+func update_theme() -> void:
+	const CONST_ARR: PackedStringArray = ["normal", "hover", "pressed", "disabled"]
+	for theme_style in CONST_ARR:
+		var theme_sb := get_theme_stylebox(theme_style, "TranslucentButton").duplicate()
+		theme_sb.content_margin_top -= 1
+		theme_sb.content_margin_bottom -= 1
+		button.add_theme_stylebox_override(theme_style, theme_sb)
+
 func button_update_disabled() -> void:
 	var should_disable: bool = disabled_check_callback.call()
 	button.disabled = should_disable
@@ -47,7 +57,7 @@ func button_update_disabled() -> void:
 			Control.CURSOR_POINTING_HAND
 
 func setup_size() -> void:
-	dropdown.position = Vector2(control.size.x - 102, 2)
+	dropdown.position = Vector2(control.size.x - 102, 1)
 	dropdown.size = Vector2(98, 22)
 	queue_redraw()
 
@@ -69,5 +79,5 @@ func _on_mouse_exited() -> void:
 func _draw() -> void:
 	if is_hovered:
 		get_theme_stylebox("hover", "FlatButton").draw(ci, Rect2(Vector2.ZERO, size))
-	ThemeUtils.regular_font.draw_string(ci, Vector2(4, 20), text,
+	ThemeUtils.regular_font.draw_string(ci, Vector2(4, 19), text,
 			HORIZONTAL_ALIGNMENT_LEFT, -1, 13, ThemeUtils.text_color)

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -293,10 +293,6 @@ static func _setup_panelcontainer(theme: Theme) -> void:
 	var textbox_stylebox := StyleBoxFlat.new()
 	textbox_stylebox.set_corner_radius_all(2)
 	textbox_stylebox.set_border_width_all(2)
-	textbox_stylebox.content_margin_left = 6.0
-	textbox_stylebox.content_margin_right = 6.0
-	textbox_stylebox.content_margin_top = 2.0
-	textbox_stylebox.content_margin_bottom = 4.0
 	textbox_stylebox.bg_color = overlay_panel_inner_color.lerp(extreme_theme_color, 0.2)
 	textbox_stylebox.border_color = subtle_panel_border_color
 	theme.set_stylebox("panel", "TextBox", textbox_stylebox)
@@ -1200,6 +1196,7 @@ static func _setup_textedit(theme: Theme) -> void:
 	theme.add_type("TextEdit")
 	theme.set_color("caret_color", "TextEdit", Color.TRANSPARENT)
 	theme.set_color("selection_color", "TextEdit", selection_color)
+	theme.set_constant("line_spacing", "TextEdit", 3)
 	theme.set_font_size("font_size", "TextEdit", 12)
 	theme.set_font("font", "TextEdit", mono_font)
 	
@@ -1208,8 +1205,9 @@ static func _setup_textedit(theme: Theme) -> void:
 	normal_stylebox.border_color = line_edit_normal_border_color
 	normal_stylebox.set_border_width_all(2)
 	normal_stylebox.set_corner_radius_all(5)
-	normal_stylebox.content_margin_left = 5.0
+	normal_stylebox.content_margin_left = 6.0
 	theme.set_stylebox("normal", "TextEdit", normal_stylebox)
+	theme.set_stylebox("read_only", "TextEdit", normal_stylebox)
 	
 	var focus_stylebox := StyleBoxFlat.new()
 	focus_stylebox.draw_center = false

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -470,6 +470,10 @@ msgid "Theme preset"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -487,6 +491,10 @@ msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -705,6 +713,10 @@ msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of the formatter configs."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -471,6 +471,10 @@ msgid "Theme preset"
 msgstr "Шаблон на тема"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr "Определя стойностите по подразбиране на гамовите настройки, включително шаблона на синтаксовото маркиране."
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr "Основни цветове на темата"
 
@@ -489,6 +493,10 @@ msgstr "Цветове на SVG текста"
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
 msgstr "Шаблон на синтаксово маркиране"
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
+msgstr "Определя стойностите по подразбиране на синтаксовото маркиране за SVG текста."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Symbol color"
@@ -707,6 +715,10 @@ msgstr "Помощ"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Шаблон"
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of the formatter configs."
+msgstr "Определя стойностите по подразбиране на настройките на форматировача."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/de.po
+++ b/translations/de.po
@@ -473,6 +473,10 @@ msgid "Theme preset"
 msgstr "Zoom zurücksetzen"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Primary theme colors"
 msgstr "Farbe deaktivieren"
@@ -493,6 +497,10 @@ msgstr "SVG Textfarben"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -717,6 +725,11 @@ msgstr "Hilfe"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Voreinstellung"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Verändert den Skalierungsfaktor der Benutzeroberfläche."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/en.po
+++ b/translations/en.po
@@ -471,6 +471,10 @@ msgid "Theme preset"
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -488,6 +492,10 @@ msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -706,6 +714,10 @@ msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of the formatter configs."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:

--- a/translations/es.po
+++ b/translations/es.po
@@ -473,6 +473,10 @@ msgid "Theme preset"
 msgstr "Reestablecer el zoom"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -492,6 +496,10 @@ msgstr "Colores del texto de los SVG"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -717,6 +725,11 @@ msgstr "Ayuda"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Preajuste"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Si la velocidad de fotogramas está limitada, este valor determina la cantidad máxima de fotogramas por segundo."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/et.po
+++ b/translations/et.po
@@ -473,6 +473,10 @@ msgid "Theme preset"
 msgstr "Taasta suurendus"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -492,6 +496,10 @@ msgstr "SVG teksti värvid"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -716,6 +724,11 @@ msgstr "Abi"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Eelseadistus"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Muudab kasutajaliidese suurust."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -473,6 +473,10 @@ msgid "Theme preset"
 msgstr "Réinitialiser le zoom"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Primary theme colors"
 msgstr "Désactiver la couleur"
@@ -493,6 +497,10 @@ msgstr "Couleurs de texte SVG"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -718,6 +726,11 @@ msgstr "Aide"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Préréglage"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Si le taux de rafraîchissement est limité, cette valeur déterminera le nombre maximum d'images par seconde."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -475,6 +475,10 @@ msgid "Theme preset"
 msgstr "Zoom resetten"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Primary theme colors"
 msgstr "De kleur uitzetten"
@@ -495,6 +499,10 @@ msgstr "SVG tekstkleuren"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -722,6 +730,11 @@ msgstr "Help"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Voorinstelling"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Verandert het maat-factor van de gebruikersinterface."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -474,6 +474,10 @@ msgid "Theme preset"
 msgstr "Redefinir zoom"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -493,6 +497,10 @@ msgstr "Cores de texto SVG"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -717,6 +725,11 @@ msgstr "Ajuda"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Predefinição"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Muda o fator de escala da interfaçe."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -474,6 +474,10 @@ msgid "Theme preset"
 msgstr "Сбросить масштаб"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -493,6 +497,10 @@ msgstr "Цвет SVG текста"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -717,6 +725,11 @@ msgstr "Помощь"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Пресет"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Изменить масштаб пользовательского интерфейса."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -473,6 +473,10 @@ msgid "Theme preset"
 msgstr "Скинути масштаб"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 msgid "Primary theme colors"
 msgstr ""
 
@@ -492,6 +496,10 @@ msgstr "Колір SVG тексту"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -717,6 +725,11 @@ msgstr "Допомога"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "Пресет"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "Змінити масштаб інтерфейсу користувача."
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -480,6 +480,10 @@ msgid "Theme preset"
 msgstr "重置缩放"
 
 #: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
 #, fuzzy
 msgid "Primary theme colors"
 msgstr "禁用该颜色"
@@ -500,6 +504,10 @@ msgstr "SVG 文本颜色"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Highlighter preset"
+msgstr ""
+
+#: src/ui_parts/settings_menu.gd:
+msgid "Determines the default values of SVG highlighter settings."
 msgstr ""
 
 #: src/ui_parts/settings_menu.gd:
@@ -729,6 +737,11 @@ msgstr "帮助"
 #: src/ui_parts/settings_menu.gd:
 msgid "Preset"
 msgstr "预设"
+
+#: src/ui_parts/settings_menu.gd:
+#, fuzzy
+msgid "Determines the default values of the formatter configs."
+msgstr "改变用户界面的缩放尺寸。"
 
 #: src/ui_parts/settings_menu.gd:
 msgid "Keep comments"


### PR DESCRIPTION
Fixes some unrelated small regressions, straightens some weird code, reworks settings menu to have more types of previews. For now just a rough implementation of regular old text and code text with highlighting.