### PR TITLE
Allow tab navigation throughout the application

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -39,7 +39,6 @@ HandlerGUI="*res://src/autoload/HandlerGUI.gd"
 window/size/viewport_width=1040
 window/size/viewport_height=650
 window/size/mode=2
-window/energy_saving/keep_screen_on=false
 mouse_cursor/tooltip_position_offset=Vector2(0, 10)
 
 [editor_overrides]

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -527,7 +527,7 @@ const MAX_FPS_MAX = 600
 			emit_changed()
 			external_call(Configs.sync_max_fps)
 
-@export var keep_screen_on := true:
+@export var keep_screen_on := false:
 	set(new_value):
 		if keep_screen_on != new_value:
 			keep_screen_on = new_value

--- a/src/ui_parts/about_menu.gd
+++ b/src/ui_parts/about_menu.gd
@@ -29,6 +29,13 @@ func _ready() -> void:
 	tab_container.tab_changed.connect(_on_tab_changed)
 	_on_tab_changed(0)
 
+func _unhandled_input(event: InputEvent) -> void:
+	var tab_count := tab_container.get_tab_count()
+	if ShortcutUtils.is_action_pressed(event, "select_next_tab"):
+		tab_container.current_tab = (tab_container.current_tab + 1) % tab_count
+	elif ShortcutUtils.is_action_pressed(event, "select_previous_tab"):
+		tab_container.current_tab = (tab_container.current_tab + tab_count - 1) % tab_count
+
 func _on_tab_changed(idx: int) -> void:
 	match idx:
 		0:

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -65,9 +65,25 @@ func _ready() -> void:
 	update_language_button()
 	update_close_button()
 	setup_tabs()
-	tabs.get_child(0).button_pressed = true
+	press_tab(0)
 	Configs.theme_changed.connect(update_theme)
 	update_theme()
+
+func _unhandled_input(event: InputEvent) -> void:
+	var tab_count := tabs.get_child_count()
+	var focused_tab_idx: int
+	for i in tab_count:
+		if tabs.get_child(i).button_pressed:
+			focused_tab_idx = i
+			break
+	
+	if ShortcutUtils.is_action_pressed(event, "select_next_tab"):
+		press_tab((focused_tab_idx + 1) % tab_count)
+	elif ShortcutUtils.is_action_pressed(event, "select_previous_tab"):
+		press_tab((focused_tab_idx + tab_count - 1) % tab_count)
+
+func press_tab(index: int) -> void:
+	tabs.get_child(index).button_pressed = true
 
 func update_theme() -> void:
 	var stylebox := ThemeDB.get_default_theme().get_stylebox("panel", theme_type_variation).duplicate()
@@ -405,7 +421,6 @@ func setup_content(reset_scroll := true) -> void:
 				use_native_file_dialog.permanent_disable_checkbox(true)
 			elif use_native_file_dialog_forced_off:
 				use_native_file_dialog.permanent_disable_checkbox(false)
-			
 			
 			current_setup_setting = "use_filename_for_window_title"
 			add_checkbox(Translator.translate("Sync window title to file name"))

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -174,8 +174,8 @@ static func recalculate_colors() -> void:
 	context_icon_hover_color = tinted_contrast_color
 	context_icon_pressed_color = max_contrast_color
 	
-	translucent_button_color_disabled = Color(disabled_color.lerp(extreme_theme_color, 0.4), 0.16)
-	flat_button_color_disabled = Color(disabled_color.lerp(extreme_theme_color, 0.4), 0.12)
+	translucent_button_color_disabled = Color(disabled_color.lerp(extreme_theme_color, 0.4), 0.24)
+	flat_button_color_disabled = Color(disabled_color.lerp(extreme_theme_color, 0.4), 0.18)
 	
 	subtle_flat_panel_color = base_color
 	contrast_flat_panel_color = Color(tinted_contrast_color, 0.1)
@@ -547,8 +547,8 @@ static func _setup_button(theme: Theme) -> void:
 	theme.add_type("TranslucentButton")
 	theme.set_type_variation("TranslucentButton", "Button")
 	theme.set_color("icon_normal_color", "TranslucentButton", context_icon_normal_color)
-	theme.set_color("icon_hover_color", "TranslucentButton", context_icon_normal_color)
-	theme.set_color("icon_pressed_color", "TranslucentButton", context_icon_normal_color)
+	theme.set_color("icon_hover_color", "TranslucentButton", context_icon_hover_color)
+	theme.set_color("icon_pressed_color", "TranslucentButton", context_icon_pressed_color)
 	
 	var normal_translucent_button_stylebox := StyleBoxFlat.new()
 	normal_translucent_button_stylebox.set_corner_radius_all(5)


### PR DESCRIPTION
These can now be used in the settings menu and the about menu, for consistent expectations throughout the application. Also, keep_screen_on default was fixed and a few small theming tweaks were made.