### PR TITLE
Isolate debug content

### DIFF
--- a/src/ui_parts/debug_content.gd
+++ b/src/ui_parts/debug_content.gd
@@ -1,0 +1,51 @@
+extends VBoxContainer
+
+@onready var debug_label: Label = $DebugLabel
+@onready var input_debug_label: Label = $InputDebugLabel
+
+func _ready() -> void:
+	State.show_debug_changed.connect(_on_show_debug_changed)
+	_on_show_debug_changed()
+	get_window().window_input.connect(_update_input_debug)
+
+func _on_show_debug_changed() -> void:
+	if State.show_debug:
+		show()
+		update_debug()
+		input_debug_label.text = ""
+	else:
+		hide()
+
+# The strings here are intentionally not localized.
+func update_debug() -> void:
+	var debug_text := ""
+	debug_text += "FPS: %d\n" % Performance.get_monitor(Performance.TIME_FPS)
+	debug_text += "Static Mem: %s\n" % String.humanize_size(int(Performance.get_monitor(Performance.MEMORY_STATIC)))
+	debug_text += "Nodes: %d\n" % Performance.get_monitor(Performance.OBJECT_NODE_COUNT)
+	debug_text += "Stray nodes: %d\n" % Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
+	debug_text += "Objects: %d\n" % Performance.get_monitor(Performance.OBJECT_COUNT)
+	debug_label.text = debug_text
+	# Set up the next update if the container is still visible.
+	if visible:
+		get_tree().create_timer(1.0).timeout.connect(update_debug)
+
+var last_event_text := ""
+var last_event_repeat_count := 1
+
+func _update_input_debug(event: InputEvent) -> void:
+	if visible and event.is_pressed():
+		var new_text := input_debug_label.text
+		var event_text := event.as_text()
+		if event is InputEventMouse:
+			event_text += " (" + String.num(event.position.x, 2) + ", " + String.num(event.position.y, 2) + ")"
+		if event_text == last_event_text:
+			last_event_repeat_count += 1
+			new_text = new_text.left(new_text.rfind("\n", new_text.length() - 2) + 1)
+			event_text += " (%d)" % last_event_repeat_count
+		else:
+			last_event_text = event_text
+			last_event_repeat_count = 1
+		if new_text.count("\n") >= 5:
+			new_text = new_text.right(-new_text.find("\n") - 1)
+		new_text += event_text + "\n"
+		input_debug_label.text = new_text

--- a/src/ui_parts/debug_content.gd.uid
+++ b/src/ui_parts/debug_content.gd.uid
@@ -1,0 +1,1 @@
+uid://mtwptdpc3cxs

--- a/src/ui_parts/display.tscn
+++ b/src/ui_parts/display.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://bvrncl7e6yn5b"]
+[gd_scene load_steps=17 format=3 uid="uid://bvrncl7e6yn5b"]
 
 [ext_resource type="Script" uid="uid://bxmb134e3sqpr" path="res://src/ui_parts/display.gd" id="1_oib5g"]
 [ext_resource type="Texture2D" uid="uid://iglrqrqyg4kn" path="res://assets/icons/Reference.svg" id="4_2hiq7"]
@@ -14,6 +14,7 @@
 [ext_resource type="Texture2D" uid="uid://c68og6bsqt0lb" path="res://assets/icons/Checkerboard.svg" id="11_1bm1s"]
 [ext_resource type="Script" uid="uid://dtplje5mhdmrj" path="res://src/ui_parts/display_texture.gd" id="12_qi23s"]
 [ext_resource type="Script" uid="uid://csqewpxr21ywy" path="res://src/ui_parts/handles_manager.gd" id="13_lwhwy"]
+[ext_resource type="Script" uid="uid://mtwptdpc3cxs" path="res://src/ui_parts/debug_content.gd" id="15_ryr8t"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_kqplg"]
 shader = ExtResource("10_x7ybk")
@@ -144,7 +145,6 @@ mouse_filter = 1
 script = ExtResource("13_lwhwy")
 
 [node name="DebugMargins" type="MarginContainer" parent="ViewportPanel"]
-visible = false
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
@@ -152,13 +152,14 @@ mouse_filter = 2
 theme_override_constants/margin_top = 36
 theme_override_constants/margin_right = 10
 
-[node name="DebugContainer" type="VBoxContainer" parent="ViewportPanel/DebugMargins"]
+[node name="DebugContent" type="VBoxContainer" parent="ViewportPanel/DebugMargins"]
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = -18
+script = ExtResource("15_ryr8t")
 
-[node name="DebugLabel" type="Label" parent="ViewportPanel/DebugMargins/DebugContainer"]
+[node name="DebugLabel" type="Label" parent="ViewportPanel/DebugMargins/DebugContent"]
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -167,7 +168,7 @@ theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 14
 horizontal_alignment = 2
 
-[node name="InputDebugLabel" type="Label" parent="ViewportPanel/DebugMargins/DebugContainer"]
+[node name="InputDebugLabel" type="Label" parent="ViewportPanel/DebugMargins/DebugContent"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.75, 0.75, 0.75, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -10,43 +10,12 @@ const ViewportScene = preload("res://src/ui_parts/display.tscn")
 
 func _ready() -> void:
 	var shortcuts := ShortcutsRegistration.new()
-	shortcuts.add_shortcut("view_show_grid", State.toggle_show_grid, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("view_show_handles", State.toggle_show_handles, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("view_rasterized_svg", State.toggle_view_rasterized, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("view_show_reference", func() -> void:
-			Configs.savedata.get_active_tab().show_reference = not Configs.savedata.get_active_tab().show_reference,
-			ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("view_overlay_reference", func() -> void:
-			Configs.savedata.get_active_tab().overlay_reference = not Configs.savedata.get_active_tab().overlay_reference,
-			ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("load_reference", FileUtils.open_image_import_dialog, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("toggle_snap", func() -> void: Configs.savedata.snap *= -1, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	shortcuts.add_shortcut("import", FileUtils.open_svg_import_dialog, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
 	shortcuts.add_shortcut("export", HandlerGUI.open_export, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
 	shortcuts.add_shortcut("save", FileUtils.save_svg, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	shortcuts.add_shortcut("save_as", FileUtils.save_svg_as, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_tab", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index()),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_all_other_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.ALL_OTHERS),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_tabs_to_left", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_LEFT),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_tabs_to_right", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_RIGHT),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_empty_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.EMPTY),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("close_saved_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.SAVED),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("new_tab", Configs.savedata.add_empty_tab, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("select_next_tab",
-			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() + 1, Configs.savedata.get_tab_count())),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
-	shortcuts.add_shortcut("select_previous_tab",
-			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() - 1, Configs.savedata.get_tab_count())),
-			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
 	shortcuts.add_shortcut("optimize", State.optimize, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
 	shortcuts.add_shortcut("reset_svg", FileUtils.reset_svg, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
-	shortcuts.add_shortcut("debug", State.toggle_show_debug)
 	shortcuts.add_shortcut("ui_undo", func() -> void: Configs.savedata.get_active_tab().undo(), ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
 	shortcuts.add_shortcut("ui_redo", func() -> void: Configs.savedata.get_active_tab().redo(), ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)
 	shortcuts.add_shortcut("ui_cancel", State.clear_all_selections, ShortcutsRegistration.Behavior.STRICT_NO_PASSTHROUGH)

--- a/src/ui_parts/tab_bar.gd
+++ b/src/ui_parts/tab_bar.gd
@@ -27,6 +27,28 @@ var proposed_drop_idx := -1:
 			queue_redraw()
 
 func _ready() -> void:
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("close_tab", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index()),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_all_other_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.ALL_OTHERS),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_tabs_to_left", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_LEFT),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_tabs_to_right", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.TO_RIGHT),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_empty_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.EMPTY),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("close_saved_tabs", func() -> void: FileUtils.close_tabs(Configs.savedata.get_active_tab_index(), FileUtils.TabCloseMode.SAVED),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("new_tab", Configs.savedata.add_empty_tab, ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("select_next_tab",
+			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() + 1, Configs.savedata.get_tab_count())),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	shortcuts.add_shortcut("select_previous_tab",
+			func() -> void: Configs.savedata.set_active_tab_index(posmod(Configs.savedata.get_active_tab_index() - 1, Configs.savedata.get_tab_count())),
+			ShortcutsRegistration.Behavior.PASS_THROUGH_POPUPS)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
 	Configs.active_tab_changed.connect(activate)
 	Configs.tabs_changed.connect(activate)
 	Configs.active_tab_changed.connect(scroll_to_active)
@@ -119,8 +141,7 @@ func _draw() -> void:
 			icon_modulate = get_theme_color("icon_disabled_color", "Button")
 		else:
 			var line_x := scroll_forwards_rect.position.x
-			draw_line(Vector2(line_x, 0), Vector2(line_x, size.y),
-					ThemeUtils.basic_panel_border_color)
+			draw_line(Vector2(line_x, 0), Vector2(line_x, size.y), ThemeUtils.basic_panel_border_color)
 			if scroll_forwards_rect.has_point(mouse_pos):
 				var stylebox_theme := "pressed" if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT) else "hover"
 				get_theme_stylebox(stylebox_theme, "FlatButton").draw(ci, scroll_forwards_rect)
@@ -134,8 +155,7 @@ func _draw() -> void:
 			x_pos = prev_tab_rect.end.x
 		else:
 			x_pos = get_tab_rect(proposed_drop_idx).position.x
-		draw_line(Vector2(x_pos, 0), Vector2(x_pos, size.y),
-				Configs.savedata.basic_color_valid, 4)
+		draw_line(Vector2(x_pos, 0), Vector2(x_pos, size.y), Configs.savedata.basic_color_valid, 4)
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -196,24 +216,16 @@ func _gui_input(event: InputEvent) -> void:
 							has_saved_tabs = true
 							break
 					
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_tab"))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_tab"))
 					# TODO Unify into "Close multiple tabs"
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_all_other_tabs", tab_count < 2))
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_tabs_to_left", hovered_idx == 0))
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_tabs_to_right", hovered_idx == tab_count - 1))
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_empty_tabs", not has_empty_tabs))
-					btn_arr.append(ContextPopup.create_shortcut_button_without_icon(
-							"close_saved_tabs", not has_saved_tabs))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_all_other_tabs", tab_count < 2))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_tabs_to_left", hovered_idx == 0))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_tabs_to_right", hovered_idx == tab_count - 1))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_empty_tabs", not has_empty_tabs))
+					btn_arr.append(ContextPopup.create_shortcut_button_without_icon("close_saved_tabs", not has_saved_tabs))
 					
-					btn_arr.append(ContextPopup.create_shortcut_button("open_externally",
-							file_absent))
-					btn_arr.append(ContextPopup.create_shortcut_button("open_in_folder",
-							file_absent))
+					btn_arr.append(ContextPopup.create_shortcut_button("open_externally", file_absent))
+					btn_arr.append(ContextPopup.create_shortcut_button("open_in_folder", file_absent))
 				var tab_popup := ContextPopup.new()
 				tab_popup.setup(btn_arr, true, -1, -1, PackedInt32Array([6]))
 				


### PR DESCRIPTION
The debug content is completely independent of everything else, so display.gd doesn't need to handle it. I've made it into its own script. Also moves various shortcuts to more appropriate places, like tab-related shortcuts are now tied to the tab bar. Even though currently the tab bar and viewport are always active, this makes more sense and might make some future changes require less moving things around.