### PR TITLE
Rework shortcut system

### DIFF
--- a/assets/icons/ShortcutPanel.svg
+++ b/assets/icons/ShortcutPanel.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#def" d="M4 2a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V3a1 1 0 00-1-1Zm2.75 2h3l-1 3h2l-4 4 .75-3h-2z"/><path fill="none" d="M1.5 4.5v8a2 2 0 002 2h9a2 2 0 002-2v-8" stroke="#def" stroke-linecap="round"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#fff" d="M4 2a1 1 0 00-1 1v9a1 1 0 001 1h8a1 1 0 001-1V3a1 1 0 00-1-1Zm2.75 2h3l-1 3h2l-4 4 .75-3h-2z"/><path fill="none" d="M1.5 4.5v8a2 2 0 002 2h9a2 2 0 002-2v-8" stroke="#fff" stroke-linecap="round"/></svg>

--- a/godot_only/scripts/update_translations.gd
+++ b/godot_only/scripts/update_translations.gd
@@ -16,6 +16,7 @@ const COMMENTS_DICT = {
 	"Dark": "Refers to a theme preset.",
 	"Light": "Refers to a theme preset.",
 	"Black (OLED)": "Refers to a theme preset.",
+	"translation-credits": "Translators (comma-separated): Your preferred alias or real name, followed optionally by your email in angle brackets, e.g., <email@example.com>.\nThis list is used for credits, adding yourself to it is optional. New entries are added after all the existing ones. Do not remove or rearrange entries.",
 }
 
 const TRANSLATIONS_DIR = "translations"

--- a/src/data_classes/ShortcutRegistration.gd
+++ b/src/data_classes/ShortcutRegistration.gd
@@ -1,0 +1,16 @@
+class_name ShortcutsRegistration extends RefCounted
+
+@warning_ignore("unused_signal")
+signal activated(activated_action: String)
+
+enum Behavior {PASS_THROUGH_ALL, PASS_THROUGH_POPUPS, PASS_THROUGH_AND_PRESERVE_POPUPS, NO_PASSTHROUGH, STRICT_NO_PASSTHROUGH}
+
+# The elements with the same indices from these 3 arrays corresponds to a shortcut registration.
+var actions := PackedStringArray()
+var behaviors: Array[Behavior] = []
+var callbacks: Array[Callable] = []
+
+func add_shortcut(new_action: String, new_callback: Callable, new_behavior := Behavior.NO_PASSTHROUGH) -> void:
+	actions.append(new_action)
+	behaviors.append(new_behavior)
+	callbacks.append(new_callback)

--- a/src/data_classes/ShortcutRegistration.gd.uid
+++ b/src/data_classes/ShortcutRegistration.gd.uid
@@ -1,0 +1,1 @@
+uid://bssv7pdsnjec0

--- a/src/ui_parts/about_menu.gd
+++ b/src/ui_parts/about_menu.gd
@@ -13,6 +13,11 @@ extends PanelContainer
 @onready var tab_container: TabContainer = $VBoxContainer/TabContainer
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("select_next_tab", select_next_tab)
+	shortcuts.add_shortcut("select_previous_tab", select_previous_tab)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	var stylebox := get_theme_stylebox("panel").duplicate()
 	stylebox.content_margin_top += 2.0
 	add_theme_stylebox_override("panel", stylebox)
@@ -29,12 +34,13 @@ func _ready() -> void:
 	tab_container.tab_changed.connect(_on_tab_changed)
 	_on_tab_changed(0)
 
-func _unhandled_input(event: InputEvent) -> void:
+
+func select_next_tab() -> void:
+	tab_container.current_tab = (tab_container.current_tab + 1) % tab_container.get_tab_count()
+
+func select_previous_tab() -> void:
 	var tab_count := tab_container.get_tab_count()
-	if ShortcutUtils.is_action_pressed(event, "select_next_tab"):
-		tab_container.current_tab = (tab_container.current_tab + 1) % tab_count
-	elif ShortcutUtils.is_action_pressed(event, "select_previous_tab"):
-		tab_container.current_tab = (tab_container.current_tab + tab_count - 1) % tab_count
+	tab_container.current_tab = (tab_container.current_tab + tab_count - 1) % tab_count
 
 func _on_tab_changed(idx: int) -> void:
 	match idx:

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -7,6 +7,10 @@ extends VBoxContainer
 @onready var options_button: Button = %MetaActions/OptionsButton
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("copy_svg_text", func() -> void: DisplayServer.clipboard_set(State.svg_text))
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	Configs.theme_changed.connect(sync_theming)
 	sync_theming()
 	State.parsing_finished.connect(update_error)

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -9,9 +9,74 @@ const ViewportScene = preload("res://src/ui_parts/display.tscn")
 @onready var panel_container: PanelContainer = $PanelContainer
 
 func _ready() -> void:
-	Configs.theme_changed.connect(sync_theming)
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("view_show_grid", State.toggle_show_grid, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("view_show_handles", State.toggle_show_handles, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("view_rasterized_svg", State.toggle_view_rasterized, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("view_show_reference", State.toggle_show_reference, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("view_overlay_reference", State.toggle_overlay_reference, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("load_reference", FileUtils.open_image_import_dialog, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("toggle_snap", func() -> void: Configs.savedata.snap *= -1, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("import", FileUtils.open_svg_import_dialog, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("export", HandlerGUI.open_export, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("save", FileUtils.save_svg, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
+	shortcuts.add_shortcut("save_as", FileUtils.save_svg_as, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_tab", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index()),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_all_other_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.ALL_OTHERS),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_tabs_to_left", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_LEFT),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_tabs_to_right", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_RIGHT),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_empty_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.EMPTY),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_saved_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.SAVED),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("new_tab", Configs.savedata.add_empty_tab, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("select_next_tab",
+			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() + 1, Configs.savedata.get_tab_count())),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("select_previous_tab",
+			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() - 1, Configs.savedata.get_tab_count())),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("optimize", State.optimize, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("reset_svg", FileUtils.reset_svg, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("debug", State.toggle_show_debug)
+	shortcuts.add_shortcut("ui_undo", func() -> void: Configs.savedata.get_active_tab().undo(), ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("ui_redo", func() -> void: Configs.savedata.get_active_tab().redo(), ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("ui_cancel", State.clear_all_selections, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("delete", State.delete_selected, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("move_up", State.move_up_selected, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("move_down", State.move_down_selected, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("duplicate", State.duplicate_selected, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	shortcuts.add_shortcut("select_all", State.select_all, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
+	
+	shortcuts.add_shortcut("move_absolute", State.respond_to_key_input.bind("M"))
+	shortcuts.add_shortcut("move_relative", State.respond_to_key_input.bind("m"))
+	shortcuts.add_shortcut("line_absolute", State.respond_to_key_input.bind("L"))
+	shortcuts.add_shortcut("line_relative", State.respond_to_key_input.bind("l"))
+	shortcuts.add_shortcut("horizontal_line_absolute", State.respond_to_key_input.bind("H"))
+	shortcuts.add_shortcut("horizontal_line_relative", State.respond_to_key_input.bind("h"))
+	shortcuts.add_shortcut("vertical_line_absolute", State.respond_to_key_input.bind("V"))
+	shortcuts.add_shortcut("vertical_line_relative", State.respond_to_key_input.bind("v"))
+	shortcuts.add_shortcut("close_path_absolute", State.respond_to_key_input.bind("Z"))
+	shortcuts.add_shortcut("close_path_relative", State.respond_to_key_input.bind("z"))
+	shortcuts.add_shortcut("elliptical_arc_absolute", State.respond_to_key_input.bind("A"))
+	shortcuts.add_shortcut("elliptical_arc_relative", State.respond_to_key_input.bind("a"))
+	shortcuts.add_shortcut("cubic_bezier_absolute", State.respond_to_key_input.bind("C"))
+	shortcuts.add_shortcut("cubic_bezier_relative", State.respond_to_key_input.bind("c"))
+	shortcuts.add_shortcut("shorthand_cubic_bezier_absolute", State.respond_to_key_input.bind("S"))
+	shortcuts.add_shortcut("shorthand_cubic_bezier_relative", State.respond_to_key_input.bind("s"))
+	shortcuts.add_shortcut("quadratic_bezier_absolute", State.respond_to_key_input.bind("Q"))
+	shortcuts.add_shortcut("quadratic_bezier_relative", State.respond_to_key_input.bind("q"))
+	shortcuts.add_shortcut("shorthand_quadratic_bezier_absolute", State.respond_to_key_input.bind("T"))
+	shortcuts.add_shortcut("shorthand_quadratic_bezier_relative", State.respond_to_key_input.bind("t"))
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	Configs.layout_changed.connect(update_layout)
 	update_layout()
+	Configs.theme_changed.connect(sync_theming)
 	sync_theming()
 	if NativeMenu.has_feature(NativeMenu.FEATURE_GLOBAL_MENU):
 		add_child(MacMenuScene.instantiate())
@@ -105,8 +170,7 @@ func update_layout() -> void:
 				btn.toggled.connect(func(_toggled_on: bool) -> void:
 						layout_nodes[node_part].visible = (node_part == part))
 			if part == Utils.LayoutPart.INSPECTOR:
-				State.requested_scroll_to_selection.connect(
-						btn.set_pressed.bind(true).unbind(2))
+				State.requested_scroll_to_selection.connect(btn.set_pressed.bind(true).unbind(2))
 			buttons_hbox.add_child(btn)
 			if i == 0:
 				btn.button_pressed = true

--- a/src/ui_parts/export_menu.gd
+++ b/src/ui_parts/export_menu.gd
@@ -30,6 +30,11 @@ var dimensions := Vector2.ZERO
 
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
+	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	final_size_label.add_theme_color_override("font_color", ThemeUtils.subtle_text_color)
 	cancel_button.pressed.connect(queue_free)
 	export_button.pressed.connect(_on_export_button_pressed)
@@ -189,17 +194,4 @@ func update() -> void:
 
 func get_dimensions_text(sides: Vector2, integer := false) -> String:
 	var precision := 0 if integer else 2
-	return "%s×%s" % [Utils.num_simple(sides.x, precision),
-			Utils.num_simple(sides.y, precision)]
-
-
-func _unhandled_input(event: InputEvent) -> void:
-	if not visible:
-		return
-	
-	if ShortcutUtils.is_action_pressed(event, "ui_undo"):
-		undo_redo.undo()
-		accept_event()
-	elif ShortcutUtils.is_action_pressed(event, "ui_redo"):
-		undo_redo.redo()
-		accept_event()
+	return "%s×%s" % [Utils.num_simple(sides.x, precision), Utils.num_simple(sides.y, precision)]

--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -95,6 +95,14 @@ new_extensions: PackedStringArray) -> void:
 
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("find", func() -> void: search_button.button_pressed = not search_button.button_pressed)
+	shortcuts.add_shortcut("ui_accept", func() -> void:
+			var selected_item_indices := file_list.get_selected_items()
+			if not selected_item_indices.is_empty():
+				call_activation_callback(file_list.get_item_metadata(selected_item_indices[0])))
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	# Signal connections.
 	file_field.text_changed.connect(_on_file_field_text_changed)
 	folder_up_button.pressed.connect(_on_folder_up_button_pressed)
@@ -504,13 +512,3 @@ func get_drive_icon(path: String) -> Texture2D:
 		return load("res://assets/icons/DirPictures.svg")
 	else:
 		return folder_icon
-
-func _unhandled_input(event: InputEvent) -> void:
-	if ShortcutUtils.is_action_pressed(event, "find"):
-		search_button.button_pressed = not search_button.button_pressed
-		accept_event()
-	elif event.is_action_pressed("ui_accept"):
-		var selected_item_indices := file_list.get_selected_items()
-		if not selected_item_indices.is_empty():
-			call_activation_callback(file_list.get_item_metadata(selected_item_indices[0]))
-			accept_event()

--- a/src/ui_parts/import_warning_menu.gd
+++ b/src/ui_parts/import_warning_menu.gd
@@ -34,15 +34,13 @@ func _ready() -> void:
 		var preview_parse_result := SVGParser.text_to_root(preview_text)
 		var preview := preview_parse_result.svg
 		if is_instance_valid(preview):
-			texture_preview.setup_svg(SVGParser.root_to_editor_text(preview),
-					preview.get_size())
+			texture_preview.setup_svg(SVGParser.root_to_editor_text(preview), preview.get_size())
 	
 	if imported_text_parse_result.error != SVGParser.ParseError.OK:
 		texture_preview.hide()
 		margin_container.custom_minimum_size.y = 48
 		size.y = 0
-		warnings_label.add_theme_color_override("default_color",
-				Configs.savedata.basic_color_error)
+		warnings_label.add_theme_color_override("default_color", Configs.savedata.basic_color_error)
 		warnings_label.text = "[center]%s: %s" % [Translator.translate(
 				"Syntax error"), SVGParser.get_error_string(imported_text_parse_result.error)]
 	else:

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -27,6 +27,11 @@ func get_tab_localized_name(tab_index: TabIndex) -> String:
 var focused_tab_index := -1 as TabIndex
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("select_next_tab", select_next_tab)
+	shortcuts.add_shortcut("select_previous_tab", select_previous_tab)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	close_button.pressed.connect(queue_free)
 	scroll_container.get_v_scroll_bar().visibility_changed.connect(adjust_right_margin)
 	adjust_right_margin()
@@ -37,12 +42,12 @@ func _ready() -> void:
 	sync_localization()
 	press_tab(0)
 
-func _unhandled_input(event: InputEvent) -> void:
+func select_next_tab() -> void:
+	press_tab((focused_tab_index + 1) % TabIndex.size())
+
+func select_previous_tab() -> void:
 	var tab_count := TabIndex.size()
-	if ShortcutUtils.is_action_pressed(event, "select_next_tab"):
-		press_tab((focused_tab_index + 1) % tab_count)
-	elif ShortcutUtils.is_action_pressed(event, "select_previous_tab"):
-		press_tab((focused_tab_index + tab_count - 1) % tab_count)
+	press_tab((focused_tab_index + tab_count - 1) % tab_count)
 
 func press_tab(index: int) -> void:
 	tabs.get_child(index).button_pressed = true

--- a/src/ui_parts/viewport.gd
+++ b/src/ui_parts/viewport.gd
@@ -153,8 +153,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _on_zoom_changed(new_zoom_level: float, offset: Vector2) -> void:
 	State.set_zoom(new_zoom_level)
 	adjust_view(offset)
-	display.material.set_shader_parameter("uv_scale",
-			nearest_po2(int(State.zoom * 32.0)) / 32.0)
+	display.material.set_shader_parameter("uv_scale", nearest_po2(int(State.zoom * 32.0)) / 32.0)
 
 var last_size_adjusted := size / State.zoom
 

--- a/src/ui_widgets/BetterButton.gd
+++ b/src/ui_widgets/BetterButton.gd
@@ -9,6 +9,11 @@ var timer: SceneTreeTimer
 
 ## A shortcut that corresponds to the same action that this button does.
 @export var action := ""
+var shortcuts_bind: ShortcutsRegistration:
+	set(new_value):
+		shortcuts_bind = new_value
+		if is_instance_valid(shortcuts_bind):
+			shortcuts_bind.activated.connect(_on_shortcut_activated)
 
 
 func _ready() -> void:
@@ -46,21 +51,20 @@ func _on_pressed() -> void:
 	set_deferred("just_pressed", false)
 	HandlerGUI.throw_action_event(action)
 
-func _unhandled_input(event: InputEvent) -> void:
-	if action.is_empty() or toggle_mode:
+func _on_shortcut_activated(activated_action: String) -> void:
+	if activated_action != action or toggle_mode or just_pressed:
 		return
 	
-	if not just_pressed and ShortcutUtils.is_action_pressed(event, action):
-		begin_bulk_theme_override()
-		add_theme_color_override("icon_normal_color", get_theme_color("icon_pressed_color"))
-		add_theme_color_override("icon_hover_color", get_theme_color("icon_pressed_color"))
-		add_theme_stylebox_override("normal", get_theme_stylebox("pressed"))
-		add_theme_stylebox_override("hover", get_theme_stylebox("hover_pressed"))
-		end_bulk_theme_override()
-		if is_instance_valid(timer):
-			timer.timeout.disconnect(end_highlight)
-		timer = get_tree().create_timer(HIGHLIGHT_TIME)
-		timer.timeout.connect(end_highlight)
+	begin_bulk_theme_override()
+	add_theme_color_override("icon_normal_color", get_theme_color("icon_pressed_color"))
+	add_theme_color_override("icon_hover_color", get_theme_color("icon_pressed_color"))
+	add_theme_stylebox_override("normal", get_theme_stylebox("pressed"))
+	add_theme_stylebox_override("hover", get_theme_stylebox("hover_pressed"))
+	end_bulk_theme_override()
+	if is_instance_valid(timer):
+		timer.timeout.disconnect(end_highlight)
+	timer = get_tree().create_timer(HIGHLIGHT_TIME)
+	timer.timeout.connect(end_highlight)
 
 func end_highlight() -> void:
 	begin_bulk_theme_override()

--- a/src/ui_widgets/PanelGrid.gd
+++ b/src/ui_widgets/PanelGrid.gd
@@ -1,6 +1,8 @@
 @icon("res://godot_only/icons/PanelGrid.svg")
 class_name PanelGrid extends Control
 
+const copy_icon = preload("res://assets/icons/Copy.svg")
+
 # Can be made into vars if necessary.
 const border_width = 1
 const side_spacing = 6
@@ -11,8 +13,15 @@ const bottom_spacing = 2
 @export var items: PackedStringArray
 @export var dim_last_item := false
 
+var boxes: Array[Rect2] = []
+var copy_button: Button
+
+
+func _ready() -> void:
+	mouse_exited.connect(remove_copy_button)
 
 func _draw() -> void:
+	boxes.clear()
 	var item_count := items.size()
 	if item_count == 0:
 		return
@@ -31,28 +40,60 @@ func _draw() -> void:
 	
 	custom_minimum_size.y = box_height * ceili(item_count / float(effective_columns))
 	
+	# One big filled rect for everything but the last row.
 	@warning_ignore("integer_division")
 	RenderingServer.canvas_item_add_rect(ci, Rect2(0, 0, size.x,
 			box_height * (item_count / effective_columns)), inner_color)
 	
-	for item_idx in item_count:
-		var pos_x := (size.x / effective_columns) * (item_idx % effective_columns)
+	for idx in item_count:
+		var pos_x := (size.x / effective_columns) * (idx % effective_columns)
 		@warning_ignore("integer_division")
-		var pos_y := box_height * (item_idx / effective_columns)
+		var pos_y := box_height * (idx / effective_columns)
 		
-		if item_idx == item_count - 1:
+		# Sigh...
+		var box_rect := Rect2(pos_x, pos_y, box_width, box_height)
+		if is_zero_approx(pos_x):
+			box_rect = Rect2(1, pos_y, box_width - 1, box_height)
+		boxes.append(box_rect)
+		
+		if idx == item_count - 1:
 			if item_count % effective_columns != 0:
-				RenderingServer.canvas_item_add_rect(ci,
-						Rect2(pos_x, pos_y, box_width, box_height), inner_color)
+				RenderingServer.canvas_item_add_rect(ci, box_rect, inner_color)
 			if dim_last_item:
 				text_color = ThemeUtils.dimmer_text_color
 		
-		# Sigh...
-		if is_zero_approx(pos_x):
-			draw_rect(Rect2(1, pos_y, box_width - 1, box_height), border_color, false, 1.0)
-		else:
-			draw_rect(Rect2(pos_x, pos_y, box_width, box_height), border_color, false, 1.0)
-		
+		draw_rect(box_rect, border_color, false, 1.0)
 		text_font.draw_string(ci, Vector2(pos_x + side_spacing, pos_y + top_spacing +\
-				text_font_size), items[item_idx], HORIZONTAL_ALIGNMENT_LEFT, -1,
+				text_font_size), items[idx], HORIZONTAL_ALIGNMENT_LEFT, -1,
 				text_font_size, text_color)
+
+
+func _gui_input(event: InputEvent) -> void:
+	if not (event is InputEventMouseMotion):
+		return
+	
+	for idx in items.size():
+		var item := items[idx]
+		var item_after_angle_bracket := item.get_slice("<", 1)
+		if not item_after_angle_bracket.is_empty():
+			if ">" in item_after_angle_bracket:
+				var email := item_after_angle_bracket.get_slice(">", 0)
+				var box := boxes[idx]
+				if box.has_point(event.position):
+					if not is_instance_valid(copy_button):
+						copy_button = Button.new()
+						copy_button.theme_type_variation = "FlatButton"
+						copy_button.icon = copy_icon
+						copy_button.focus_mode = Control.FOCUS_NONE
+						copy_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+						copy_button.mouse_filter = Control.MOUSE_FILTER_PASS
+						copy_button.tooltip_text = Translator.translate("Copy email")
+						copy_button.pressed.connect(DisplayServer.clipboard_set.bind(email))
+						add_child(copy_button)
+						copy_button.position = Vector2(box.end.x - copy_button.size.x - 1, box.position.y + 1)
+					return
+	remove_copy_button()
+
+func remove_copy_button() -> void:
+	if is_instance_valid(copy_button):
+		copy_button.queue_free()

--- a/src/ui_widgets/good_color_picker.gd
+++ b/src/ui_widgets/good_color_picker.gd
@@ -143,6 +143,11 @@ func update_keyword_button() -> void:
 		keyword_button.show()
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
+	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	Configs.theme_changed.connect(sync_color_space_buttons)
 	sync_color_space_buttons()
 	# Set up signals.
@@ -218,8 +223,7 @@ func set_display_color(new_display_color: Color) -> void:
 func update() -> void:
 	# Adjust the shaders.
 	tracks_arr[0].material.set_shader_parameter("v", display_color.v)
-	tracks_arr[0].material.set_shader_parameter("base_color",
-			Color.from_hsv(display_color.h, display_color.s, 1.0))
+	tracks_arr[0].material.set_shader_parameter("base_color", Color.from_hsv(display_color.h, display_color.s, 1.0))
 	tracks_arr[1].material.set_shader_parameter("base_color", display_color)
 	tracks_arr[2].material.set_shader_parameter("base_color", display_color)
 	tracks_arr[3].material.set_shader_parameter("base_color", display_color)
@@ -255,11 +259,9 @@ func _on_color_wheel_gui_input(event: InputEvent) -> void:
 		backup()
 	var new_color := display_color
 	if Utils.is_event_drag(event) or is_event_drag_start:
-		var event_pos_on_wheel: Vector2 = event.position + color_wheel.position -\
-				color_wheel_drawn.position
+		var event_pos_on_wheel: Vector2 = event.position + color_wheel.position - color_wheel_drawn.position
 		new_color.h = fposmod(center.angle_to_point(event_pos_on_wheel), TAU) / TAU
-		new_color.s = minf(event_pos_on_wheel.distance_to(center) * 2 /\
-				color_wheel_drawn.size.x, 1.0)
+		new_color.s = minf(event_pos_on_wheel.distance_to(center) * 2 / color_wheel_drawn.size.x, 1.0)
 		set_display_color(new_color)
 	if Utils.is_event_drag_end(event):
 		register_visual_change(display_color)
@@ -527,18 +529,6 @@ func hex(col: Color) -> String:
 		col.h = 1.0
 	
 	return col.to_html(alpha_enabled and col.a != 1.0)
-
-
-func _unhandled_input(event: InputEvent) -> void:
-	if not visible:
-		return
-	
-	if ShortcutUtils.is_action_pressed(event, "ui_undo"):
-		undo_redo.undo()
-		accept_event()
-	elif ShortcutUtils.is_action_pressed(event, "ui_redo"):
-		undo_redo.redo()
-		accept_event()
 
 
 func _on_eyedropper_pressed() -> void:

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -150,9 +150,9 @@ func _unhandled_input(event: InputEvent) -> void:
 		set_value(initial_slider_value)
 		accept_event()
 
+
 func get_slider_value_at_y(y_coord: float) -> float:
-	return snappedf(lerpf(MAX_VALUE, MIN_VALUE,
-			(y_coord - 4) / (temp_button.size.y - 4)), SLIDER_STEP)
+	return snappedf(lerpf(MAX_VALUE, MIN_VALUE, (y_coord - 4) / (temp_button.size.y - 4)), SLIDER_STEP)
 
 func _on_slider_mouse_exited() -> void:
 	slider_hovered = false

--- a/src/ui_widgets/settings_content_shortcuts.gd
+++ b/src/ui_widgets/settings_content_shortcuts.gd
@@ -20,6 +20,11 @@ func get_translated_shortcut_tab(tab_idx: String) -> String:
 	return ""
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
+	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	var button_group := ButtonGroup.new()
 	for tab_idx in shortcut_tab_names:
 		var btn := Button.new()
@@ -36,12 +41,6 @@ func _ready() -> void:
 		categories_container.add_child(btn)
 	categories_container.get_child(0).button_pressed = true
 	categories_container.get_child(0).pressed.emit()
-
-func _unhandled_input(event: InputEvent) -> void:
-	if ShortcutUtils.is_action_pressed(event, "ui_undo"):
-		undo_redo.undo()
-	elif ShortcutUtils.is_action_pressed(event, "ui_redo"):
-		undo_redo.redo()
 
 
 func show_shortcuts(category: String) -> void:

--- a/src/ui_widgets/transform_popup.gd
+++ b/src/ui_widgets/transform_popup.gd
@@ -29,6 +29,11 @@ var undo_redo := UndoRedoRef.new()
 @onready var apply_matrix: Button = %ApplyMatrix
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
+	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	Configs.language_changed.connect(sync_localization)
 	add_button.pressed.connect(popup_new_transform_context.bind(0, add_button))
 	apply_matrix.pressed.connect(_on_apply_matrix_pressed)
@@ -177,15 +182,6 @@ func popup_new_transform_context(idx: int, control: Control) -> void:
 	var transform_context := ContextPopup.new()
 	transform_context.setup_with_title(btn_array, Translator.translate("New transform"), true)
 	HandlerGUI.popup_under_rect_center(transform_context, control.get_global_rect(), get_viewport())
-
-
-func _unhandled_input(event: InputEvent) -> void:
-	if ShortcutUtils.is_action_pressed(event, "ui_undo"):
-		undo_redo.undo()
-		accept_event()
-	elif ShortcutUtils.is_action_pressed(event, "ui_redo"):
-		undo_redo.redo()
-		accept_event()
 
 
 # So I have to rebuild this in its entirety to keep the references safe or something...

--- a/src/ui_widgets/zoom_menu.gd
+++ b/src/ui_widgets/zoom_menu.gd
@@ -6,23 +6,22 @@ const MAX_ZOOM = 512.0
 signal zoom_changed(zoom_level: float, offset: Vector2)
 signal zoom_reset_pressed
 
-@onready var zoom_out_button: Button = $ZoomOut
-@onready var zoom_in_button: Button = $ZoomIn
-@onready var zoom_reset_button: Button = $ZoomReset
+@onready var zoom_out_button: BetterButton = $ZoomOut
+@onready var zoom_in_button: BetterButton = $ZoomIn
+@onready var zoom_reset_button: BetterButton = $ZoomReset
 
 var _zoom_level: float
 
 
-func _unhandled_input(event: InputEvent) -> void:
-	if ShortcutUtils.is_action_pressed(event, "zoom_in"):
-		zoom_in()
-		accept_event()
-	elif ShortcutUtils.is_action_pressed(event, "zoom_out"):
-		zoom_out()
-		accept_event()
-	elif ShortcutUtils.is_action_pressed(event, "zoom_reset"):
-		zoom_reset()
-		accept_event()
+func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("zoom_in", zoom_in)
+	shortcuts.add_shortcut("zoom_out", zoom_out)
+	shortcuts.add_shortcut("zoom_reset", zoom_reset)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	zoom_out_button.shortcuts_bind = shortcuts
+	zoom_in_button.shortcuts_bind = shortcuts
+	zoom_reset_button.shortcuts_bind = shortcuts
 
 
 func set_zoom(new_value: float, offset := Vector2(0.5, 0.5)) -> void:

--- a/src/ui_widgets/zoom_menu.tscn
+++ b/src/ui_widgets/zoom_menu.tscn
@@ -6,6 +6,7 @@
 [ext_resource type="Script" uid="uid://ynx3s1jc6bwq" path="res://src/ui_widgets/BetterButton.gd" id="3_vgfv3"]
 
 [node name="ZoomMenu" type="HBoxContainer"]
+anchors_preset = -1
 offset_right = 114.0
 offset_bottom = 24.0
 alignment = 1

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -1,26 +1,5 @@
 @abstract class_name ShortcutUtils
 
-# Can be activated in all contexts.
-const UNIVERSAL_ACTIONS: PackedStringArray = ["quit", "toggle_fullscreen", "about_info",
-		"about_donate", "check_updates", "open_settings", "about_repo", "about_website",
-		"open_externally", "open_in_folder"]
-
-# Requires there being no dialogs.
-const EFFECT_ACTIONS: PackedStringArray = ["view_show_grid", "view_show_handles",
-		"view_rasterized_svg", "view_show_reference", "view_overlay_reference",
-		"load_reference", "toggle_snap"]
-
-# Requires there being no popups either.
-const EDITOR_ACTIONS: PackedStringArray = ["import", "export", "save", "save_as",
-		"close_tab", "close_all_other_tabs", "close_tabs_to_left", "close_tabs_to_right",
-		"close_empty_tabs", "close_saved_tabs", "new_tab", "select_next_tab",
-		"select_previous_tab", "copy_svg_text", "optimize", "reset_svg", "debug"]
-
-# Requires no drag-and-drop actions ongoing.
-const PRISTINE_ACTIONS: PackedStringArray = ["ui_undo", "ui_redo", "ui_cancel", "delete",
-		"move_up", "move_down", "duplicate", "select_all"]
-
-
 # The bool after each action is for whether the action can be modified.
 const _action_categories_dict: Dictionary[String, Dictionary] = {
 	"file": {

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -177,7 +177,8 @@ static func recalculate_colors() -> void:
 	contrast_flat_panel_color = Color(tinted_contrast_color, 0.1)
 	overlay_panel_inner_color = base_color.lerp(extreme_theme_color, 0.1)
 	overlay_panel_border_color = base_color.lerp(max_contrast_color, 0.32)
-	overlay_panel_border_color.s = minf(overlay_panel_border_color.s * 2.0, lerpf(overlay_panel_border_color.s, 1.0, 0.2))
+	overlay_panel_border_color.s = minf(overlay_panel_border_color.s * 4.0, lerpf(overlay_panel_border_color.s, 1.0, 0.6))
+	overlay_panel_border_color.v = lerpf(overlay_panel_border_color.v, 1.0, 0.125)
 	
 	scrollbar_pressed_color = intermediate_color.blend(Color(tinted_contrast_color.lerp(
 			accent_color.lerp(max_contrast_color, 0.1), 0.2), 0.4))


### PR DESCRIPTION
Shortcuts are now handled through a registration system. Every control that wants its own shortcuts must register them in HandlerGUI by passing the action name, a callable, and a mode (e.g., no passthrough, pass through popups, etc.)

Fixes #1422

Also makes emails in the translators list copyable.