### PR TITLE
Improve selection rectangle shader

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -20,7 +20,7 @@ func get_setting_default(setting: String) -> Variant:
 		"accent_color":
 			match theme_preset:
 				ThemePreset.DARK: return Color("6191f2")
-				ThemePreset.LIGHT: return Color("0830a6")
+				ThemePreset.LIGHT: return Color("0031bf")
 				ThemePreset.BLACK: return Color("7c8dbf")
 		"highlighter_preset":
 			match theme_preset:

--- a/src/shaders/animated_stroke.gdshader
+++ b/src/shaders/animated_stroke.gdshader
@@ -6,15 +6,41 @@ uniform float ant_width = 2.0;
 uniform float ant_length = 10.0;
 uniform float ant_speed = 30.0;
 
+varying float cos_skew;
+varying float max_rotation_factor;
+
+void vertex() {
+	// A bunch of hacks to deal with rotated or skewed drawing resulting in ants
+	// that are too long, fast, and sometimes wide.
+	vec2 col0 = MODEL_MATRIX[0].xy;
+	vec2 col1 = MODEL_MATRIX[1].xy;
+	
+	float rotation = atan(col0.y, col0.x);
+	float det = col0.x * col1.y - col0.y * col1.x;
+	
+	vec2 col0_norm = normalize(col0);
+	vec2 col1_norm = normalize(col1) * sign(det);
+	
+	float dot_product = dot(col0_norm, col1_norm);
+	float skew = acos(clamp(dot_product, -1.0, 1.0)) - PI * 0.5;
+	
+	cos_skew = cos(skew);
+	max_rotation_factor = max(abs(cos(rotation)), abs(sin(rotation)));
+}
+
 void fragment() {
+	float corrected_length = ant_length * cos_skew * max_rotation_factor;
+	float corrected_speed = ant_speed * cos_skew * max_rotation_factor;
+	float corrected_width = ant_width * max_rotation_factor;
+	
 	vec2 uv = UV;
 	vec2 fw = fwidth(uv);
-	float adjusted_ant_width = min(ant_width, min(0.5 / fw.x, 0.5 / fw.y));
+	float adjusted_ant_width = min(corrected_width, min(0.5 / fw.x, 0.5 / fw.y)) + 0.15;
 	vec2 aw = fw * adjusted_ant_width;
-
+	
 	vec2 cond = (sign(abs(uv - 0.5) - 0.5 + aw) + 1.0) * 0.5 * ceil(((sign(uv.yx - aw.yx) + 1.0) * 0.5 * (sign(uv - 0.5) * vec2(0.5, -0.5) + 0.5) * 0.5 + (sign(1.0 - aw.yx - uv.yx) + 1.0) * 0.5 * (sign(uv - 0.5) * vec2(-0.5, 0.5)+ 0.5) * 0.5));
 	float dir = dot(vec2(cond.y, -cond.x), sign(uv.yx - 0.5) * uv / aw);
-	float ant_type = round(fract((dir * adjusted_ant_width + TIME * ant_speed) * 0.5 / ant_length));
+	float ant_type = round(fract((dir * adjusted_ant_width + TIME * corrected_speed) * 0.5 / corrected_length));
 	vec4 ant_color = mix(ant_color_1, ant_color_2, ant_type);
 	COLOR = (cond.x + cond.y) * ant_color;
 }

--- a/src/shaders/animated_stroke_static.gdshader
+++ b/src/shaders/animated_stroke_static.gdshader
@@ -7,15 +7,40 @@ uniform vec4 ant_color_2: source_color = vec4(0.0, 0.0, 0.0, 1.0);
 uniform float ant_width = 2.0;
 uniform float ant_length = 10.0;
 
+varying float cos_skew;
+varying float max_rotation_factor;
+
+void vertex() {
+	// A bunch of hacks to deal with rotated or skewed drawing resulting in ants
+	// that are too long, fast, and sometimes wide.
+	vec2 col0 = MODEL_MATRIX[0].xy;
+	vec2 col1 = MODEL_MATRIX[1].xy;
+	
+	float rotation = atan(col0.y, col0.x);
+	float det = col0.x * col1.y - col0.y * col1.x;
+	
+	vec2 col0_norm = normalize(col0);
+	vec2 col1_norm = normalize(col1) * sign(det);
+	
+	float dot_product = dot(col0_norm, col1_norm);
+	float skew = acos(clamp(dot_product, -1.0, 1.0)) - PI * 0.5;
+	
+	cos_skew = cos(skew);
+	max_rotation_factor = max(abs(cos(rotation)), abs(sin(rotation)));
+}
+
 void fragment() {
+	float corrected_length = ant_length * cos_skew * max_rotation_factor;
+	float corrected_width = ant_width * max_rotation_factor;
+	
 	vec2 uv = UV;
 	vec2 fw = fwidth(uv);
-	float adjusted_ant_width = min(ant_width, min(0.5 / fw.x, 0.5 / fw.y));
+	float adjusted_ant_width = min(corrected_width, min(0.5 / fw.x, 0.5 / fw.y)) + 0.15;
 	vec2 aw = fw * adjusted_ant_width;
-
+	
 	vec2 cond = (sign(abs(uv - 0.5) - 0.5 + aw) + 1.0) * 0.5 * ceil(((sign(uv.yx - aw.yx) + 1.0) * 0.5 * (sign(uv - 0.5) * vec2(0.5, -0.5) + 0.5) * 0.5 + (sign(1.0 - aw.yx - uv.yx) + 1.0) * 0.5 * (sign(uv - 0.5) * vec2(-0.5, 0.5)+ 0.5) * 0.5));
 	float dir = dot(vec2(cond.y, -cond.x), sign(uv.yx - 0.5) * uv / aw);
-	float ant_type = round(fract((dir * adjusted_ant_width) * 0.5 / ant_length));
+	float ant_type = round(fract((dir * adjusted_ant_width) * 0.5 / corrected_length));
 	vec4 ant_color = mix(ant_color_1, ant_color_2, ant_type);
 	COLOR = (cond.x + cond.y) * ant_color;
 }

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -553,11 +553,11 @@ static func _setup_button(theme: Theme) -> void:
 	var normal_translucent_button_stylebox := StyleBoxFlat.new()
 	normal_translucent_button_stylebox.set_corner_radius_all(5)
 	normal_translucent_button_stylebox.set_content_margin_all(4)
-	normal_translucent_button_stylebox.bg_color = hover_overlay_color
+	normal_translucent_button_stylebox.bg_color = strong_hover_overlay_color
 	theme.set_stylebox("normal", "TranslucentButton", normal_translucent_button_stylebox)
 	
 	var hover_translucent_button_stylebox := normal_translucent_button_stylebox.duplicate()
-	hover_translucent_button_stylebox.bg_color = strong_hover_overlay_color
+	hover_translucent_button_stylebox.bg_color = stronger_hover_overlay_color
 	theme.set_stylebox("hover", "TranslucentButton", hover_translucent_button_stylebox)
 	
 	var pressed_translucent_button_stylebox := normal_translucent_button_stylebox.duplicate()


### PR DESCRIPTION
This is as good as I can get it to be.

Before:

<img width="1060" height="705" alt="image" src="https://github.com/user-attachments/assets/21e3a205-3f6f-4699-ade0-7d751a8c2388" />

After:

<img width="1060" height="705" alt="image" src="https://github.com/user-attachments/assets/ba5530f8-c695-48c0-9cb1-2bab8e294793" />
