### PR TITLE
Isolate debug logic

### DIFF
--- a/src/autoload/State.gd
+++ b/src/autoload/State.gd
@@ -240,12 +240,10 @@ func set_zoom(new_value: float) -> void:
 var view_rasterized := false
 var show_grid := true
 var show_handles := true
-var show_debug := false
 
 signal view_rasterized_changed
 signal show_grid_changed
 signal show_handles_changed
-signal show_debug_changed
 
 func toggle_view_rasterized() -> void:
 	view_rasterized = not view_rasterized
@@ -258,10 +256,6 @@ func toggle_show_grid() -> void:
 func toggle_show_handles() -> void:
 	show_handles = not show_handles
 	show_handles_changed.emit()
-
-func toggle_show_debug() -> void:
-	show_debug = not show_debug
-	show_debug_changed.emit()
 
 
 # Override the selected elements with a single new selected element.

--- a/src/ui_parts/debug_content.gd
+++ b/src/ui_parts/debug_content.gd
@@ -1,20 +1,25 @@
-extends VBoxContainer
+extends MarginContainer
 
-@onready var debug_label: Label = $DebugLabel
-@onready var input_debug_label: Label = $InputDebugLabel
+@onready var debug_label: Label = $DebugContainer/DebugLabel
+@onready var input_debug_label: Label = $DebugContainer/InputDebugLabel
+@onready var debug_container: VBoxContainer = $DebugContainer
 
 func _ready() -> void:
-	State.show_debug_changed.connect(_on_show_debug_changed)
-	_on_show_debug_changed()
+	var shortcuts := ShortcutsRegistration.new()
+	shortcuts.add_shortcut("debug", toggle_debug_visibility)
+	HandlerGUI.register_shortcuts(self, shortcuts)
+	
+	set_debug_visibility(false)
 	get_window().window_input.connect(_update_input_debug)
 
-func _on_show_debug_changed() -> void:
-	if State.show_debug:
-		show()
-		update_debug()
+func toggle_debug_visibility() -> void:
+	set_debug_visibility(not debug_container.visible)
+
+func set_debug_visibility(visibility: bool) -> void:
+	debug_container.visible = visibility
+	if visible:
 		input_debug_label.text = ""
-	else:
-		hide()
+		update_debug()
 
 # The strings here are intentionally not localized.
 func update_debug() -> void:

--- a/src/ui_parts/debug_content.tscn
+++ b/src/ui_parts/debug_content.tscn
@@ -2,12 +2,24 @@
 
 [ext_resource type="Script" uid="uid://mtwptdpc3cxs" path="res://src/ui_parts/debug_content.gd" id="1_7pqvx"]
 
-[node name="DebugContent" type="VBoxContainer"]
+[node name="DebugContent" type="MarginContainer"]
+anchors_preset = -1
+offset_top = 4.0
+offset_right = 10.0
+offset_bottom = 40.0
+size_flags_horizontal = 8
+size_flags_vertical = 0
 mouse_filter = 2
-theme_override_constants/separation = -18
+theme_override_constants/margin_top = 36
+theme_override_constants/margin_right = 10
 script = ExtResource("1_7pqvx")
 
-[node name="DebugLabel" type="Label" parent="."]
+[node name="DebugContainer" type="VBoxContainer" parent="."]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/separation = -18
+
+[node name="DebugLabel" type="Label" parent="DebugContainer"]
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
@@ -16,7 +28,7 @@ theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 14
 horizontal_alignment = 2
 
-[node name="InputDebugLabel" type="Label" parent="."]
+[node name="InputDebugLabel" type="Label" parent="DebugContainer"]
 layout_mode = 2
 theme_override_colors/font_color = Color(0.75, 0.75, 0.75, 1)
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -25,7 +25,6 @@ func _ready() -> void:
 			Configs.savedata.get_active_tab().overlay_reference = not Configs.savedata.get_active_tab().overlay_reference,
 			ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	shortcuts.add_shortcut("toggle_snap", func() -> void: Configs.savedata.snap *= -1, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
-	shortcuts.add_shortcut("debug", State.toggle_show_debug)
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
 	zoom_widget.setup_limits(Canvas.MIN_ZOOM, Canvas.MAX_ZOOM)

--- a/src/ui_parts/display.tscn
+++ b/src/ui_parts/display.tscn
@@ -101,13 +101,5 @@ stretch = true
 script = ExtResource("9_ryr8t")
 metadata/_custom_type_script = "uid://8bxv5i60h8rb"
 
-[node name="DebugMargins" type="MarginContainer" parent="ViewportPanel"]
-layout_mode = 2
-size_flags_horizontal = 8
-size_flags_vertical = 0
-mouse_filter = 2
-theme_override_constants/margin_top = 36
-theme_override_constants/margin_right = 10
-
-[node name="DebugContent" parent="ViewportPanel/DebugMargins" instance=ExtResource("15_ryr8t")]
+[node name="DebugContent" parent="ViewportPanel" instance=ExtResource("15_ryr8t")]
 layout_mode = 2

--- a/src/ui_parts/mac_menu.gd
+++ b/src/ui_parts/mac_menu.gd
@@ -1,214 +1,211 @@
 # The MacOS-specific top menu.
 extends Node
 
-var global_rid: RID
-var appl_rid: RID
-var help_rid: RID
+# TODO This made things really complicated during a refactor, it's to be reinstated in the future.
 
-var file_rid: RID
-var file_idx: int
-var file_optimize_idx: int
-var file_reset_svg_idx: int
-
-var edit_rid: RID
-var edit_idx: int
-var tool_rid: RID
-var tool_idx: int
-
-var view_rid: RID
-var view_idx: int
-var view_show_grid_idx: int
-var view_show_handles_idx: int
-var view_rasterized_svg_idx: int
-var view_show_reference_idx: int
-var view_overlay_reference_idx: int
-var view_show_debug_idx: int
-
-var snap_rid: RID
-var snap_idx: int
-var snap_enable_idx: int
-var snap_0125_idx: int
-var snap_025_idx: int
-var snap_05_idx: int
-var snap_1_idx: int
-var snap_2_idx: int
-var snap_4_idx: int
-
-
-func _enter_tree() -> void:
-	# Included menus
-	global_rid = NativeMenu.get_system_menu(NativeMenu.MAIN_MENU_ID)
-	appl_rid = NativeMenu.get_system_menu(NativeMenu.APPLICATION_MENU_ID)
-	help_rid = NativeMenu.get_system_menu(NativeMenu.HELP_MENU_ID)
-	# Custom menus
-	_generate_main_menus()
-	_setup_menu_items()
-	# Updates
-	Configs.language_changed.connect(_reset_menus)
-	Configs.shortcuts_changed.connect(_reset_menus)
-	# For now only keep check items up to date. Disabling things reliably is complicated.
-	Configs.snap_changed.connect(_on_snap_changed)
-	State.view_rasterized_changed.connect(_on_view_rasterized_changed)
-	State.show_grid_changed.connect(_on_show_grid_changed)
-	State.show_handles_changed.connect(_on_show_handles_changed)
-	Configs.active_tab_reference_changed.connect(_on_active_tab_reference_changed)
-	State.show_debug_changed.connect(_on_show_debug_changed)
-	# Updating checked items didn't work without the await.
-	await get_tree().process_frame
-	_on_snap_changed()
-	_on_view_rasterized_changed()
-	_on_show_grid_changed()
-	_on_show_handles_changed()
-	_on_active_tab_reference_changed()
-	_on_show_debug_changed()
-
-
-func _reset_menus() -> void:
-	NativeMenu.remove_item(global_rid, snap_idx)
-	NativeMenu.remove_item(global_rid, view_idx)
-	NativeMenu.remove_item(global_rid, tool_idx)
-	NativeMenu.remove_item(global_rid, edit_idx)
-	NativeMenu.remove_item(global_rid, file_idx)
-	NativeMenu.free_menu(file_rid)
-	NativeMenu.free_menu(edit_rid)
-	NativeMenu.free_menu(tool_rid)
-	NativeMenu.free_menu(view_rid)
-	NativeMenu.free_menu(snap_rid)
-	_generate_main_menus()
-	_setup_menu_items()
-
-
-func _generate_main_menus() -> void:
-	file_rid = NativeMenu.create_menu()
-	edit_rid = NativeMenu.create_menu()
-	tool_rid = NativeMenu.create_menu()
-	view_rid = NativeMenu.create_menu()
-	snap_rid = NativeMenu.create_menu()
-	file_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("File"), file_rid)
-	edit_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Edit"), edit_rid)
-	tool_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Tool"), tool_rid)
-	view_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("View"), view_rid)
-	snap_idx = NativeMenu.add_submenu_item(global_rid,
-			Translator.translate("Snap"), snap_rid)
-
-
-func _clear_menu_items() -> void:
-	NativeMenu.clear(appl_rid)
-	NativeMenu.clear(help_rid)
-	NativeMenu.clear(file_rid)
-	NativeMenu.clear(edit_rid)
-	NativeMenu.clear(tool_rid)
-	NativeMenu.clear(view_rid)
-	NativeMenu.clear(snap_rid)
-
-
-func _setup_menu_items() -> void:
-	_clear_menu_items()
-	_add_item(appl_rid, "open_settings")
-	# Help menu.
-	_add_icon_item(help_rid, "open_settings")
-	_add_icon_item(help_rid, "about_repo")
-	_add_icon_item(help_rid, "about_info")
-	_add_icon_item(help_rid, "about_donate")
-	_add_icon_item(help_rid, "about_website")
-	_add_icon_item(help_rid, "check_updates")
-	# File menu.
-	_add_many_items(file_rid, PackedStringArray(["import", "export", "save", "save_as"]))
-	NativeMenu.add_separator(file_rid)
-	_add_item(file_rid, "copy_svg_text")
-	file_optimize_idx = _add_item(file_rid, "optimize")
-	NativeMenu.add_separator(file_rid)
-	file_reset_svg_idx = _add_item(file_rid, "reset_svg")
-	# Edit and Tool menus.
-	_add_many_items(edit_rid, ShortcutUtils.get_actions("edit"))
-	_add_many_items(tool_rid, ShortcutUtils.get_actions("tool"))
-	# View menu.
-	view_show_grid_idx = _add_check_item(view_rid, "view_show_grid")
-	view_show_handles_idx = _add_check_item(view_rid, "view_show_handles")
-	view_rasterized_svg_idx = _add_check_item(view_rid, "view_rasterized_svg")
-	NativeMenu.add_separator(view_rid)
-	view_show_reference_idx = _add_item(view_rid, "load_reference")
-	view_show_reference_idx = _add_check_item(view_rid, "view_show_reference")
-	view_overlay_reference_idx = _add_check_item(view_rid, "view_overlay_reference")
-	view_show_debug_idx = _add_check_item(view_rid, "view_show_debug")
-	NativeMenu.add_separator(view_rid)
-	_add_many_items(view_rid, PackedStringArray(["zoom_in", "zoom_out", "zoom_reset"]))
-	# Snap menu.
-	snap_enable_idx = _add_check_item(snap_rid, "toggle_snap")
-	NativeMenu.add_separator(snap_rid)
-	snap_0125_idx = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
-	snap_025_idx = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)
-	snap_05_idx = NativeMenu.add_radio_check_item(snap_rid, "0.5", _set_snap, _set_snap, 0.5)
-	snap_1_idx = NativeMenu.add_radio_check_item(snap_rid, "1", _set_snap, _set_snap, 1)
-	snap_2_idx = NativeMenu.add_radio_check_item(snap_rid, "2", _set_snap, _set_snap, 2)
-	snap_4_idx = NativeMenu.add_radio_check_item(snap_rid, "4", _set_snap, _set_snap, 4)
-
-
-func _add_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_item(menu_rid,
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name,
-			_get_action_keycode(action_name))
-
-func _add_many_items(menu_rid: RID, actions: PackedStringArray) -> void:
-	for action in actions:
-		_add_item(menu_rid, action)
-
-func _add_check_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_check_item(menu_rid,
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
-
-func _add_many_icon_items(menu_rid: RID, actions: PackedStringArray) -> void:
-	for action in actions:
-		_add_icon_item(menu_rid, action)
-
-func _add_icon_item(menu_rid: RID, action_name: String) -> int:
-	return NativeMenu.add_icon_item(menu_rid,
-			ShortcutUtils.get_action_icon(action_name),
-			TranslationUtils.get_action_description(action_name),
-			HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
-
-
-func _get_action_keycode(action: String) -> Key:
-	var shortcut := ShortcutUtils.get_action_first_valid_shortcut(action)
-	if is_instance_valid(shortcut):
-		return shortcut.get_keycode_with_modifiers()
-	return KEY_NONE
-
-
-func _on_view_rasterized_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.view_rasterized)
-
-func _on_show_grid_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_grid_idx, State.show_grid)
-
-func _on_show_handles_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_handles_idx, State.show_handles)
-
-func _on_active_tab_reference_changed() -> void:
-	var active_tab := Configs.savedata.get_active_tab()
-	var has_reference := is_instance_valid(active_tab.reference_image)
-	NativeMenu.set_item_checked(view_rid, view_show_reference_idx, has_reference and active_tab.show_reference)
-	NativeMenu.set_item_checked(view_rid, view_overlay_reference_idx, has_reference and active_tab.overlay_reference)
-
-func _on_show_debug_changed() -> void:
-	NativeMenu.set_item_checked(view_rid, view_show_debug_idx, State.show_debug)
-
-
-func _on_snap_changed() -> void:
-	var snap_amount := absf(Configs.savedata.snap)
-	NativeMenu.set_item_checked(snap_rid, snap_enable_idx, Configs.savedata.snap > 0)
-	NativeMenu.set_item_checked(snap_rid, snap_0125_idx, is_equal_approx(snap_amount, 0.125))
-	NativeMenu.set_item_checked(snap_rid, snap_025_idx, is_equal_approx(snap_amount, 0.25))
-	NativeMenu.set_item_checked(snap_rid, snap_05_idx, is_equal_approx(snap_amount, 0.5))
-	NativeMenu.set_item_checked(snap_rid, snap_1_idx, is_equal_approx(snap_amount, 1))
-	NativeMenu.set_item_checked(snap_rid, snap_2_idx, is_equal_approx(snap_amount, 2))
-	NativeMenu.set_item_checked(snap_rid, snap_4_idx, is_equal_approx(snap_amount, 4))
-
-func _set_snap(amount: float) -> void:
-	Configs.savedata.snap = amount
+#var global_rid: RID
+#var appl_rid: RID
+#var help_rid: RID
+#
+#var file_rid: RID
+#var file_idx: int
+#var file_optimize_idx: int
+#var file_reset_svg_idx: int
+#
+#var edit_rid: RID
+#var edit_idx: int
+#var tool_rid: RID
+#var tool_idx: int
+#
+#var view_rid: RID
+#var view_idx: int
+#var view_show_grid_idx: int
+#var view_show_handles_idx: int
+#var view_rasterized_svg_idx: int
+#var view_show_reference_idx: int
+#var view_overlay_reference_idx: int
+#var view_show_debug_idx: int
+#
+#var snap_rid: RID
+#var snap_idx: int
+#var snap_enable_idx: int
+#var snap_0125_idx: int
+#var snap_025_idx: int
+#var snap_05_idx: int
+#var snap_1_idx: int
+#var snap_2_idx: int
+#var snap_4_idx: int
+#
+#
+#func _enter_tree() -> void:
+	## Included menus
+	#global_rid = NativeMenu.get_system_menu(NativeMenu.MAIN_MENU_ID)
+	#appl_rid = NativeMenu.get_system_menu(NativeMenu.APPLICATION_MENU_ID)
+	#help_rid = NativeMenu.get_system_menu(NativeMenu.HELP_MENU_ID)
+	## Custom menus
+	#_generate_main_menus()
+	#_setup_menu_items()
+	## Updates
+	#Configs.language_changed.connect(_reset_menus)
+	#Configs.shortcuts_changed.connect(_reset_menus)
+	## For now only keep check items up to date. Disabling things reliably is complicated.
+	#Configs.snap_changed.connect(_on_snap_changed)
+	#State.view_rasterized_changed.connect(_on_view_rasterized_changed)
+	#State.show_grid_changed.connect(_on_show_grid_changed)
+	#State.show_handles_changed.connect(_on_show_handles_changed)
+	#Configs.active_tab_reference_changed.connect(_on_active_tab_reference_changed)
+	## Updating checked items didn't work without the await.
+	#await get_tree().process_frame
+	#_on_snap_changed()
+	#_on_view_rasterized_changed()
+	#_on_show_grid_changed()
+	#_on_show_handles_changed()
+	#_on_active_tab_reference_changed()
+#
+#
+#func _reset_menus() -> void:
+	#NativeMenu.remove_item(global_rid, snap_idx)
+	#NativeMenu.remove_item(global_rid, view_idx)
+	#NativeMenu.remove_item(global_rid, tool_idx)
+	#NativeMenu.remove_item(global_rid, edit_idx)
+	#NativeMenu.remove_item(global_rid, file_idx)
+	#NativeMenu.free_menu(file_rid)
+	#NativeMenu.free_menu(edit_rid)
+	#NativeMenu.free_menu(tool_rid)
+	#NativeMenu.free_menu(view_rid)
+	#NativeMenu.free_menu(snap_rid)
+	#_generate_main_menus()
+	#_setup_menu_items()
+#
+#
+#func _generate_main_menus() -> void:
+	#file_rid = NativeMenu.create_menu()
+	#edit_rid = NativeMenu.create_menu()
+	#tool_rid = NativeMenu.create_menu()
+	#view_rid = NativeMenu.create_menu()
+	#snap_rid = NativeMenu.create_menu()
+	#file_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("File"), file_rid)
+	#edit_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Edit"), edit_rid)
+	#tool_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Tool"), tool_rid)
+	#view_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("View"), view_rid)
+	#snap_idx = NativeMenu.add_submenu_item(global_rid,
+			#Translator.translate("Snap"), snap_rid)
+#
+#
+#func _clear_menu_items() -> void:
+	#NativeMenu.clear(appl_rid)
+	#NativeMenu.clear(help_rid)
+	#NativeMenu.clear(file_rid)
+	#NativeMenu.clear(edit_rid)
+	#NativeMenu.clear(tool_rid)
+	#NativeMenu.clear(view_rid)
+	#NativeMenu.clear(snap_rid)
+#
+#
+#func _setup_menu_items() -> void:
+	#_clear_menu_items()
+	#_add_item(appl_rid, "open_settings")
+	## Help menu.
+	#_add_icon_item(help_rid, "open_settings")
+	#_add_icon_item(help_rid, "about_repo")
+	#_add_icon_item(help_rid, "about_info")
+	#_add_icon_item(help_rid, "about_donate")
+	#_add_icon_item(help_rid, "about_website")
+	#_add_icon_item(help_rid, "check_updates")
+	## File menu.
+	#_add_many_items(file_rid, PackedStringArray(["import", "export", "save", "save_as"]))
+	#NativeMenu.add_separator(file_rid)
+	#_add_item(file_rid, "copy_svg_text")
+	#file_optimize_idx = _add_item(file_rid, "optimize")
+	#NativeMenu.add_separator(file_rid)
+	#file_reset_svg_idx = _add_item(file_rid, "reset_svg")
+	## Edit and Tool menus.
+	#_add_many_items(edit_rid, ShortcutUtils.get_actions("edit"))
+	#_add_many_items(tool_rid, ShortcutUtils.get_actions("tool"))
+	## View menu.
+	#view_show_grid_idx = _add_check_item(view_rid, "view_show_grid")
+	#view_show_handles_idx = _add_check_item(view_rid, "view_show_handles")
+	#view_rasterized_svg_idx = _add_check_item(view_rid, "view_rasterized_svg")
+	#NativeMenu.add_separator(view_rid)
+	#view_show_reference_idx = _add_item(view_rid, "load_reference")
+	#view_show_reference_idx = _add_check_item(view_rid, "view_show_reference")
+	#view_overlay_reference_idx = _add_check_item(view_rid, "view_overlay_reference")
+	#view_show_debug_idx = _add_check_item(view_rid, "view_show_debug")
+	#NativeMenu.add_separator(view_rid)
+	#_add_many_items(view_rid, PackedStringArray(["zoom_in", "zoom_out", "zoom_reset"]))
+	## Snap menu.
+	#snap_enable_idx = _add_check_item(snap_rid, "toggle_snap")
+	#NativeMenu.add_separator(snap_rid)
+	#snap_0125_idx = NativeMenu.add_radio_check_item(snap_rid, "0.125", _set_snap, _set_snap, 0.125)
+	#snap_025_idx = NativeMenu.add_radio_check_item(snap_rid, "0.25", _set_snap, _set_snap, 0.25)
+	#snap_05_idx = NativeMenu.add_radio_check_item(snap_rid, "0.5", _set_snap, _set_snap, 0.5)
+	#snap_1_idx = NativeMenu.add_radio_check_item(snap_rid, "1", _set_snap, _set_snap, 1)
+	#snap_2_idx = NativeMenu.add_radio_check_item(snap_rid, "2", _set_snap, _set_snap, 2)
+	#snap_4_idx = NativeMenu.add_radio_check_item(snap_rid, "4", _set_snap, _set_snap, 4)
+#
+#
+#func _add_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_item(menu_rid,
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name,
+			#_get_action_keycode(action_name))
+#
+#func _add_many_items(menu_rid: RID, actions: PackedStringArray) -> void:
+	#for action in actions:
+		#_add_item(menu_rid, action)
+#
+#func _add_check_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_check_item(menu_rid,
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
+#
+#func _add_many_icon_items(menu_rid: RID, actions: PackedStringArray) -> void:
+	#for action in actions:
+		#_add_icon_item(menu_rid, action)
+#
+#func _add_icon_item(menu_rid: RID, action_name: String) -> int:
+	#return NativeMenu.add_icon_item(menu_rid,
+			#ShortcutUtils.get_action_icon(action_name),
+			#TranslationUtils.get_action_description(action_name),
+			#HandlerGUI.throw_action_event, HandlerGUI.throw_action_event, action_name)
+#
+#
+#func _get_action_keycode(action: String) -> Key:
+	#var shortcut := ShortcutUtils.get_action_first_valid_shortcut(action)
+	#if is_instance_valid(shortcut):
+		#return shortcut.get_keycode_with_modifiers()
+	#return KEY_NONE
+#
+#
+#func _on_view_rasterized_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_rasterized_svg_idx, State.view_rasterized)
+#
+#func _on_show_grid_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_grid_idx, State.show_grid)
+#
+#func _on_show_handles_changed() -> void:
+	#NativeMenu.set_item_checked(view_rid, view_show_handles_idx, State.show_handles)
+#
+#func _on_active_tab_reference_changed() -> void:
+	#var active_tab := Configs.savedata.get_active_tab()
+	#var has_reference := is_instance_valid(active_tab.reference_image)
+	#NativeMenu.set_item_checked(view_rid, view_show_reference_idx, has_reference and active_tab.show_reference)
+	#NativeMenu.set_item_checked(view_rid, view_overlay_reference_idx, has_reference and active_tab.overlay_reference)
+#
+#
+#func _on_snap_changed() -> void:
+	#var snap_amount := absf(Configs.savedata.snap)
+	#NativeMenu.set_item_checked(snap_rid, snap_enable_idx, Configs.savedata.snap > 0)
+	#NativeMenu.set_item_checked(snap_rid, snap_0125_idx, is_equal_approx(snap_amount, 0.125))
+	#NativeMenu.set_item_checked(snap_rid, snap_025_idx, is_equal_approx(snap_amount, 0.25))
+	#NativeMenu.set_item_checked(snap_rid, snap_05_idx, is_equal_approx(snap_amount, 0.5))
+	#NativeMenu.set_item_checked(snap_rid, snap_1_idx, is_equal_approx(snap_amount, 1))
+	#NativeMenu.set_item_checked(snap_rid, snap_2_idx, is_equal_approx(snap_amount, 2))
+	#NativeMenu.set_item_checked(snap_rid, snap_4_idx, is_equal_approx(snap_amount, 4))
+#
+#func _set_snap(amount: float) -> void:
+	#Configs.savedata.snap = amount


### PR DESCRIPTION
Also deprecates the Mac menu as it relies on global variables, which I want to move away from. I hope to reinstate it in the near future to tap into shortcut registrations instead.