### PR TITLE
Cache inner markup when changing viewbox rect

### DIFF
--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -29,7 +29,7 @@ static func markup_check_is_root_empty(markup: String) -> bool:
 	return describes_svg and parser.read() == OK and parser.get_node_type() == XMLParser.NODE_ELEMENT_END and parser.get_node_name() == "svg"
 
 ## Creates markup for an SVG that only represents a rectangular cutout of the original.
-static func root_cutout_to_markup(root_element: ElementRoot, custom_width: float, custom_height: float, custom_viewbox: Rect2) -> String:
+static func root_cutout_to_markup(root_element: ElementRoot, custom_width: float, custom_height: float, custom_viewbox: Rect2, replace_inner: String = "") -> PackedStringArray:
 	# Build a new root element, set it up, and convert it to markup.
 	var new_root_element: ElementRoot = root_element.duplicate(false)
 	new_root_element.set_attribute("viewBox", ListParser.rect_to_list(custom_viewbox))
@@ -39,9 +39,14 @@ static func root_cutout_to_markup(root_element: ElementRoot, custom_width: float
 	# Since we only converted a single root element to markup, it would have closed.
 	# Remove the closure and add all the other elements' markup before closing it manually.
 	markup = markup.left(maxi(markup.find("/>"), markup.find("</svg>"))) + ">"
-	for child_idx in root_element.get_child_count():
-		markup += _xnode_to_markup(root_element.get_xnode(PackedInt32Array([child_idx])), Configs.savedata.editor_formatter, true)
-	return markup + "</svg>"
+	var inner := replace_inner
+	if not replace_inner:
+		print("not caching")
+		for child_idx in root_element.get_child_count():
+			inner += _xnode_to_markup(root_element.get_xnode(PackedInt32Array([child_idx])), Configs.savedata.editor_formatter, true)
+	else:
+		print("caching")
+	return [markup + inner + "</svg>", inner]
 
 
 ## Converts the child elements of a root element into markup, excluding the root tag itself.

--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -41,11 +41,8 @@ static func root_cutout_to_markup(root_element: ElementRoot, custom_width: float
 	markup = markup.left(maxi(markup.find("/>"), markup.find("</svg>"))) + ">"
 	var inner := replace_inner
 	if not replace_inner:
-		print("not caching")
 		for child_idx in root_element.get_child_count():
 			inner += _xnode_to_markup(root_element.get_xnode(PackedInt32Array([child_idx])), Configs.savedata.editor_formatter, true)
-	else:
-		print("caching")
 	return [markup + inner + "</svg>", inner]
 
 

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -63,7 +63,7 @@ func _on_svg_changed() -> void:
 		root_element = State.root_element
 		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
 	_current_svg_size = root_element.get_size()
-	queue_texture_update()
+	queue_texture_update(true)
 	handles_manager.queue_update_handles()
 
 func _on_hover_changed() -> void:

--- a/src/ui_widgets/Canvas.gd
+++ b/src/ui_widgets/Canvas.gd
@@ -202,17 +202,13 @@ func _texture_update() -> void:
 		_texture_update_dirty_inner = false
 		last_inner = ""
 	
-	var sw := Stopwatch.start(true, "a")
 	var svg_text := SVGParser.root_cutout_to_markup(root_element, display_rect.size.x,
 			display_rect.size.y, Rect2(root_element.world_to_canvas(display_rect.position),
 			display_rect.size / root_element.canvas_transform.get_scale()), last_inner)
-	sw.measure(true)
-	sw.name = "b"
 	last_inner = svg_text[1]
 	Utils.set_control_position_fixed(display_texture, display_rect.position)
 	display_texture.size = display_rect.size
 	display_texture.texture = SVGTexture.create_from_string(svg_text[0], image_zoom)
-	sw.measure()
 
 
 func sync_checkerboard() -> void:

--- a/src/ui_widgets/Canvas.gd
+++ b/src/ui_widgets/Canvas.gd
@@ -174,10 +174,14 @@ var texture_view_rect := Rect2():
 			queue_texture_update()
 
 var _texture_update_pending := false
+var _texture_update_dirty_inner := false
 
-func queue_texture_update() -> void:
+func queue_texture_update(dirty_inner := false) -> void:
 	_texture_update.call_deferred()
 	_texture_update_pending = true
+	_texture_update_dirty_inner = _texture_update_dirty_inner or dirty_inner
+
+var last_inner: String
 
 func _texture_update() -> void:
 	if not _texture_update_pending:
@@ -194,12 +198,21 @@ func _texture_update() -> void:
 	display_rect.size = display_rect.size.snapped(Vector2(pixel_size, pixel_size))
 	display_rect.end = display_rect.end.min(Vector2(ceili(root_element.width), ceili(root_element.height)))
 	
+	if _texture_update_dirty_inner:
+		_texture_update_dirty_inner = false
+		last_inner = ""
+	
+	var sw := Stopwatch.start(true, "a")
 	var svg_text := SVGParser.root_cutout_to_markup(root_element, display_rect.size.x,
 			display_rect.size.y, Rect2(root_element.world_to_canvas(display_rect.position),
-			display_rect.size / root_element.canvas_transform.get_scale()))
+			display_rect.size / root_element.canvas_transform.get_scale()), last_inner)
+	sw.measure(true)
+	sw.name = "b"
+	last_inner = svg_text[1]
 	Utils.set_control_position_fixed(display_texture, display_rect.position)
 	display_texture.size = display_rect.size
-	display_texture.texture = SVGTexture.create_from_string(svg_text, image_zoom)
+	display_texture.texture = SVGTexture.create_from_string(svg_text[0], image_zoom)
+	sw.measure()
 
 
 func sync_checkerboard() -> void:


### PR DESCRIPTION
As the title says, this makes the `SVGParser::root_cutout_to_markup` function accept another parameter that contains the cached inner XML. If the actual SVG content is changed, then the inner markup needs to be re-"rendered," but if it hasn't changed, then it can just be reused.