### PR TITLE
Switch to atlas drawing

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -325,6 +325,11 @@ debug={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194334,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+advanced_debug={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"command_or_control_autoremap":true,"alt_pressed":false,"shift_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194334,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 check_updates={
 "deadzone": 0.2,
 "events": []

--- a/src/ui_parts/debug_content.gd
+++ b/src/ui_parts/debug_content.gd
@@ -1,19 +1,28 @@
 extends MarginContainer
 
+var advanced_mode := false
+
 @onready var debug_label: Label = $DebugContainer/DebugLabel
 @onready var input_debug_label: Label = $DebugContainer/InputDebugLabel
 @onready var debug_container: VBoxContainer = $DebugContainer
 
 func _ready() -> void:
 	var shortcuts := ShortcutsRegistration.new()
-	shortcuts.add_shortcut("debug", toggle_debug_visibility)
+	shortcuts.add_shortcut("debug", toggle_debug)
+	shortcuts.add_shortcut("advanced_debug", toggle_debug.bind(true))
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
 	set_debug_visibility(false)
 	get_window().window_input.connect(_update_input_debug)
 
-func toggle_debug_visibility() -> void:
-	set_debug_visibility(not debug_container.visible)
+func toggle_debug(advanced := false) -> void:
+	if advanced and not advanced_mode:
+		advanced_mode = true
+		set_debug_visibility(true)
+	else:
+		if not advanced:
+			advanced_mode = false
+		set_debug_visibility(not debug_container.visible)
 
 func set_debug_visibility(visibility: bool) -> void:
 	debug_container.visible = visibility
@@ -26,9 +35,20 @@ func update_debug() -> void:
 	var debug_text := ""
 	debug_text += "FPS: %d\n" % Performance.get_monitor(Performance.TIME_FPS)
 	debug_text += "Static Mem: %s\n" % String.humanize_size(int(Performance.get_monitor(Performance.MEMORY_STATIC)))
+	
+	debug_text += "Objects: %d\n" % Performance.get_monitor(Performance.OBJECT_COUNT)
 	debug_text += "Nodes: %d\n" % Performance.get_monitor(Performance.OBJECT_NODE_COUNT)
 	debug_text += "Stray nodes: %d\n" % Performance.get_monitor(Performance.OBJECT_ORPHAN_NODE_COUNT)
-	debug_text += "Objects: %d\n" % Performance.get_monitor(Performance.OBJECT_COUNT)
+	
+	if advanced_mode:
+		debug_text += "Resources: %d\n" % Performance.get_monitor(Performance.OBJECT_RESOURCE_COUNT)
+		debug_text += "Total Objects Drawn: %d\n" % Performance.get_monitor(Performance.RENDER_TOTAL_OBJECTS_IN_FRAME)
+		debug_text += "Total Primitives Drawn: %d\n" % Performance.get_monitor(Performance.RENDER_TOTAL_PRIMITIVES_IN_FRAME)
+		debug_text += "Total Draw Calls: %d\n" % Performance.get_monitor(Performance.RENDER_TOTAL_DRAW_CALLS_IN_FRAME)
+		debug_text += "Video Mem: %s\n" % String.humanize_size(int(Performance.get_monitor(Performance.RENDER_VIDEO_MEM_USED)))
+		debug_text += "Texture Mem: %s\n" % String.humanize_size(int(Performance.get_monitor(Performance.RENDER_TEXTURE_MEM_USED)))
+		debug_text += "Buffer Mem: %s\n" % String.humanize_size(int(Performance.get_monitor(Performance.RENDER_BUFFER_MEM_USED)))
+	
 	debug_label.text = debug_text
 	# Set up the next update if the container is still visible.
 	if visible:

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -46,7 +46,8 @@ func _ready() -> void:
 	center_frame()
 
 func _on_svg_resized() -> void:
-	root_element = State.root_element
+	if root_element != State.root_element:
+		root_element = State.root_element
 	sync_checkerboard()
 	center_frame()
 	queue_redraw()
@@ -62,6 +63,7 @@ func _on_svg_changed() -> void:
 	if root_element != State.root_element:
 		root_element = State.root_element
 		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
+	
 	_current_svg_size = root_element.get_size()
 	queue_texture_update()
 	handles_manager.queue_update_handles()

--- a/src/utils/ShortcutUtils.gd
+++ b/src/utils/ShortcutUtils.gd
@@ -41,6 +41,7 @@ const _action_categories_dict: Dictionary[String, Dictionary] = {
 		"zoom_reset": true,
 		"toggle_fullscreen": true,
 		"debug": false,
+		"advanced_debug": false,
 		"view_show_grid": true,
 		"view_show_handles": true,
 		"view_rasterized_svg": true,
@@ -104,7 +105,7 @@ static func get_action_icon(action: String) -> Texture2D:
 		"find": return load("res://assets/icons/Search.svg")
 		"zoom_in": return load("res://assets/icons/Plus.svg")
 		"zoom_out": return load("res://assets/icons/Minus.svg")
-		"debug": return load("res://assets/icons/Debug.svg")
+		"debug", "advanced_debug": return load("res://assets/icons/Debug.svg")
 		"toggle_snap": return load("res://assets/icons/Snap.svg")
 		"quit": return load("res://assets/icons/Quit.svg")
 		"open_settings": return load("res://assets/icons/Gear.svg")

--- a/src/utils/TranslationUtils.gd
+++ b/src/utils/TranslationUtils.gd
@@ -64,6 +64,7 @@ static func get_action_description(action_name: String, for_button := false) -> 
 		"view_show_reference": return Translator.translate("Show reference image")
 		"view_overlay_reference": return Translator.translate("Overlay reference image")
 		"debug": return Translator.translate("View debug information")
+		"advanced_debug": return Translator.translate("View advanced debug information")
 		"move_relative": return get_path_command_description("m")
 		"move_absolute": return get_path_command_description("M")
 		"line_relative": return get_path_command_description("l")


### PR DESCRIPTION
Uses AtlasTextures for drawing handles instead of multiple Texture2Ds. I haven't measured FPS differences or improvements in lag spikes, but on a big SVG the monitors said this lead to a 35% reduction in draw calls, while not having any obvious drawbacks.

Also adds advanced debug with Ctrl+F3.