### PR TITLE
Modular viewports (WIP, won't merge)

### DIFF
--- a/Canvas.gd
+++ b/Canvas.gd
@@ -1,0 +1,87 @@
+class_name Canvas extends SubViewportContainer
+
+var view_rasterized := false
+var show_grid := true
+var show_handles := true
+var show_reference := false
+var overlay_reference := false
+
+var camera_zoom: float
+var camera_position: Vector2
+var camera_unsnapped_position: Vector2
+
+signal zoom_changed
+
+func toggle_view_rasterized() -> void:
+	view_rasterized = not view_rasterized
+
+func toggle_show_grid() -> void:
+	show_grid = not show_grid
+
+func toggle_show_handles() -> void:
+	show_handles = not show_handles
+
+func toggle_show_reference() -> void:
+	show_reference = not show_reference
+
+func toggle_overlay_reference() -> void:
+	overlay_reference = not overlay_reference
+
+func set_zoom(new_value: float) -> void:
+	if camera_zoom != new_value:
+		camera_zoom = new_value
+		zoom_changed.emit()
+
+
+const GRID_TICKS_INTERVAL = 4
+const GRID_TICK_DISTANCE = float(GRID_TICKS_INTERVAL)
+
+var ci := get_canvas_item()
+var grid_ci := RenderingServer.canvas_item_create()
+var grid_numbers_ci := RenderingServer.canvas_item_create()
+var reference_image_ci := RenderingServer.canvas_item_create()
+
+var reference_texture: Texture2D
+
+
+func _ready() -> void:
+	var viewport := SubViewport.new()
+	add_child(viewport)
+	viewport.set_script(load("res://src/ui_parts/viewport.gd"))
+	viewport.size_2d_override_stretch = true
+	viewport.disable_3d = true
+	viewport.handle_input_locally = false
+	viewport.gui_snap_controls_to_pixels = false
+	
+	var reference_texture_rect := TextureRect.new()
+	reference_texture_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	reference_texture_rect.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	reference_texture_rect.visible = false
+	viewport.add_child(reference_texture_rect)
+	var checkerboard_texture_rect := TextureRect.new()
+	checkerboard_texture_rect.texture = load("res://assets/icons/backgrounds/Checkerboard.svg")
+	checkerboard_texture_rect.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	checkerboard_texture_rect.stretch_mode = TextureRect.STRETCH_TILE
+	checkerboard_texture_rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	var zoom_shader_material := ShaderMaterial.new()
+	zoom_shader_material.shader = load("res://src/shaders/zoom_shader.gdshader")
+	checkerboard_texture_rect.material = zoom_shader_material
+	viewport.add_child(checkerboard_texture_rect)
+	var display_texture_rect := TextureRect.new()
+	display_texture_rect.set_script(load("res://src/ui_parts/display_texture.gd"))
+	checkerboard_texture_rect.add_child(display_texture_rect)
+	var controls := Control.new()
+	controls.set_script(load("res://src/ui_parts/handles_manager.gd"))
+	viewport.add_child(controls)
+	
+	Configs.grid_color_changed.connect(queue_redraw)
+	update_show_grid()
+	RenderingServer.canvas_item_set_parent(grid_ci, ci)
+	RenderingServer.canvas_item_set_parent(grid_numbers_ci, ci)
+	State.svg_resized.connect(queue_redraw)
+	State.zoom_changed.connect(change_zoom)
+	State.zoom_changed.connect(queue_redraw)
+
+func exit_tree() -> void:
+	RenderingServer.free_rid(grid_ci)
+	RenderingServer.free_rid(grid_numbers_ci)

--- a/Canvas.gd.uid
+++ b/Canvas.gd.uid
@@ -1,0 +1,1 @@
+uid://8bxv5i60h8rb

--- a/ShortcutRegistrationArray.gd
+++ b/ShortcutRegistrationArray.gd
@@ -1,0 +1,20 @@
+class_name ShortcutRegistrationArray extends RefCounted
+
+var shortcuts := PackedStringArray()
+var actions: Array[Callable] = []
+var disabled_callbacks: Array[Callable] = []
+var check_toggle_callbacks: Array[Callable] = []
+
+func add_action_shortcut(new_shortcut: String, new_action: Callable,
+new_disabled_callback := Callable()) -> void:
+	shortcuts.append(new_shortcut)
+	actions.append(new_action)
+	disabled_callbacks.append(new_disabled_callback)
+	check_toggle_callbacks.append(Callable())
+
+func add_toggle_shortcut(new_shortcut: String, new_action: Callable,
+new_check_toggle_callback: Callable, new_disabled_callback := Callable()) -> void:
+	shortcuts.append(new_shortcut)
+	actions.append(new_action)
+	disabled_callbacks.append(new_disabled_callback)
+	check_toggle_callbacks.append(new_check_toggle_callback)

--- a/ShortcutRegistrationArray.gd.uid
+++ b/ShortcutRegistrationArray.gd.uid
@@ -1,0 +1,1 @@
+uid://clui25c28dteu

--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -14,6 +14,12 @@ const ShortcutPanelScene = preload("res://src/ui_parts/shortcut_panel.tscn")
 var menu_stack: Array[ColorRect]
 var popup_stack: Array[Control]
 
+var registered_shortcuts: Dictionary[Control, ShortcutRegistrationArray] = {}
+
+func register_shortcuts(control: Control, registrations: ShortcutRegistrationArray) -> void:
+	registered_shortcuts[control] = registrations
+	control.tree_exiting.connect(func() -> void: registered_shortcuts.erase(control))
+
 var shortcut_panel: PanelContainer
 
 func _enter_tree() -> void:

--- a/src/autoload/State.gd
+++ b/src/autoload/State.gd
@@ -230,18 +230,9 @@ func clear_proposed_drop_xid() -> void:
 		proposed_drop_changed.emit()
 
 
-signal zoom_changed
-@warning_ignore("unused_signal")
-signal view_changed
 signal viewport_size_changed
 
-var zoom := 0.0
 var viewport_size := Vector2i.ZERO
-
-func set_zoom(new_value: float) -> void:
-	if zoom != new_value:
-		zoom = new_value
-		zoom_changed.emit()
 
 func set_viewport_size(new_value: Vector2i) -> void:
 	if viewport_size != new_value:
@@ -249,39 +240,9 @@ func set_viewport_size(new_value: Vector2i) -> void:
 		viewport_size_changed.emit()
 
 
-var view_rasterized := false
-var show_grid := true
-var show_handles := true
-var show_reference := false
-var overlay_reference := false
 var show_debug := false
 
-signal view_rasterized_changed
-signal show_grid_changed
-signal show_handles_changed
-signal show_reference_changed
-signal overlay_reference_changed
 signal show_debug_changed
-
-func toggle_view_rasterized() -> void:
-	view_rasterized = not view_rasterized
-	view_rasterized_changed.emit()
-
-func toggle_show_grid() -> void:
-	show_grid = not show_grid
-	show_grid_changed.emit()
-
-func toggle_show_handles() -> void:
-	show_handles = not show_handles
-	show_handles_changed.emit()
-
-func toggle_show_reference() -> void:
-	show_reference = not show_reference
-	show_reference_changed.emit()
-
-func toggle_overlay_reference() -> void:
-	overlay_reference = not overlay_reference
-	overlay_reference_changed.emit()
 
 func toggle_show_debug() -> void:
 	show_debug = not show_debug

--- a/src/ui_parts/display.tscn
+++ b/src/ui_parts/display.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://bvrncl7e6yn5b"]
+[gd_scene load_steps=10 format=3 uid="uid://bvrncl7e6yn5b"]
 
 [ext_resource type="Script" uid="uid://bxmb134e3sqpr" path="res://src/ui_parts/display.gd" id="1_oib5g"]
 [ext_resource type="Texture2D" uid="uid://iglrqrqyg4kn" path="res://assets/icons/Reference.svg" id="4_2hiq7"]
@@ -7,17 +7,8 @@
 [ext_resource type="Script" uid="uid://ynx3s1jc6bwq" path="res://src/ui_widgets/BetterButton.gd" id="6_3v3ve"]
 [ext_resource type="PackedScene" uid="uid://dad7fkhmsooc6" path="res://src/ui_widgets/number_edit.tscn" id="7_wrrfr"]
 [ext_resource type="PackedScene" uid="uid://oltvrf01xrxl" path="res://src/ui_widgets/zoom_menu.tscn" id="8_xtdmn"]
-[ext_resource type="Script" uid="uid://b6pmlbnl76wmm" path="res://src/ui_parts/viewport.gd" id="9_4xrk7"]
 [ext_resource type="Script" uid="uid://rqrxhe8wa6fn" path="res://src/ui_parts/tab_bar.gd" id="9_rll1m"]
 [ext_resource type="Script" uid="uid://cbajqkgudfvh0" path="res://src/ui_parts/viewport_container.gd" id="9_ryr8t"]
-[ext_resource type="Shader" uid="uid://i2y5pyhcgra2" path="res://src/shaders/zoom_shader.gdshader" id="10_x7ybk"]
-[ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://assets/icons/backgrounds/Checkerboard.svg" id="11_1bm1s"]
-[ext_resource type="Script" uid="uid://dtplje5mhdmrj" path="res://src/ui_parts/display_texture.gd" id="12_qi23s"]
-[ext_resource type="Script" uid="uid://csqewpxr21ywy" path="res://src/ui_parts/handles_manager.gd" id="13_lwhwy"]
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_kqplg"]
-shader = ExtResource("10_x7ybk")
-shader_parameter/uv_scale = 1.0
 
 [node name="Display" type="VBoxContainer"]
 anchors_preset = 15
@@ -100,55 +91,13 @@ allow_lower = false
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="ViewportContainer" type="SubViewportContainer" parent="ViewportPanel/VBoxContainer"]
+[node name="Viewport" type="SubViewportContainer" parent="ViewportPanel/VBoxContainer"]
 clip_contents = true
 custom_minimum_size = Vector2(450, 0)
 layout_mode = 2
 size_flags_vertical = 3
 stretch = true
 script = ExtResource("9_ryr8t")
-
-[node name="Viewport" type="SubViewport" parent="ViewportPanel/VBoxContainer/ViewportContainer"]
-unique_name_in_owner = true
-disable_3d = true
-handle_input_locally = false
-gui_snap_controls_to_pixels = false
-size = Vector2i(1040, 595)
-size_2d_override_stretch = true
-render_target_update_mode = 4
-script = ExtResource("9_4xrk7")
-
-[node name="ReferenceTexture" type="TextureRect" parent="ViewportPanel/VBoxContainer/ViewportContainer/Viewport"]
-visible = false
-offset_right = 128.0
-offset_bottom = 128.0
-expand_mode = 1
-stretch_mode = 5
-
-[node name="Checkerboard" type="TextureRect" parent="ViewportPanel/VBoxContainer/ViewportContainer/Viewport"]
-texture_filter = 1
-material = SubResource("ShaderMaterial_kqplg")
-clip_contents = true
-texture = ExtResource("11_1bm1s")
-expand_mode = 1
-stretch_mode = 1
-
-[node name="DisplayTexture" type="TextureRect" parent="ViewportPanel/VBoxContainer/ViewportContainer/Viewport/Checkerboard"]
-clip_contents = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-expand_mode = 1
-script = ExtResource("12_qi23s")
-
-[node name="Controls" type="Control" parent="ViewportPanel/VBoxContainer/ViewportContainer/Viewport"]
-layout_mode = 3
-anchors_preset = 0
-mouse_filter = 1
-script = ExtResource("13_lwhwy")
 
 [node name="DebugMargins" type="MarginContainer" parent="ViewportPanel"]
 visible = false
@@ -187,6 +136,3 @@ horizontal_alignment = 2
 [connection signal="pressed" from="ViewportPanel/VBoxContainer/Toolbar/ViewportOptions/LeftMenu/Reference" to="." method="_on_reference_pressed"]
 [connection signal="toggled" from="ViewportPanel/VBoxContainer/Toolbar/ViewportOptions/LeftMenu/Snapping/SnapButton" to="." method="_on_snap_button_toggled"]
 [connection signal="value_changed" from="ViewportPanel/VBoxContainer/Toolbar/ViewportOptions/LeftMenu/Snapping/SnapNumberEdit" to="." method="_on_snap_number_edit_value_changed"]
-[connection signal="zoom_changed" from="ViewportPanel/VBoxContainer/Toolbar/ViewportOptions/ZoomMenu" to="ViewportPanel/VBoxContainer/ViewportContainer/Viewport" method="_on_zoom_changed"]
-[connection signal="zoom_reset_pressed" from="ViewportPanel/VBoxContainer/Toolbar/ViewportOptions/ZoomMenu" to="ViewportPanel/VBoxContainer/ViewportContainer/Viewport" method="center_frame"]
-[connection signal="size_changed" from="ViewportPanel/VBoxContainer/ViewportContainer/Viewport" to="ViewportPanel/VBoxContainer/ViewportContainer/Viewport" method="_on_size_changed"]

--- a/src/ui_parts/mac_menu.gd
+++ b/src/ui_parts/mac_menu.gd
@@ -1,216 +1,219 @@
 # The MacOS-specific top menu.
 extends Node
 
-var global_rid: RID
-var appl_rid: RID
-var help_rid: RID
+# TODO Bring back from the purgatory. This menu made it way harder to implement
+# viewport-related functionality.
 
-var file_rid: RID
-var file_idx: int
-var file_optimize_idx: int
-var file_reset_svg_idx: int
-
-var edit_rid: RID
-var edit_idx: int
-var tool_rid: RID
-var tool_idx: int
-
-var view_rid: RID
-var view_idx: int
-var view_show_grid_idx: int
-var view_show_handles_idx: int
-var view_rasterized_svg_idx: int
-var view_show_reference_idx: int
-var view_overlay_reference_idx: int
-var view_show_debug_idx: int
-
-var snap_rid: RID
-var snap_idx: int
-var snap_enable_idx: int
-var snap_0125_idx: int
-var snap_025_idx: int
-var snap_05_idx: int
-var snap_1_idx: int
-var snap_2_idx: int
-var snap_4_idx: int
-
-
-func _enter_tree() -> void:
-	# Included menus
-	global_rid = NativeMenu.get_system_menu(NativeMenu.MAIN_MENU_ID)
-	appl_rid = NativeMenu.get_system_menu(NativeMenu.APPLICATION_MENU_ID)
-	help_rid = NativeMenu.get_system_menu(NativeMenu.HELP_MENU_ID)
-	# Custom menus
-	_generate_main_menus()
-	_setup_menu_items()
-	# Updates
-	Configs.language_changed.connect(_reset_menus)
-	Configs.shortcuts_changed.connect(_reset_menus)
-	# For now only keep check items up to date. Disabling things reliably is complicated.
-	Configs.snap_changed.connect(_on_snap_changed)
-	State.view_rasterized_changed.connect(_on_view_rasterized_changed)
-	State.show_grid_changed.connect(_on_show_grid_changed)
-	State.show_handles_changed.connect(_on_show_handles_changed)
-	State.show_reference_changed.connect(_on_show_reference_changed)
-	State.overlay_reference_changed.connect(_on_overlay_reference_changed)
-	State.show_debug_changed.connect(_on_show_debug_changed)
-	# Updating checked items didn't work without the await.
-	await get_tree().process_frame
-	_on_snap_changed()
-	_on_view_rasterized_changed()
-	_on_show_grid_changed()
-	_on_show_handles_changed()
-	_on_show_reference_changed()
-	_on_overlay_reference_changed()
-	_on_show_debug_changed()
-
-
-func _reset_menus() -> void:
-	NativeMenu.remove_item(global_rid, snap_idx)
-	NativeMenu.remove_item(global_rid, view_idx)
-	NativeMenu.remove_item(global_rid, tool_idx)
-	NativeMenu.remove_item(global_rid, edit_idx)
-	NativeMenu.remove_item(global_rid, file_idx)
-	NativeMenu.free_menu(file_rid)
-	NativeMenu.free_menu(edit_rid)
-	NativeMenu.free_menu(tool_rid)
-	NativeMenu.free_menu(view_rid)
-	NativeMenu.free_menu(snap_rid)
-	_generate_main_menus()
-	_setup_menu_items()
-
-
-func _generate_main_menus() -> void:
-	file_rid = NativeMenu.create_menu()
-	edit_rid = NativeMenu.create_menu()
-	tool_rid = NativeMenu.create_menu()
-	view_rid = NativeMenu.create_menu()
-	snap_rid = NativeMenu.create_menu()
-	file_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("File"), file_rid)
-	edit_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Edit"), edit_rid)
-	tool_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Tool"), tool_rid)
-	view_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("View"), view_rid)
-	snap_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Snap"), snap_rid)
-
-
-func _clear_menu_items() -> void:
-	NativeMenu.clear(appl_rid)
-	NativeMenu.clear(help_rid)
-	NativeMenu.clear(file_rid)
-	NativeMenu.clear(edit_rid)
-	NativeMenu.clear(tool_rid)
-	NativeMenu.clear(view_rid)
-	NativeMenu.clear(snap_rid)
-
-
-func _setup_menu_items() -> void:
-	_clear_menu_items()
-	_add_item(appl_rid, "open_settings")
-	# Help menu.
-	_add_icon_item(help_rid, "open_settings")
-	_add_icon_item(help_rid, "about_repo")
-	_add_icon_item(help_rid, "about_info")
-	_add_icon_item(help_rid, "about_donate")
-	_add_icon_item(help_rid, "about_website")
-	_add_icon_item(help_rid, "check_updates")
-	# File menu.
-	_add_many_items(file_rid, PackedStringArray(["import", "export", "save", "save_as"]))
-	NativeMenu.add_separator(file_rid)
-	_add_item(file_rid, "copy_svg_text")
-	file_optimize_idx = _add_item(file_rid, "optimize")
-	NativeMenu.add_separator(file_rid)
-	file_reset_svg_idx = _add_item(file_rid, "reset_svg")
-	# Edit and Tool menus.
-	_add_many_items(edit_rid, ShortcutUtils.get_actions("edit"))
-	_add_many_items(tool_rid, ShortcutUtils.get_actions("tool"))
-	# View menu.
-	view_show_grid_idx = _add_check_item(view_rid, "view_show_grid")
-	view_show_handles_idx = _add_check_item(view_rid, "view_show_handles")
-	view_rasterized_svg_idx = _add_check_item(view_rid, "view_rasterized_svg")
-	NativeMenu.add_separator(view_rid)
-	view_show_reference_idx = _add_item(view_rid, "load_reference")
-	view_show_reference_idx = _add_check_item(view_rid, "view_show_reference")
-	view_overlay_reference_idx = _add_check_item(view_rid, "view_overlay_reference")
-	view_show_debug_idx = _add_check_item(view_rid, "view_show_debug")
-	NativeMenu.add_separator(view_rid)
-	_add_many_items(view_rid, PackedStringArray(["zoom_in", "zoom_out", "zoom_reset"]))
-	# Snap menu.
-	snap_enable_idx = _add_check_item(snap_rid, "toggle_snap")
-	NativeMenu.add_separator(snap_rid)
-	snap_0125_idx = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
-	snap_025_idx = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)
-	snap_05_idx = NativeMenu.add_radio_check_item(snap_rid, "0.5", _set_snap, _set_snap, 0.5)
-	snap_1_idx = NativeMenu.add_radio_check_item(snap_rid, "1", _set_snap, _set_snap, 1)
-	snap_2_idx = NativeMenu.add_radio_check_item(snap_rid, "2", _set_snap, _set_snap, 2)
-	snap_4_idx = NativeMenu.add_radio_check_item(snap_rid, "4", _set_snap, _set_snap, 4)
+#var global_rid: RID
+#var appl_rid: RID
+#var help_rid: RID
+#
+#var file_rid: RID
+#var file_idx: int
+#var file_optimize_idx: int
+#var file_reset_svg_idx: int
+#
+#var edit_rid: RID
+#var edit_idx: int
+#var tool_rid: RID
+#var tool_idx: int
+#
+#var view_rid: RID
+#var view_idx: int
+#var view_show_grid_idx: int
+#var view_show_handles_idx: int
+#var view_rasterized_svg_idx: int
+#var view_show_reference_idx: int
+#var view_overlay_reference_idx: int
+#var view_show_debug_idx: int
+#
+#var snap_rid: RID
+#var snap_idx: int
+#var snap_enable_idx: int
+#var snap_0125_idx: int
+#var snap_025_idx: int
+#var snap_05_idx: int
+#var snap_1_idx: int
+#var snap_2_idx: int
+#var snap_4_idx: int
+#
+#
+#func _enter_tree() -> void:
+	## Included menus
+	#global_rid = NativeMenu.get_system_menu(NativeMenu.MAIN_MENU_ID)
+	#appl_rid = NativeMenu.get_system_menu(NativeMenu.APPLICATION_MENU_ID)
+	#help_rid = NativeMenu.get_system_menu(NativeMenu.HELP_MENU_ID)
+	## Custom menus
+	#_generate_main_menus()
+	#_setup_menu_items()
+	## Updates
+	#Configs.language_changed.connect(_reset_menus)
+	#Configs.shortcuts_changed.connect(_reset_menus)
+	## For now only keep check items up to date. Disabling things reliably is complicated.
+	#Configs.snap_changed.connect(_on_snap_changed)
+	#State.view_rasterized_changed.connect(_on_view_rasterized_changed)
+	#State.show_grid_changed.connect(_on_show_grid_changed)
+	#State.show_handles_changed.connect(_on_show_handles_changed)
+	#State.show_reference_changed.connect(_on_show_reference_changed)
+	#State.overlay_reference_changed.connect(_on_overlay_reference_changed)
+	#State.show_debug_changed.connect(_on_show_debug_changed)
+	## Updating checked items didn't work without the await.
+	#await get_tree().process_frame
+	#_on_snap_changed()
+	#_on_view_rasterized_changed()
+	#_on_show_grid_changed()
+	#_on_show_handles_changed()
+	#_on_show_reference_changed()
+	#_on_overlay_reference_changed()
+	#_on_show_debug_changed()
+#
+#
+#func _reset_menus() -> void:
+	#NativeMenu.remove_item(global_rid, snap_idx)
+	#NativeMenu.remove_item(global_rid, view_idx)
+	#NativeMenu.remove_item(global_rid, tool_idx)
+	#NativeMenu.remove_item(global_rid, edit_idx)
+	#NativeMenu.remove_item(global_rid, file_idx)
+	#NativeMenu.free_menu(file_rid)
+	#NativeMenu.free_menu(edit_rid)
+	#NativeMenu.free_menu(tool_rid)
+	#NativeMenu.free_menu(view_rid)
+	#NativeMenu.free_menu(snap_rid)
+	#_generate_main_menus()
+	#_setup_menu_items()
+#
+#
+#func _generate_main_menus() -> void:
+	#file_rid = NativeMenu.create_menu()
+	#edit_rid = NativeMenu.create_menu()
+	#tool_rid = NativeMenu.create_menu()
+	#view_rid = NativeMenu.create_menu()
+	#snap_rid = NativeMenu.create_menu()
+	#file_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("File"), file_rid)
+	#edit_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Edit"), edit_rid)
+	#tool_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Tool"), tool_rid)
+	#view_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("View"), view_rid)
+	#snap_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Snap"), snap_rid)
+#
+#
+#func _clear_menu_items() -> void:
+	#NativeMenu.clear(appl_rid)
+	#NativeMenu.clear(help_rid)
+	#NativeMenu.clear(file_rid)
+	#NativeMenu.clear(edit_rid)
+	#NativeMenu.clear(tool_rid)
+	#NativeMenu.clear(view_rid)
+	#NativeMenu.clear(snap_rid)
 
 
-func _add_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_item(menu_rid,
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name,
-			_get_action_keycode(action_name))
-
-func _add_many_items(menu_rid: RID, actions: PackedStringArray) -> void:
-	for action in actions:
-		_add_item(menu_rid, action)
-
-func _add_check_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_check_item(menu_rid,
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
-
-func _add_many_icon_items(menu_rid: RID, actions: PackedStringArray) -> void:
-	for action in actions:
-		_add_icon_item(menu_rid, action)
-
-func _add_icon_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_icon_item(menu_rid,
-			ShortcutUtils.get_action_icon(action_name),
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
-
-
-func _get_action_keycode(action: String) -> Key:
-	var shortcut := ShortcutUtils.get_action_first_valid_shortcut(action)
-	if is_instance_valid(shortcut):
-		return shortcut.get_keycode_with_modifiers()
-	return KEY_NONE
-
-
-func _on_view_rasterized_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.view_rasterized)
-
-func _on_show_grid_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_grid_idx, State.show_grid)
-
-func _on_show_handles_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_handles_idx, State.show_handles)
-
-func _on_show_reference_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_reference_idx, State.show_reference)
-
-func _on_overlay_reference_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_overlay_reference_idx, State.overlay_reference)
-
-func _on_show_debug_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_debug_idx, State.show_debug)
-
-
-func _on_snap_changed() -> void:
-	var snap_amount := absf(Configs.savedata.snap)
-	NativeMenu.set_item_checked(snap_rid, snap_enable_idx, Configs.savedata.snap > 0)
-	NativeMenu.set_item_checked(snap_rid, snap_0125_idx, is_equal_approx(snap_amount, 0.125))
-	NativeMenu.set_item_checked(snap_rid, snap_025_idx, is_equal_approx(snap_amount, 0.25))
-	NativeMenu.set_item_checked(snap_rid, snap_05_idx, is_equal_approx(snap_amount, 0.5))
-	NativeMenu.set_item_checked(snap_rid, snap_1_idx, is_equal_approx(snap_amount, 1))
-	NativeMenu.set_item_checked(snap_rid, snap_2_idx, is_equal_approx(snap_amount, 2))
-	NativeMenu.set_item_checked(snap_rid, snap_4_idx, is_equal_approx(snap_amount, 4))
-
-func _set_snap(amount: float) -> void:
-	Configs.savedata.snap = amount
+#func _setup_menu_items() -> void:
+	#_clear_menu_items()
+	#_add_item(appl_rid, "open_settings")
+	## Help menu.
+	#_add_icon_item(help_rid, "open_settings")
+	#_add_icon_item(help_rid, "about_repo")
+	#_add_icon_item(help_rid, "about_info")
+	#_add_icon_item(help_rid, "about_donate")
+	#_add_icon_item(help_rid, "about_website")
+	#_add_icon_item(help_rid, "check_updates")
+	## File menu.
+	#_add_many_items(file_rid, PackedStringArray(["import", "export", "save", "save_as"]))
+	#NativeMenu.add_separator(file_rid)
+	#_add_item(file_rid, "copy_svg_text")
+	#file_optimize_idx = _add_item(file_rid, "optimize")
+	#NativeMenu.add_separator(file_rid)
+	#file_reset_svg_idx = _add_item(file_rid, "reset_svg")
+	## Edit and Tool menus.
+	#_add_many_items(edit_rid, ShortcutUtils.get_actions("edit"))
+	#_add_many_items(tool_rid, ShortcutUtils.get_actions("tool"))
+	## View menu.
+	#view_show_grid_idx = _add_check_item(view_rid, "view_show_grid")
+	#view_show_handles_idx = _add_check_item(view_rid, "view_show_handles")
+	#view_rasterized_svg_idx = _add_check_item(view_rid, "view_rasterized_svg")
+	#NativeMenu.add_separator(view_rid)
+	#view_show_reference_idx = _add_item(view_rid, "load_reference")
+	#view_show_reference_idx = _add_check_item(view_rid, "view_show_reference")
+	#view_overlay_reference_idx = _add_check_item(view_rid, "view_overlay_reference")
+	#view_show_debug_idx = _add_check_item(view_rid, "view_show_debug")
+	#NativeMenu.add_separator(view_rid)
+	#_add_many_items(view_rid, PackedStringArray(["zoom_in", "zoom_out", "zoom_reset"]))
+	## Snap menu.
+	#snap_enable_idx = _add_check_item(snap_rid, "toggle_snap")
+	#NativeMenu.add_separator(snap_rid)
+	#snap_0125_idx = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
+	#snap_025_idx = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)
+	#snap_05_idx = NativeMenu.add_radio_check_item(snap_rid, "0.5", _set_snap, _set_snap, 0.5)
+	#snap_1_idx = NativeMenu.add_radio_check_item(snap_rid, "1", _set_snap, _set_snap, 1)
+	#snap_2_idx = NativeMenu.add_radio_check_item(snap_rid, "2", _set_snap, _set_snap, 2)
+	#snap_4_idx = NativeMenu.add_radio_check_item(snap_rid, "4", _set_snap, _set_snap, 4)
+#
+#
+#func _add_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_item(menu_rid,
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name,
+			#_get_action_keycode(action_name))
+#
+#func _add_many_items(menu_rid: RID, actions: PackedStringArray) -> void:
+	#for action in actions:
+		#_add_item(menu_rid, action)
+#
+#func _add_check_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_check_item(menu_rid,
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
+#
+#func _add_many_icon_items(menu_rid: RID, actions: PackedStringArray) -> void:
+	#for action in actions:
+		#_add_icon_item(menu_rid, action)
+#
+#func _add_icon_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_icon_item(menu_rid,
+			#ShortcutUtils.get_action_icon(action_name),
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
+#
+#
+#func _get_action_keycode(action: String) -> Key:
+	#var shortcut := ShortcutUtils.get_action_first_valid_shortcut(action)
+	#if is_instance_valid(shortcut):
+		#return shortcut.get_keycode_with_modifiers()
+	#return KEY_NONE
+#
+#
+#func _on_view_rasterized_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.view_rasterized)
+#
+#func _on_show_grid_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_grid_idx, State.show_grid)
+#
+#func _on_show_handles_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_handles_idx, State.show_handles)
+#
+#func _on_show_reference_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_reference_idx, State.show_reference)
+#
+#func _on_overlay_reference_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_overlay_reference_idx, State.overlay_reference)
+#
+#func _on_show_debug_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_debug_idx, State.show_debug)
+#
+#
+#func _on_snap_changed() -> void:
+	#var snap_amount := absf(Configs.savedata.snap)
+	#NativeMenu.set_item_checked(snap_rid, snap_enable_idx, Configs.savedata.snap > 0)
+	#NativeMenu.set_item_checked(snap_rid, snap_0125_idx, is_equal_approx(snap_amount, 0.125))
+	#NativeMenu.set_item_checked(snap_rid, snap_025_idx, is_equal_approx(snap_amount, 0.25))
+	#NativeMenu.set_item_checked(snap_rid, snap_05_idx, is_equal_approx(snap_amount, 0.5))
+	#NativeMenu.set_item_checked(snap_rid, snap_1_idx, is_equal_approx(snap_amount, 1))
+	#NativeMenu.set_item_checked(snap_rid, snap_2_idx, is_equal_approx(snap_amount, 2))
+	#NativeMenu.set_item_checked(snap_rid, snap_4_idx, is_equal_approx(snap_amount, 4))
+#
+#func _set_snap(amount: float) -> void:
+	#Configs.savedata.snap = amount

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -19,11 +19,11 @@ var limit_bottom := 0.0
 @onready var view: SubViewportContainer = get_parent()
 @onready var controls: HandlesManager = $Controls
 @onready var display_texture: DisplayTexture = $Checkerboard/DisplayTexture
-@onready var reference_texture: TextureRect = $ReferenceTexture
 @onready var zoom_menu: ZoomMenu = %ZoomMenu
 
 
 func _ready() -> void:
+	size_changed.connect(_on_size_changed)
 	zoom_menu.zoom_changed.connect(view.update.unbind(2))
 	State.svg_resized.connect(resize)
 	Configs.active_tab_changed.connect(zoom_menu.zoom_reset)
@@ -54,7 +54,6 @@ func resize() -> void:
 	var root_element_size := State.root_element.get_size()
 	if root_element_size.is_finite():
 		display.size = root_element_size
-		reference_texture.size = root_element_size
 	zoom_menu.zoom_reset()
 
 func center_frame() -> void:

--- a/src/ui_parts/viewport_container.gd
+++ b/src/ui_parts/viewport_container.gd
@@ -1,29 +1,4 @@
-extends SubViewportContainer
-
-const TICKS_INTERVAL = 4
-const TICK_DISTANCE = float(TICKS_INTERVAL)
-
-var ci := get_canvas_item()
-var grid_ci := RenderingServer.canvas_item_create()
-var grid_numbers_ci := RenderingServer.canvas_item_create()
-
-var camera_zoom: float
-var camera_position: Vector2
-var camera_unsnapped_position: Vector2
-
-
-func _ready() -> void:
-	Configs.grid_color_changed.connect(queue_redraw)
-	State.show_grid_changed.connect(update_show_grid)
-	update_show_grid()
-	RenderingServer.canvas_item_set_parent(grid_ci, ci)
-	RenderingServer.canvas_item_set_parent(grid_numbers_ci, ci)
-	State.svg_resized.connect(queue_redraw)
-	State.zoom_changed.connect(change_zoom)
-	State.zoom_changed.connect(queue_redraw)
-
-func exit_tree() -> void:
-	RenderingServer.free_rid(grid_numbers_ci)
+extends Canvas
 
 func change_zoom() -> void:
 	camera_zoom = State.zoom
@@ -64,13 +39,13 @@ func _draw() -> void:
 	var draw_minor_lines := (camera_zoom >= 8.0)
 	var mark_pixel_lines := (camera_zoom >= 128.0)
 	@warning_ignore("integer_division")
-	var rate := nearest_po2(roundi(maxf(128.0 / (TICKS_INTERVAL * camera_zoom), 2.0))) / 2
+	var rate := nearest_po2(roundi(maxf(128.0 / (GRID_TICKS_INTERVAL * camera_zoom), 2.0))) / 2
 	
 	var i := fmod(-camera_position.x, 1.0)
-	var major_line_h_offset := fposmod(-camera_position.x, TICK_DISTANCE)
+	var major_line_h_offset := fposmod(-camera_position.x, GRID_TICK_DISTANCE)
 	# Horizontal offset.
 	while i <= grid_size.x:
-		if major_line_h_offset != fposmod(i, TICK_DISTANCE):
+		if major_line_h_offset != fposmod(i, GRID_TICK_DISTANCE):
 			if draw_minor_lines:
 				minor_points.append(Vector2(i * camera_zoom, 0))
 				minor_points.append(Vector2(i * camera_zoom, grid_size.y * camera_zoom))
@@ -79,8 +54,8 @@ func _draw() -> void:
 							Vector2(i * camera_zoom + 4, 14), String.num_int64(floori(i + camera_position.x)),
 							HORIZONTAL_ALIGNMENT_LEFT, -1, 14, axis_line_color)
 		else:
-			var coord := snappedi(i + camera_position.x, TICKS_INTERVAL)
-			if int(coord / TICK_DISTANCE) % rate == 0:
+			var coord := snappedi(i + camera_position.x, GRID_TICKS_INTERVAL)
+			if int(coord / GRID_TICK_DISTANCE) % rate == 0:
 				major_points.append(Vector2(i * camera_zoom, 0))
 				major_points.append(Vector2(i * camera_zoom, grid_size.y * camera_zoom))
 				ThemeUtils.regular_font.draw_string(grid_numbers_ci,
@@ -92,10 +67,10 @@ func _draw() -> void:
 		i += 1.0
 	
 	i = fmod(-camera_position.y, 1.0)
-	var major_line_v_offset := fposmod(-camera_position.y, TICK_DISTANCE)
+	var major_line_v_offset := fposmod(-camera_position.y, GRID_TICK_DISTANCE)
 	# Vertical offset.
 	while i < grid_size.y:
-		if major_line_v_offset != fposmod(i, TICK_DISTANCE):
+		if major_line_v_offset != fposmod(i, GRID_TICK_DISTANCE):
 			if draw_minor_lines:
 				minor_points.append(Vector2(0, i * camera_zoom))
 				minor_points.append(Vector2(grid_size.x * camera_zoom, i * camera_zoom))
@@ -104,8 +79,8 @@ func _draw() -> void:
 							Vector2(4, i * camera_zoom + 14), String.num_int64(floori(i + camera_position.y)),
 							HORIZONTAL_ALIGNMENT_LEFT, -1, 14, axis_line_color)
 		else:
-			var coord := snappedi(i + camera_position.y, TICKS_INTERVAL)
-			if int(coord / TICK_DISTANCE) % rate == 0:
+			var coord := snappedi(i + camera_position.y, GRID_TICKS_INTERVAL)
+			if int(coord / GRID_TICK_DISTANCE) % rate == 0:
 				major_points.append(Vector2(0, i * camera_zoom))
 				major_points.append(Vector2(grid_size.x * camera_zoom, i * camera_zoom))
 				ThemeUtils.regular_font.draw_string(grid_numbers_ci,


### PR DESCRIPTION
This was my first attempt at a major infrastructural rework to make viewports modular, so we can mimic them for the settings preview. Because I was going through old parts of the codebase and coming up with ideas as I went. I've kind of realized that this change needs to be paired with a rework to shortcuts. Doing so is a pretty high-priority change, purely because I want to have that in my promotional videos for the new alpha.

I'll pull some things away from this PR and close it when that's done. I think a rework to settings became a kind of necessary prerequisite as I went along, so that the main viewport can provide its shortcuts.