### PR TITLE
Improve UndoRedoRef

### DIFF
--- a/src/config_classes/TabData.gd
+++ b/src/config_classes/TabData.gd
@@ -45,7 +45,7 @@ func set_svg_text(new_text: String) -> void:
 	if not is_instance_valid(undo_redo):
 		undo_redo = UndoRedoRef.new()
 	var old_value := _svg_text
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(self, "_svg_text", new_text)
 	undo_redo.add_undo_property(self, "_svg_text", old_value)
 	undo_redo.add_do_property(State, "svg_text", new_text)

--- a/src/ui_parts/export_menu.gd
+++ b/src/ui_parts/export_menu.gd
@@ -104,21 +104,21 @@ func _on_clipboard_button_pressed() -> void:
 
 func _on_dropdown_value_changed(new_value: String) -> void:
 	var current_format := export_data.format
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "format", new_value)
 	undo_redo.add_undo_property(export_data, "format", current_format)
 	undo_redo.commit_action()
 
 func _on_lossless_check_box_toggled(toggled_on: bool) -> void:
 	var current_lossy := export_data.lossy
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "lossy", not toggled_on)
 	undo_redo.add_undo_property(export_data, "lossy", current_lossy)
 	undo_redo.commit_action()
 
 func _on_quality_value_changed(new_value: float) -> void:
 	var current_quality := export_data.quality
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "quality", new_value / 100)
 	undo_redo.add_undo_property(export_data, "quality", current_quality)
 	undo_redo.commit_action()
@@ -127,7 +127,7 @@ func _on_scale_edit_value_changed(new_value: float) -> void:
 	if new_value == export_data.upscale_amount:
 		return
 	var current_upscale_amount := export_data.upscale_amount
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "upscale_amount", new_value)
 	undo_redo.add_undo_property(export_data, "upscale_amount", current_upscale_amount)
 	undo_redo.commit_action()
@@ -136,7 +136,7 @@ func _on_width_edit_value_changed(new_value: float) -> void:
 	if roundi(dimensions.x * export_data.upscale_amount) == roundi(new_value):
 		return
 	var current_upscale_amount := export_data.upscale_amount
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "upscale_amount", new_value / dimensions.x)
 	undo_redo.add_undo_property(export_data, "upscale_amount", current_upscale_amount)
 	undo_redo.commit_action()
@@ -145,7 +145,7 @@ func _on_height_edit_value_changed(new_value: float) -> void:
 	if roundi(dimensions.y * export_data.upscale_amount) == roundi(new_value):
 		return
 	var current_upscale_amount := export_data.upscale_amount
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_property(export_data, "upscale_amount", new_value / dimensions.y)
 	undo_redo.add_undo_property(export_data, "upscale_amount", current_upscale_amount)
 	undo_redo.commit_action()

--- a/src/ui_widgets/UndoRedoRef.gd
+++ b/src/ui_widgets/UndoRedoRef.gd
@@ -11,7 +11,7 @@ var _undo_redo := UndoRedo.new()
 func _init() -> void:
 	_undo_redo.version_changed.connect(version_changed.emit)
 
-func create_action(name: String) -> void:
+func create_action(name := "") -> void:
 	_undo_redo.create_action(name)
 
 func add_do_method(callable: Callable) -> void:
@@ -46,6 +46,9 @@ func has_undo() -> bool:
 
 func has_redo() -> bool:
 	return _undo_redo.has_redo()
+
+func clear_history() -> void:
+	_undo_redo.clear_history()
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_PREDELETE:

--- a/src/ui_widgets/good_color_picker.gd
+++ b/src/ui_widgets/good_color_picker.gd
@@ -188,7 +188,7 @@ func register_visual_change(new_color: Color, use_backup := true) -> void:
 	new_color == (backup_display_color if use_backup else display_color):
 		return
 	
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(set_color.bind(hex(new_color), new_color))
 	if use_backup:
 		undo_redo.add_undo_method(set_color.bind(backup_color, backup_display_color))
@@ -395,7 +395,7 @@ func _on_keyword_button_pressed() -> void:
 			get_viewport())
 
 func set_to_keyword(keyword: String) -> void:
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	if color.strip_edges() == keyword:
 		undo_redo.add_do_method(set_color.bind(backup_color, backup_display_color))
 		undo_redo.add_undo_method(set_color.bind(color, display_color))
@@ -407,7 +407,7 @@ func set_to_keyword(keyword: String) -> void:
 
 func _on_reset_color_button_pressed() -> void:
 	reset_color_button.disabled = true
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(set_color.bind(starting_color, starting_display_color))
 	undo_redo.add_undo_method(set_color.bind(color, display_color))
 	undo_redo.commit_action()

--- a/src/ui_widgets/transform_popup.gd
+++ b/src/ui_widgets/transform_popup.gd
@@ -104,7 +104,7 @@ func create_mini_number_field(idx: int, property: String) -> BetterLineEdit:
 
 
 func update_value(new_value: float, idx: int, property: String) -> void:
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(attribute_ref.set_transform_property.bind(idx, property, new_value))
 	undo_redo.add_do_method(rebuild)
 	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(get_transform_list()))
@@ -112,7 +112,7 @@ func update_value(new_value: float, idx: int, property: String) -> void:
 	undo_redo.commit_action()
 
 func insert_transform(idx: int, transform_type: String) -> void:
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(attribute_ref.insert_transform.bind(idx, transform_type))
 	undo_redo.add_do_method(rebuild)
 	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(get_transform_list()))
@@ -120,7 +120,7 @@ func insert_transform(idx: int, transform_type: String) -> void:
 	undo_redo.commit_action()
 
 func delete_transform(idx: int) -> void:
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(attribute_ref.delete_transform.bind(idx))
 	undo_redo.add_do_method(rebuild)
 	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(get_transform_list()))
@@ -129,7 +129,7 @@ func delete_transform(idx: int) -> void:
 
 func _on_apply_matrix_pressed() -> void:
 	var final_transform := attribute_ref.get_final_precise_transform()
-	undo_redo.create_action("")
+	undo_redo.create_action()
 	undo_redo.add_do_method(attribute_ref.set_transform_list.bind([
 			Transform.TransformMatrix.new(final_transform[0], final_transform[1],
 			final_transform[2], final_transform[3], final_transform[4],


### PR DESCRIPTION
Implements clear_history() in UndoRedoRef and makes it so commit_action() doesn't require a name for the action.