### PR TITLE
filled in missing translations and checked fuzzy translations for Dutch

### DIFF
--- a/translations/nl.po
+++ b/translations/nl.po
@@ -76,9 +76,8 @@ msgid "Restore"
 msgstr "Herstel"
 
 #: src/autoload/State.gd:
-#, fuzzy
 msgid "View in Inspector"
-msgstr "Bekijken In Lijst"
+msgstr "Bekijk in Inspecteur"
 
 #: src/autoload/State.gd:
 msgid "Convert To"
@@ -135,26 +134,25 @@ msgstr "6-cijferige hex"
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd:
 msgid "Dark"
-msgstr ""
+msgstr "Donker"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd:
-#, fuzzy
 msgid "Light"
-msgstr "Hoogte"
+msgstr "Helder"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd:
 msgid "Black (OLED)"
-msgstr ""
+msgstr "Zwart (OLED)"
 
 #: src/config_classes/SaveData.gd:
 msgid "Default Dark"
-msgstr ""
+msgstr "Standaard Donker"
 
 #: src/config_classes/SaveData.gd:
 msgid "Default Light"
-msgstr ""
+msgstr "Standaard Helder"
 
 #: src/config_classes/TabData.gd:
 msgid "Empty"
@@ -260,13 +258,12 @@ msgid "Snap size"
 msgstr "Maat inknappen"
 
 #: src/ui_parts/display.gd:
-#, fuzzy
 msgid "Paste reference image"
-msgstr "Referentiebeeld inladen"
+msgstr "Referentiebeeld plakken"
 
 #: src/ui_parts/donate_menu.gd:
 msgid "Links to donation platforms"
-msgstr ""
+msgstr "Koppelingen naar donatieplatformen"
 
 #: src/ui_parts/donate_menu.gd: src/ui_parts/export_menu.gd:
 #: src/ui_parts/import_warning_menu.gd: src/ui_widgets/choose_name_dialog.gd:
@@ -422,11 +419,11 @@ msgstr "Element toevoegen"
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
 #: src/ui_parts/layout_configuration.gd:
 msgid "Excluded"
-msgstr ""
+msgstr "Uitgezonderd"
 
 #: src/ui_parts/layout_configuration.gd:
 msgid "Drag and drop to change the layout"
-msgstr ""
+msgstr "Sleep en laat los om de indeling te veranderen"
 
 #: src/ui_parts/mac_menu.gd: src/ui_widgets/settings_content_shortcuts.gd:
 msgid "File"
@@ -530,23 +527,20 @@ msgid "Update check failed"
 msgstr "Updatecontrole mislukt"
 
 #: src/ui_parts/update_menu.gd:
-#, fuzzy
 msgid "View all releases"
-msgstr "Selecteer alle elementen"
+msgstr "Bekijk alle releases"
 
 #: src/ui_parts/update_menu.gd:
 msgid "GodSVG is up-to-date."
 msgstr "GodSVG is up-to-date."
 
 #: src/ui_parts/update_menu.gd:
-#, fuzzy
 msgid "New versions available!"
-msgstr "Nieuwe versies"
+msgstr "Nieuwe versies beschikbaar!"
 
 #: src/ui_widgets/PanelGrid.gd:
-#, fuzzy
 msgid "Copy email"
-msgstr "Pad kopiëren"
+msgstr "E-mail kopiëren"
 
 #: src/ui_widgets/choose_name_dialog.gd:
 msgid "Create"
@@ -575,7 +569,7 @@ msgstr "Kleurenplukker"
 
 #: src/ui_widgets/fps_limit_dropdown.gd: src/ui_widgets/setting_frame.gd:
 msgid "Unlimited"
-msgstr ""
+msgstr "Onbeperkt"
 
 #: src/ui_widgets/good_color_picker.gd:
 msgid "Color keywords"
@@ -586,9 +580,8 @@ msgid "Eyedropper"
 msgstr "Druppelaar"
 
 #: src/ui_widgets/palette_config.gd:
-#, fuzzy
 msgid "Add new color"
-msgstr "Textkleur"
+msgstr "Voeg nieuwe kleur toe"
 
 #: src/ui_widgets/palette_config.gd:
 msgid "Unnamed palettes won't be shown."
@@ -649,11 +642,11 @@ msgstr "Ook gebruikt door"
 
 #: src/ui_widgets/profile_frame.gd:
 msgid "Apply"
-msgstr ""
+msgstr "Toepassen"
 
 #: src/ui_widgets/profile_frame.gd:
 msgid "Apply all of this preset's defaults"
-msgstr ""
+msgstr "Pas alle standaardwaardes van deze voorinstelling toe"
 
 #: src/ui_widgets/setting_frame.gd: src/ui_widgets/setting_shortcut.gd:
 msgid "Reset to default"
@@ -686,9 +679,8 @@ msgid "Preset"
 msgstr "Voorinstelling"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Determines the default values of the formatter configs."
-msgstr "Verandert het maat-factor van de gebruikersinterface."
+msgstr "Bepaalt de standaard waarde van de formatter-configuraties."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Keep comments"
@@ -775,28 +767,24 @@ msgid "Remove unnecessary parameters"
 msgstr "Verwijder onnodige parameters"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Theme preset"
-msgstr "Zoom resetten"
+msgstr "Thema-preset"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Determines the default values of theming-related settings, including the highlighter preset."
-msgstr ""
+msgstr "Bepaalt de standaard waardes voor thema-instellingen, inclusief de markering voorinstelling."
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Primary theme colors"
-msgstr "De kleur uitzetten"
+msgstr "Primaire thema-kleuren"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Base color"
-msgstr "Basiskleuren"
+msgstr "Basiskleur"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Accent color"
-msgstr "Textkleur"
+msgstr "Accentkleur"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "SVG Text colors"
@@ -804,11 +792,11 @@ msgstr "SVG tekstkleuren"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Highlighter preset"
-msgstr ""
+msgstr "Markeerder voorinstelling"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Determines the default values of SVG highlighter settings."
-msgstr ""
+msgstr "Bepaalt de standaardwaardes van SVG markeerder instellingen"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Symbol color"
@@ -845,9 +833,8 @@ msgstr "Fout-kleur"
 
 #. Refers to the draggable gizmos.
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Handles"
-msgstr "Handvat maat"
+msgstr "Hendels"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Inside color"
@@ -870,37 +857,33 @@ msgid "Hovered selected color"
 msgstr "Zweefde gekozen kleur"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Selection rectangle"
-msgstr "Kies een afbeedling"
+msgstr "Selectie-vierkant"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Speed"
-msgstr ""
+msgstr "Snelheid"
 
 #. Refers to the selection rectangle's animated dashed stroke.
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Dash length"
-msgstr ""
+msgstr "Stippelijn lengte"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Color {index}"
-msgstr "Kleurenplukker"
+msgstr "Kleur {index}"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Basic colors"
 msgstr "Basiskleuren"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Canvas color"
-msgstr "Binnenkantkleuren"
+msgstr "Canvaskleur"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Grid color"
-msgstr "Geldige kleur"
+msgstr "Raster kleur"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Valid color"
@@ -920,7 +903,7 @@ msgstr "Sluit tabbladen met de middelste muisknop"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "When enabled, clicking on a tab with the middle mouse button closes it instead of simply focusing it."
-msgstr ""
+msgstr "Wanneer ingeschakeld, sluit een tabblad bij het klikken van de middeste muisknop in plaats van het simpelweg in focus te brengen."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Invert zoom direction"
@@ -939,43 +922,41 @@ msgid "Use CTRL for zooming"
 msgstr "Gebruik CTRL om in te zoomen"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "When enabled, scrolling pans the view instead of zooming in. To zoom, hold CTRL while scrolling."
-msgstr "Als ingeschakeld, scrollen zal het weergave verschuiven. Om te zoomen,houd CTRL ingedrukt tijdens scrollen."
+msgstr "Wanneer ingeschakeld, zal scrollen het weergave verschuiven. Om te zoomen, houd CTRL ingedrukt tijdens het scrollen."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Display"
-msgstr ""
+msgstr "Weergave"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "UI scale"
 msgstr "Gebruiksinterface maat"
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "Determines the scale factor for the interface."
-msgstr "Verandert het maat-factor van de gebruikersinterface."
+msgstr "Bepaalt de maat-factor van de interface."
 
 #. Stands for "Vertical Synchronization".
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "V-Sync"
-msgstr ""
+msgstr "V-Sync"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. May increase input lag slightly."
-msgstr ""
+msgstr "Synchroniseert grapfische rendering met vernieuwingfrequentie om scherm-scheuring te voorkomen. Kan mogelijk invoer vertraging lichtjes verhogen."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Maximum FPS"
-msgstr ""
+msgstr "Maximum FPS"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Determines the maximum number of frames per second."
-msgstr ""
+msgstr "Bepaalt de maximum aantal frames per seconde."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Keep Screen On"
-msgstr ""
+msgstr "Scherm Aan Houden"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Miscellaneous"
@@ -991,32 +972,31 @@ msgstr "Synchroniseer venstertitel naar bestandsnaam"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "When enabled, adds the current file name before the \"GodSVG\" window title."
-msgstr ""
+msgstr "Wanneer ingeschakelt, voegt de huidige bestandsnaam voor de \"GodSVG\" venstertitel."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "When enabled, uses spaces instead of a single tab for indentation."
-msgstr ""
+msgstr "Wanneer ingeschakelt, gebruikt spaties in plaats van een tab voor inspringing"
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Warps the cursor to the opposite side whenever it reaches a viewport boundary while panning."
-msgstr "Verplaatst de cursur naar de overkant wanneer het buiten de viewport gaat tijdens het rondkijken."
+msgstr "Verplaatst de cursur naar de overkant wanneer het buiten het kijkvenster gaat tijdens het rondkijken."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "Keeps the screen on even after inactivity, so the screensaver does not take over."
-msgstr ""
+msgstr "Houdt het scherm aan, zelfs na inactiviteit, zodat de screensaver niet overneemt."
 
 #: src/ui_widgets/settings_content_generic.gd:
-#, fuzzy
 msgid "When enabled, uses your operating system's native file dialog instead of GodSVG's built-in one."
-msgstr "Waneer ingeschakeld, gebruikt jouw besturingssysteem's inheemse bestandendialoog. Wanneer uitgeschakeld, gebruikt GodSVG's ingebouwde bestandendialoog."
+msgstr "Waneer ingeschakeld, gebruikt jouw besturingssysteem's inheemse bestandendialoog in plaats van GodSVG's ingebouwde bestandendialoog."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "The setting has no effect in the current configuration."
-msgstr ""
+msgstr "De instellingen heeft geen effect op de huidige configuratie."
 
 #: src/ui_widgets/settings_content_generic.gd:
 msgid "The setting can't be changed on this platform."
-msgstr ""
+msgstr "De instelling kan niet verandert worden op dit platform."
 
 #: src/ui_widgets/settings_content_palettes.gd:
 msgid "New palette"
@@ -1060,36 +1040,35 @@ msgstr "GodSVG herkent deze attribuut niet"
 
 #: src/utils/FileUtils.gd:
 msgid "The following files were discarded:"
-msgstr ""
+msgstr "De volgende bestanden zijn verworpen:"
 
 #: src/utils/FileUtils.gd:
 msgid "{file_name} was discarded."
-msgstr ""
+msgstr "{file_name} is verworpen."
 
 #: src/utils/FileUtils.gd:
 msgid "Discarded files"
-msgstr ""
+msgstr "Verworpen bestanden"
 
 #: src/utils/FileUtils.gd:
 msgid "Proceed"
-msgstr ""
+msgstr "Voortgaan"
 
 #: src/utils/FileUtils.gd:
-#, fuzzy
 msgid "{file_name} couldn't be opened."
-msgstr "Het bestand kon niet worden geopend."
+msgstr "{file_name} kon niet worden geopend."
 
 #: src/utils/FileUtils.gd:
 msgid "Check if the file still exists in the selected file path."
-msgstr "Kijk na of het bestand nog steeds bestaat in het gekozen bestandspad"
+msgstr "Kijk na of het bestand nog steeds bestaat in het gekozen bestandspad."
 
 #: src/utils/FileUtils.gd:
 msgid "Proceed with importing the rest of the files?"
-msgstr ""
+msgstr "Voortgaan met het importeren van de overige bestanden?"
 
 #: src/utils/FileUtils.gd:
 msgid "Proceed for all files that can't be opened"
-msgstr ""
+msgstr "Voortgaan voor alle bestanden die niet geopent kunnen worden"
 
 #: src/utils/FileUtils.gd:
 msgid "Save the file?"
@@ -1112,9 +1091,8 @@ msgid "Don't save"
 msgstr "Niet opslaan."
 
 #: src/utils/FileUtils.gd:
-#, fuzzy
 msgid "{file_path} is already being edited inside GodSVG."
-msgstr "Het geïmporteerde bestand is al geöpend in GodSVG"
+msgstr "{file_path} wordt al bewerkt in GodSVG"
 
 #: src/utils/FileUtils.gd:
 msgid "If you want to revert your edits since the last save, use {reset_svg}."
@@ -1129,9 +1107,8 @@ msgid "Save SVG"
 msgstr "SVG opslaan"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Save SVG as"
-msgstr "SVG opslaan als…"
+msgstr "SVG opslaan als"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Close tabs to the left"
@@ -1146,14 +1123,12 @@ msgid "Close all other tabs"
 msgstr "Kopiëer alle tekst"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Close empty tabs"
-msgstr "Tabblad sluiten"
+msgstr "Sluit lege tabbladen af"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Close saved tabs"
-msgstr "Kopiëer alle tekst"
+msgstr "Sluit opgeslagen tabbladen af"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Create tab"
@@ -1172,18 +1147,16 @@ msgid "Optimize"
 msgstr "Optimaliseren"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Optimize SVG"
-msgstr "Optimaliseren"
+msgstr "SVG optimaliseren"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Copy all text"
 msgstr "Kopiëer alle tekst"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Copy the SVG text"
-msgstr "Kopiëer alle tekst"
+msgstr "Kopiëer de SVG teksten"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Reset SVG"
@@ -1238,18 +1211,16 @@ msgid "Delete the selection"
 msgstr "Verwijder de selectie"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Move up"
-msgstr "Naar Boven"
+msgstr "Omhoog verschuiven"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Move the selection up"
 msgstr "Beweeg de selectie omhoog"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Move down"
-msgstr "Naar Onder"
+msgstr "Omlaag verschuiven"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Move the selection down"
@@ -1277,7 +1248,7 @@ msgstr "Raster weergeven"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Show handles"
-msgstr "Handvaten weergeven"
+msgstr "Hendels weergeven"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Show rasterized SVG"
@@ -1353,7 +1324,7 @@ msgstr "Applicatie afsluiten"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Toggle fullscreen"
-msgstr ""
+msgstr "Schakel fullscreen om"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Move to"
@@ -1401,41 +1372,36 @@ msgstr "Absoluut"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Code editor"
-msgstr ""
+msgstr "Code editor"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Inspector"
-msgstr ""
+msgstr "Inspecteur"
 
 #. The viewport is the area where the graphic is displayed. In similar applications, it's often called the canvas.
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Viewport"
-msgstr "Zicht"
+msgstr "Kijkvenster"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Only {extension_list} files are supported for this operation."
-msgstr "Deze bestandsextensie is leeg. Alleen {extension_list} bestanden zijn ondersteund."
+msgstr "Alleen {extension_list} bestanden zijn ondersteund voor deze operatie."
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Select {format} files"
-msgstr "Kies een XML bestand uit"
+msgstr "Kies {format} bestanden"
 
 #: src/utils/TranslationUtils.gd:
 msgid "Select an image"
 msgstr "Kies een afbeedling"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Select an {format} file"
-msgstr "Kies een XML bestand uit"
+msgstr "Kies een {format} bestand"
 
 #: src/utils/TranslationUtils.gd:
-#, fuzzy
 msgid "Save the {format} file"
-msgstr "Bewaar het .\"{format}\" bestand"
+msgstr "Bewaar het {format} bestand"
 
 #, fuzzy
 #~ msgid "If turned off, the window title remains as \"GodSVG\" without including the current file."
@@ -1445,7 +1411,7 @@ msgstr "Bewaar het .\"{format}\" bestand"
 #~ msgstr "Houdt onherkende XML structuren bij"
 
 #~ msgid "Handle colors"
-#~ msgstr "Handvatkleuren"
+#~ msgstr "Hendelkleuren"
 
 #~ msgid "Background color"
 #~ msgstr "Achtergrondskleur"
@@ -1498,7 +1464,7 @@ msgstr "Bewaar het .\"{format}\" bestand"
 #~ msgstr "Wisselt in- en uitzoemen met de muiswiel."
 
 #~ msgid "Wraps the mouse cursor around when panning the viewport."
-#~ msgstr "Wikkelt de muiscursor rond tijdens het verschuiven van de kijkvenster."
+#~ msgstr "Wikkelt de muiscursor rond tijdens het verschuiven van het kijkvenster."
 
 #~ msgid "This requires GodSVG to connect to the internet."
 #~ msgstr "Hiervoor moet GodSVG verbinding maken met het internet."


### PR DESCRIPTION
I checked for all empty (msgstr "") and fuzzy (#, fuzzy) translations. I filled those in and corrected the fuzzy ones too.
Another thing I did was check for some inconsistencies with wording, for words like "handle" and "viewport", although I didn't do a checkup on the consistency of every recurring word out there.