### PR TITLE
Fix two small bugs

### DIFF
--- a/src/ui_widgets/BetterButton.gd
+++ b/src/ui_widgets/BetterButton.gd
@@ -55,9 +55,12 @@ func _unhandled_input(event: InputEvent) -> void:
 		return
 	
 	if not just_pressed and ShortcutUtils.is_action_pressed(event, action):
+		begin_bulk_theme_override()
 		add_theme_color_override("icon_normal_color", get_theme_color("icon_pressed_color"))
 		add_theme_color_override("icon_hover_color", get_theme_color("icon_pressed_color"))
 		add_theme_stylebox_override("normal", get_theme_stylebox("pressed"))
+		add_theme_stylebox_override("hover", get_theme_stylebox("hover_pressed"))
+		end_bulk_theme_override()
 		if is_instance_valid(timer):
 			timer.timeout.disconnect(end_highlight)
 		timer = get_tree().create_timer(HIGHLIGHT_TIME)
@@ -67,4 +70,5 @@ func end_highlight() -> void:
 	remove_theme_color_override("icon_normal_color")
 	remove_theme_color_override("icon_hover_color")
 	remove_theme_stylebox_override("normal")
+	remove_theme_stylebox_override("hover")
 	timer = null

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -885,6 +885,7 @@ static func _setup_lineedit(theme: Theme) -> void:
 	theme.set_color("font_color", "LineEdit", editable_text_color)
 	theme.set_color("font_uneditable_color", "LineEdit", dimmer_text_color)
 	theme.set_color("font_placeholder_color", "LineEdit", subtle_text_color)
+	theme.set_color("font_selected_color", "LineEdit", highlighted_text_color)
 	theme.set_color("selection_color", "LineEdit", selection_color)
 	theme.set_color("disabled_selection_color", "LineEdit", disabled_selection_color)
 	theme.set_font_size("font_size", "LineEdit", 12)


### PR DESCRIPTION
Shortcut button will now be highlighted even if currently hovered. And the theme defines a color for selected text in LineEdits, instead of defaulting to white which looked a little odd on light theme.