### PR TITLE
Add an multi-resolution icon view

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -1138,7 +1138,13 @@ func get_layout_part_index(part: Utils.LayoutPart) -> int:
 @export var icon_view_sizes: PackedInt64Array = [16, 24, 32, 48, 64]:
 	set(new_value):
 		if icon_view_sizes != new_value:
-			icon_view_sizes = new_value
+			var real_sizes: PackedInt64Array
+			for size in new_value:
+				if size <= 0:
+					real_sizes.append(1)
+					continue
+				real_sizes.append(size)
+			icon_view_sizes = real_sizes
 			emit_changed()
 
 

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -561,9 +561,6 @@ const MAX_FPS_MAX = 600
 			external_call(HandlerGUI.update_window_title)
 
 
-@export var icon_view_sizes: PackedInt32Array
-
-
 # Session
 
 const MAX_SNAP = 16384
@@ -1136,6 +1133,12 @@ func get_layout_part_index(part: Utils.LayoutPart) -> int:
 		# Main part
 		if left_vertical_splitter_offset != new_value:
 			left_vertical_splitter_offset = new_value
+			emit_changed()
+
+@export var icon_view_sizes: PackedInt64Array = [16, 24, 32, 48, 64]:
+	set(new_value):
+		if icon_view_sizes != new_value:
+			icon_view_sizes = new_value
 			emit_changed()
 
 

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -1140,12 +1140,10 @@ func get_layout_part_index(part: Utils.LayoutPart) -> int:
 		if icon_view_sizes != new_value:
 			var real_sizes: PackedInt64Array
 			for size in new_value:
-				if size <= 0:
-					real_sizes.append(1)
-					continue
-				real_sizes.append(size)
+				real_sizes.append(maxi(size, 1))
 			icon_view_sizes = real_sizes
 			emit_changed()
+
 @export var icon_view_bg_override := Color.TRANSPARENT:
 	set(new_value):
 		if icon_view_bg_override != new_value:

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -561,6 +561,9 @@ const MAX_FPS_MAX = 600
 			external_call(HandlerGUI.update_window_title)
 
 
+@export var icon_view_sizes: PackedInt32Array
+
+
 # Session
 
 const MAX_SNAP = 16384

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -1146,6 +1146,11 @@ func get_layout_part_index(part: Utils.LayoutPart) -> int:
 				real_sizes.append(size)
 			icon_view_sizes = real_sizes
 			emit_changed()
+@export var icon_view_bg_override := Color.TRANSPARENT:
+	set(new_value):
+		if icon_view_bg_override != new_value:
+			icon_view_bg_override = new_value
+			emit_changed()
 
 
 # Utility

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -95,33 +95,35 @@ func update_layout() -> void:
 	
 	var global_actions := GlobalActionsScene.instantiate()
 	left_vbox.add_child(global_actions)
+	var left_vertical_split_container := VSplitContainer.new()
+	left_vertical_split_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	left_vertical_split_container.add_theme_constant_override("separation", 10)
+	left_vertical_split_container.split_offset = Configs.savedata.left_vertical_splitter_offset
+	left_vertical_split_container.dragged.connect(_on_left_vertical_splitter_dragged)
 	
-	if not top_left.is_empty() and not bottom_left.is_empty():
-		# Layout parts both on top and on the bottom.
-		var left_vertical_split_container := VSplitContainer.new()
-		left_vertical_split_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
-		left_vertical_split_container.add_theme_constant_override("separation", 10)
-		left_vertical_split_container.split_offset = Configs.savedata.left_vertical_splitter_offset
-		left_vertical_split_container.dragged.connect(_on_left_vertical_splitter_dragged)
-		left_vertical_split_container.add_child(create_layout_node(top_left[0]))
-		left_vertical_split_container.add_child(create_layout_node(bottom_left[0]))
-		left_vbox.add_child(left_vertical_split_container)
-	elif top_left.size() == 2 or bottom_left.size() == 2:
-		# Tabs for the different layout parts.
-		var layout_parts := top_left if bottom_left.is_empty() else bottom_left
-		var vbox := VBoxContainer.new()
-		vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	if not top_left.is_empty():
+		left_vertical_split_container.add_child(_create_part_box(top_left))
+	if not bottom_left.is_empty():
+		left_vertical_split_container.add_child(_create_part_box(bottom_left))
+	
+	left_vbox.add_child(left_vertical_split_container)
+
+func _create_part_box(layout_parts: Array[Utils.LayoutPart]) -> Control:
+	var vbox := VBoxContainer.new()
+	vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	
+	var layout_nodes: Dictionary[Utils.LayoutPart, Node] = {}
+	for part in layout_parts:
+		var layout_node := create_layout_node(part)
+		layout_nodes[part] = layout_node
+		layout_node.hide()
+		vbox.add_child(layout_node)
+	
+	if layout_parts.size() > 1:
 		var buttons_hbox := HBoxContainer.new()
 		buttons_hbox.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 		vbox.add_child(buttons_hbox)
-		
-		var layout_nodes: Dictionary[Utils.LayoutPart, Node] = {}
-		for part in layout_parts:
-			var layout_node := create_layout_node(part)
-			layout_nodes[part] = layout_node
-			layout_node.hide()
-			vbox.add_child(layout_node)
-		
+		vbox.move_child(buttons_hbox, 0)
 		var btn_group := ButtonGroup.new()
 		for i in layout_parts.size():
 			var part := layout_parts[i]
@@ -147,13 +149,9 @@ func update_layout() -> void:
 			if i == 0:
 				btn.button_pressed = true
 				layout_nodes[part].show()
-		left_vbox.add_child(vbox)
 	else:
-		# Layout parts disabled.
-		if not top_left.is_empty():
-			left_vbox.add_child(create_layout_node(top_left[0]))
-		elif not bottom_left.is_empty():
-			left_vbox.add_child(create_layout_node(bottom_left[0]))
+		layout_nodes[layout_parts[0]].show()
+	return vbox
 
 func _on_horizontal_splitter_dragged(offset: int) -> void:
 	Configs.savedata.horizontal_splitter_offset = offset

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -5,6 +5,7 @@ const GlobalActionsScene = preload("res://src/ui_parts/global_actions.tscn")
 const CodeEditorScene = preload("res://src/ui_parts/code_editor.tscn")
 const InspectorScene = preload("res://src/ui_parts/inspector.tscn")
 const ViewportScene = preload("res://src/ui_parts/display.tscn")
+const IconViewScene = preload("res://src/ui_parts/icon_view.tscn")
 
 @onready var panel_container: PanelContainer = $PanelContainer
 
@@ -166,4 +167,5 @@ func create_layout_node(layout_part: Utils.LayoutPart) -> Node:
 		Utils.LayoutPart.CODE_EDITOR: return CodeEditorScene.instantiate()
 		Utils.LayoutPart.INSPECTOR: return InspectorScene.instantiate()
 		Utils.LayoutPart.VIEWPORT: return ViewportScene.instantiate()
+		Utils.LayoutPart.ICON_VIEW: return IconViewScene.instantiate()
 		_: return Control.new()

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -111,19 +111,20 @@ func update_layout() -> void:
 func _create_part_box(layout_parts: Array[Utils.LayoutPart]) -> Control:
 	var vbox := VBoxContainer.new()
 	vbox.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	var layout_part_container := LayoutPartContainer.new()
+	layout_part_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	
 	var layout_nodes: Dictionary[Utils.LayoutPart, Node] = {}
 	for part in layout_parts:
 		var layout_node := create_layout_node(part)
 		layout_nodes[part] = layout_node
 		layout_node.hide()
-		vbox.add_child(layout_node)
+		layout_part_container.add_child(layout_node)
 	
 	if layout_parts.size() > 1:
 		var buttons_hbox := HBoxContainer.new()
 		buttons_hbox.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 		vbox.add_child(buttons_hbox)
-		vbox.move_child(buttons_hbox, 0)
 		var btn_group := ButtonGroup.new()
 		for i in layout_parts.size():
 			var part := layout_parts[i]
@@ -151,6 +152,8 @@ func _create_part_box(layout_parts: Array[Utils.LayoutPart]) -> Control:
 				layout_nodes[part].show()
 	else:
 		layout_nodes[layout_parts[0]].show()
+	
+	vbox.add_child(layout_part_container)
 	return vbox
 
 func _on_horizontal_splitter_dragged(offset: int) -> void:
@@ -167,3 +170,19 @@ func create_layout_node(layout_part: Utils.LayoutPart) -> Node:
 		Utils.LayoutPart.VIEWPORT: return ViewportScene.instantiate()
 		Utils.LayoutPart.ICON_VIEW: return IconViewScene.instantiate()
 		_: return Control.new()
+
+
+class LayoutPartContainer extends Container:
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_SORT_CHILDREN:
+			var child_rect := Rect2(Vector2.ZERO, size)
+			for child in get_children():
+				if child is Control:
+					fit_child_in_rect(child, child_rect)
+	
+	func _get_minimum_size() -> Vector2:
+		var max_size := Vector2()
+		for child in get_children():
+			if child is Control:
+				max_size = max_size.max(child.get_combined_minimum_size())
+		return max_size

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -29,8 +29,7 @@ func _ready() -> void:
 
 
 func load_tiles() -> void:
-	for child in icon_view_tile_container.get_children():
-		child.queue_free()
+	_delete_tiles()
 	scaled_preview.hide()
 	for new_size in Configs.savedata.icon_view_sizes:
 		icon_view_tile_container.add_child(_create_new_tile(new_size))
@@ -38,8 +37,7 @@ func load_tiles() -> void:
 
 
 func reset_tiles() -> void:
-	for child in icon_view_tile_container.get_children():
-		child.queue_free()
+	_delete_tiles()
 	scaled_preview.hide()
 	for new_size in PackedInt64Array([16, 24, 32, 48, 64]):
 		icon_view_tile_container.add_child(_create_new_tile(new_size))
@@ -56,8 +54,7 @@ func _create_new_tile(new_size: int) -> Tile:
 	tile.texture_size = new_size
 	tile.remove_requested.connect(func():
 		# queue_free doesn't immediately remove the child?
-		icon_view_tile_container.remove_child(tile)
-		tile.queue_free()
+		_delete_tile(tile)
 		_update_savedata()
 	)
 	tile.selected.connect(func():
@@ -99,6 +96,17 @@ func sync_theming() -> void:
 	color = Color.TRANSPARENT
 	border_color = ThemeUtils.subtle_panel_border_color
 	title_color = ThemeUtils.basic_panel_inner_color
+
+
+func _delete_tiles() -> void:
+	for child in icon_view_tile_container.get_children():
+		icon_view_tile_container.remove_child(child)
+		child.queue_free()
+
+
+func _delete_tile(tile: Tile) -> void:
+	icon_view_tile_container.remove_child(tile)
+	tile.queue_free()
 
 
 func _update_savedata() -> void:

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -73,7 +73,10 @@ func update_tiles() -> void:
 
 
 func _update_texture_rect_size() -> void:
-	texture_rect.custom_minimum_size = texture_rect.texture.get_size() * 2
+	if not texture_rect.texture:
+		scaled_preview.hide()
+		return
+	texture_rect.custom_minimum_size = texture_rect.texture.get_size()
 
 
 func sync_theming() -> void:

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -1,0 +1,82 @@
+extends VTitledPanel
+
+
+const Tile = preload("res://src/ui_widgets/icon_view_tile.gd")
+const TileScene = preload("res://src/ui_widgets/icon_view_tile.tscn")
+
+
+@onready var icon_view_tile_container: Control = %IconViewTileContainer
+@onready var add_new_size_button: Button = %AddNewSizeButton
+@onready var reset_button: Button = %ResetButton
+@onready var texture_rect: TextureRect = %TextureRect
+@onready var scaled_preview: HBoxContainer = %ScaledPreview
+
+
+var needs_update := false
+var selected_tile: int
+
+
+func _ready() -> void:
+	Configs.theme_changed.connect(sync_theming)
+	sync_theming()
+	reset_button.pressed.connect(reset_tiles)
+	add_new_size_button.pressed.connect(_add_new_tile)
+	State.svg_changed.connect(update_tiles)
+	reset_tiles()
+	await get_tree().process_frame
+	update_tiles()
+	visibility_changed.connect(func(): if visible and needs_update: update_tiles())
+
+
+func reset_tiles() -> void:
+	for child in icon_view_tile_container.get_children():
+		child.queue_free()
+	scaled_preview.hide()
+	for new_size in [16, 24, 32, 48, 64]:
+		icon_view_tile_container.add_child(_create_new_tile(new_size))
+	update_tiles.call_deferred()
+
+
+func _add_new_tile() -> void:
+	icon_view_tile_container.add_child(_create_new_tile(16))
+	update_tiles.call_deferred()
+
+
+func _create_new_tile(new_size: int) -> Tile:
+	var tile := TileScene.instantiate()
+	tile.set_texture_size(new_size)
+	tile.remove_requested.connect(func(): tile.queue_free())
+	tile.selected.connect(func():
+		selected_tile = tile.get_index()
+		texture_rect.texture = tile.texture
+		scaled_preview.show()
+		_update_texture_rect_size()
+	)
+	tile.texture_changed.connect(func():
+		if tile.get_index() == selected_tile:
+			texture_rect.texture = tile.texture
+			_update_texture_rect_size()
+	)
+	return tile
+
+
+func update_tiles() -> void:
+	if not visible:
+		needs_update = true
+		return
+	var svg_text := SVGParser.root_to_export_markup(State.root_element)
+	for child: Tile in icon_view_tile_container.get_children():
+		child.svg_markup = State.svg_text
+	if selected_tile >= 0 and selected_tile < icon_view_tile_container.get_child_count():
+		texture_rect.texture = icon_view_tile_container.get_child(selected_tile).texture
+		_update_texture_rect_size()
+
+
+func _update_texture_rect_size() -> void:
+	texture_rect.custom_minimum_size = texture_rect.texture.get_size() * 2
+
+
+func sync_theming() -> void:
+	color = Color.TRANSPARENT
+	border_color = ThemeUtils.subtle_panel_border_color
+	title_color = ThemeUtils.basic_panel_inner_color

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -152,5 +152,5 @@ func _update_preview_bg(new_value: String) -> void:
 	else:
 		colored_sb.bg_color = new_color
 		scaled_preview.add_theme_stylebox_override("panel", colored_sb)
-		size_label.add_theme_color_override("font_color", Color.from_ok_hsl(0, 0, 1 - new_color.ok_hsl_l))
+		size_label.add_theme_color_override("font_color", new_color.srgb_to_linear().inverted().linear_to_srgb())
 	Configs.savedata.icon_view_bg_override = new_color

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -13,7 +13,7 @@ const TileScene = preload("res://src/ui_widgets/icon_view_tile.tscn")
 
 
 var needs_update := false
-var selected_tile: int
+var selected_tile: int = -1
 
 
 func _ready() -> void:
@@ -24,7 +24,6 @@ func _ready() -> void:
 	State.svg_changed.connect(update_tiles)
 	visibility_changed.connect(func(): if visible and needs_update: update_tiles())
 	load_tiles()
-	await get_tree().process_frame
 	update_tiles()
 
 
@@ -54,6 +53,12 @@ func _create_new_tile(new_size: int) -> Tile:
 	tile.texture_size = new_size
 	tile.remove_requested.connect(func():
 		# queue_free doesn't immediately remove the child?
+		if tile.get_index() == selected_tile:
+			selected_tile = -1
+			scaled_preview.hide()
+		else:
+			if selected_tile > tile.get_index():
+				selected_tile -= 1
 		_delete_tile(tile)
 		_update_savedata()
 	)

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -12,6 +12,7 @@ const ColorEdit = preload("res://src/ui_widgets/color_edit.gd")
 @onready var reset_button: Button = %ResetButton
 @onready var texture_rect: TextureRect = %TextureRect
 @onready var scaled_preview: Control = %ScaledPreview
+@onready var scaled_preview_panel: PanelContainer = %ScaledPreviewPanel
 @onready var clear_button: Button = %ClearButton
 @onready var size_label: Label = %SizeLabel
 @onready var split_container: SplitContainer = %SplitContainer
@@ -147,10 +148,8 @@ var colored_sb := StyleBoxFlat.new()
 func _update_preview_bg(new_value: String) -> void:
 	var new_color := Color.html(new_value)
 	if new_color == Color.TRANSPARENT:
-		scaled_preview.remove_theme_stylebox_override("panel")
-		size_label.remove_theme_color_override("font_color")
+		scaled_preview_panel.remove_theme_stylebox_override("panel")
 	else:
 		colored_sb.bg_color = new_color
-		scaled_preview.add_theme_stylebox_override("panel", colored_sb)
-		size_label.add_theme_color_override("font_color", new_color.srgb_to_linear().inverted().linear_to_srgb())
+		scaled_preview_panel.add_theme_stylebox_override("panel", colored_sb)
 	Configs.savedata.icon_view_bg_override = new_color

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -9,8 +9,9 @@ const TileScene = preload("res://src/ui_widgets/icon_view_tile.tscn")
 @onready var add_new_size_button: Button = %AddNewSizeButton
 @onready var reset_button: Button = %ResetButton
 @onready var texture_rect: TextureRect = %TextureRect
-@onready var scaled_preview: HBoxContainer = %ScaledPreview
+@onready var scaled_preview: Control = %ScaledPreview
 @onready var clear_button: Button = %ClearButton
+@onready var size_label: Label = %SizeLabel
 
 
 var needs_update := false
@@ -54,7 +55,6 @@ func _create_new_tile(new_size: int) -> Tile:
 	var tile := TileScene.instantiate()
 	tile.texture_size = new_size
 	tile.remove_requested.connect(func():
-		# queue_free doesn't immediately remove the child?
 		if selected_tile == tile:
 			selected_tile = null
 			scaled_preview.hide()
@@ -94,6 +94,7 @@ func _update_texture_rect_size() -> void:
 		scaled_preview.hide()
 		return
 	texture_rect.custom_minimum_size = texture_rect.texture.get_size()
+	size_label.text = selected_tile.texture_size_string
 
 
 func sync_theming() -> void:
@@ -110,6 +111,7 @@ func _delete_tiles() -> void:
 
 
 func _delete_tile(tile: Tile) -> void:
+	# queue_free doesn't immediately remove the child?
 	icon_view_tile_container.remove_child(tile)
 	tile.queue_free()
 

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -12,6 +12,7 @@ const TileScene = preload("res://src/ui_widgets/icon_view_tile.tscn")
 @onready var scaled_preview: Control = %ScaledPreview
 @onready var clear_button: Button = %ClearButton
 @onready var size_label: Label = %SizeLabel
+@onready var split_container: SplitContainer = %SplitContainer
 
 
 var needs_update := false
@@ -26,6 +27,7 @@ func _ready() -> void:
 	clear_button.pressed.connect(reset_tiles.bind([]))
 	State.svg_changed.connect(update_tiles)
 	visibility_changed.connect(func(): if visible and needs_update: update_tiles())
+	split_container.resized.connect(func(): split_container.vertical = split_container.size.y * 2.0 > split_container.size.x)
 	load_tiles()
 	update_tiles()
 

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -102,7 +102,7 @@ func update_tiles() -> void:
 		return
 	var svg_text := SVGParser.root_to_export_markup(State.root_element)
 	for child: Tile in icon_view_tile_container.get_children():
-		child.svg_markup = State.svg_text
+		child.svg_markup = svg_text
 	if selected_tile:
 		texture_rect.texture = selected_tile.texture
 		_update_texture_rect_size()

--- a/src/ui_parts/icon_view.gd
+++ b/src/ui_parts/icon_view.gd
@@ -71,7 +71,7 @@ func _add_new_tile() -> void:
 
 
 func _create_new_tile(new_size: int) -> Tile:
-	var tile := TileScene.instantiate()
+	var tile: Tile = TileScene.instantiate()
 	tile.texture_size = new_size
 	tile.remove_requested.connect(func():
 		if selected_tile == tile:
@@ -85,6 +85,11 @@ func _create_new_tile(new_size: int) -> Tile:
 		texture_rect.texture = tile.texture
 		scaled_preview.show()
 		_update_texture_rect_size()
+	)
+	tile.texture_size_changed.connect(func():
+		if selected_tile == tile:
+			texture_rect.texture = tile.texture
+			_update_texture_rect_size()
 	)
 	tile.texture_changed.connect(func():
 		if selected_tile == tile:
@@ -114,7 +119,6 @@ func _update_texture_rect_size() -> void:
 		return
 	texture_rect.custom_minimum_size = texture_rect.texture.get_size()
 	texture_rect.size_flags_stretch_ratio = float(texture_rect.texture.get_width()) / float(texture_rect.texture.get_height())
-	#texture_rect.custom_minimum_size.x = texture_rect.size.y * float(texture_rect.texture.get_width()) / float(texture_rect.texture.get_height())
 	size_label.text = selected_tile.texture_size_string
 
 

--- a/src/ui_parts/icon_view.gd.uid
+++ b/src/ui_parts/icon_view.gd.uid
@@ -1,0 +1,1 @@
+uid://dpn15qyr7xsds

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -28,6 +28,10 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
+tooltip_text = "Add a new icon preview"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_type_variation = &"IconButton"
 icon = ExtResource("2_dyte2")
 
 [node name="ResetButton" type="Button" parent="ActionContainer"]
@@ -35,6 +39,10 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 0
+tooltip_text = "Reset the icon previews to the default sizes (16, 24, 32, 48, and 64)"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_type_variation = &"IconButton"
 icon = ExtResource("4_dyte2")
 
 [node name="VSplitContainer" type="VSplitContainer" parent="."]
@@ -65,6 +73,7 @@ layout_mode = 2
 [node name="ScaledPreview" type="HBoxContainer" parent="VSplitContainer"]
 unique_name_in_owner = true
 visible = false
+custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 
 [node name="Control" type="Control" parent="VSplitContainer/ScaledPreview"]
@@ -77,7 +86,7 @@ texture_filter = 1
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 texture = ExtResource("4_rq20x")
-expand_mode = 3
+expand_mode = 2
 stretch_mode = 4
 
 [node name="Control2" type="Control" parent="VSplitContainer/ScaledPreview"]

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -1,0 +1,85 @@
+[gd_scene load_steps=6 format=3 uid="uid://ck1u5onyy0cdc"]
+
+[ext_resource type="Script" uid="uid://dpn15qyr7xsds" path="res://src/ui_parts/icon_view.gd" id="1_dyte2"]
+[ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="2_dyte2"]
+[ext_resource type="Texture2D" uid="uid://cvh3kwbucf2n1" path="res://assets/icons/Reload.svg" id="4_dyte2"]
+[ext_resource type="PackedScene" uid="uid://18urhivvngk" path="res://src/ui_widgets/icon_view_tile.tscn" id="4_gn3ji"]
+[ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="4_rq20x"]
+
+[node name="IconView" type="Container"]
+anchors_preset = -1
+offset_bottom = 163.0
+size_flags_vertical = 3
+script = ExtResource("1_dyte2")
+border_width = 2
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_left = 5
+corner_radius_bottom_right = 5
+title_margin = 4
+panel_margin = 2
+metadata/_custom_type_script = "uid://ojo0537b6hcy"
+
+[node name="ActionContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="AddNewSizeButton" type="Button" parent="ActionContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+icon = ExtResource("2_dyte2")
+
+[node name="ResetButton" type="Button" parent="ActionContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+icon = ExtResource("4_dyte2")
+
+[node name="VSplitContainer" type="VSplitContainer" parent="."]
+layout_mode = 2
+split_offset = 250
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VSplitContainer"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="VSplitContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 3
+theme_override_constants/margin_top = 3
+theme_override_constants/margin_right = 3
+theme_override_constants/margin_bottom = 3
+
+[node name="IconViewTileContainer" type="FlowContainer" parent="VSplitContainer/ScrollContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="IconViewTile" parent="VSplitContainer/ScrollContainer/MarginContainer/IconViewTileContainer" instance=ExtResource("4_gn3ji")]
+layout_mode = 2
+
+[node name="ScaledPreview" type="HBoxContainer" parent="VSplitContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="Control" type="Control" parent="VSplitContainer/ScaledPreview"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="TextureRect" type="TextureRect" parent="VSplitContainer/ScaledPreview"]
+unique_name_in_owner = true
+texture_filter = 1
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+texture = ExtResource("4_rq20x")
+expand_mode = 3
+stretch_mode = 4
+
+[node name="Control2" type="Control" parent="VSplitContainer/ScaledPreview"]
+layout_mode = 2
+size_flags_horizontal = 3

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=5 format=3 uid="uid://ck1u5onyy0cdc"]
+[gd_scene load_steps=7 format=3 uid="uid://ck1u5onyy0cdc"]
 
 [ext_resource type="Script" uid="uid://dpn15qyr7xsds" path="res://src/ui_parts/icon_view.gd" id="1_dyte2"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="2_dyte2"]
+[ext_resource type="PackedScene" uid="uid://5f8uxavn1or1" path="res://src/ui_widgets/color_edit.tscn" id="3_dyte2"]
 [ext_resource type="Texture2D" uid="uid://dw7ho4df0uh4p" path="res://assets/icons/Clear.svg" id="4_6rnci"]
 [ext_resource type="Texture2D" uid="uid://cvh3kwbucf2n1" path="res://assets/icons/Reload.svg" id="4_dyte2"]
+[ext_resource type="PackedScene" uid="uid://bujllg1bqlub6" path="res://src/ui_widgets/color_swatch.tscn" id="4_rq20x"]
 
 [node name="IconView" type="Container"]
 anchors_preset = -1
@@ -34,6 +36,31 @@ theme_type_variation = &"IconButton"
 icon = ExtResource("2_dyte2")
 
 [node name="Control" type="Control" parent="ActionContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="TransparentColorSwatch" parent="ActionContainer" instance=ExtResource("4_rq20x")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="BlackColorSwatch" parent="ActionContainer" instance=ExtResource("4_rq20x")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="WhiteColorSwatch" parent="ActionContainer" instance=ExtResource("4_rq20x")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="ColorEdit" parent="ActionContainer" instance=ExtResource("3_dyte2")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 4
+enable_alpha = true
+
+[node name="Control2" type="Control" parent="ActionContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
@@ -91,43 +118,29 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"OutlinedPanel"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="SplitContainer/ScaledPreview"]
-custom_minimum_size = Vector2(0, 60)
-layout_mode = 2
-horizontal_scroll_mode = 4
-vertical_scroll_mode = 0
-
-[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/ScaledPreview/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/ScaledPreview"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="SizeLabel" type="Label" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer"]
+[node name="SizeLabel" type="Label" parent="SplitContainer/ScaledPreview/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="SplitContainer/ScaledPreview/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
-[node name="Control" type="Control" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
-
-[node name="TextureRect" type="TextureRect" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="SplitContainer/ScaledPreview/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 texture_filter = 1
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
-size_flags_horizontal = 4
+size_flags_horizontal = 3
 size_flags_vertical = 3
 expand_mode = 2
-stretch_mode = 4
-
-[node name="Control2" type="Control" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
-layout_mode = 2
-size_flags_horizontal = 3
+stretch_mode = 5

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://ck1u5onyy0cdc"]
+[gd_scene load_steps=5 format=3 uid="uid://ck1u5onyy0cdc"]
 
 [ext_resource type="Script" uid="uid://dpn15qyr7xsds" path="res://src/ui_parts/icon_view.gd" id="1_dyte2"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="2_dyte2"]
 [ext_resource type="Texture2D" uid="uid://dw7ho4df0uh4p" path="res://assets/icons/Clear.svg" id="4_6rnci"]
 [ext_resource type="Texture2D" uid="uid://cvh3kwbucf2n1" path="res://assets/icons/Reload.svg" id="4_dyte2"]
-[ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="4_rq20x"]
 
 [node name="IconView" type="Container"]
 anchors_preset = -1
@@ -60,17 +59,19 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
 icon = ExtResource("4_6rnci")
 
-[node name="VSplitContainer" type="VSplitContainer" parent="."]
+[node name="SplitContainer" type="SplitContainer" parent="."]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 split_offset = 250
+vertical = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VSplitContainer"]
+[node name="ScrollContainer" type="ScrollContainer" parent="SplitContainer"]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="VSplitContainer/ScrollContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="SplitContainer/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -79,51 +80,54 @@ theme_override_constants/margin_top = 3
 theme_override_constants/margin_right = 3
 theme_override_constants/margin_bottom = 3
 
-[node name="IconViewTileContainer" type="FlowContainer" parent="VSplitContainer/ScrollContainer/MarginContainer"]
+[node name="IconViewTileContainer" type="FlowContainer" parent="SplitContainer/ScrollContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="ScaledPreview" type="PanelContainer" parent="VSplitContainer"]
+[node name="ScaledPreview" type="PanelContainer" parent="SplitContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"OutlinedPanel"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VSplitContainer/ScaledPreview"]
+[node name="ScrollContainer" type="ScrollContainer" parent="SplitContainer/ScaledPreview"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
 horizontal_scroll_mode = 4
 vertical_scroll_mode = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VSplitContainer/ScaledPreview/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/ScaledPreview/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="SizeLabel" type="Label" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
-[node name="Control" type="Control" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
+[node name="Control" type="Control" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 texture_filter = 1
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 3
-texture = ExtResource("4_rq20x")
 expand_mode = 2
 stretch_mode = 4
 
-[node name="Control2" type="Control" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
+[node name="Control2" type="Control" parent="SplitContainer/ScaledPreview/ScrollContainer/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-
-[node name="SizeLabel" type="Label" parent="VSplitContainer/ScaledPreview"]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 0
-text = "hi"

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -1,15 +1,14 @@
-[gd_scene load_steps=7 format=3 uid="uid://ck1u5onyy0cdc"]
+[gd_scene load_steps=6 format=3 uid="uid://ck1u5onyy0cdc"]
 
 [ext_resource type="Script" uid="uid://dpn15qyr7xsds" path="res://src/ui_parts/icon_view.gd" id="1_dyte2"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="2_dyte2"]
 [ext_resource type="Texture2D" uid="uid://dw7ho4df0uh4p" path="res://assets/icons/Clear.svg" id="4_6rnci"]
 [ext_resource type="Texture2D" uid="uid://cvh3kwbucf2n1" path="res://assets/icons/Reload.svg" id="4_dyte2"]
-[ext_resource type="PackedScene" uid="uid://18urhivvngk" path="res://src/ui_widgets/icon_view_tile.tscn" id="4_gn3ji"]
 [ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="4_rq20x"]
 
 [node name="IconView" type="Container"]
 anchors_preset = -1
-offset_bottom = 163.0
+offset_bottom = 169.0
 size_flags_vertical = 3
 script = ExtResource("1_dyte2")
 border_width = 2
@@ -64,6 +63,8 @@ icon = ExtResource("4_6rnci")
 [node name="VSplitContainer" type="VSplitContainer" parent="."]
 custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 split_offset = 250
 
 [node name="ScrollContainer" type="ScrollContainer" parent="VSplitContainer"]
@@ -84,28 +85,45 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="IconViewTile" parent="VSplitContainer/ScrollContainer/MarginContainer/IconViewTileContainer" instance=ExtResource("4_gn3ji")]
-layout_mode = 2
-
-[node name="ScaledPreview" type="HBoxContainer" parent="VSplitContainer"]
+[node name="ScaledPreview" type="PanelContainer" parent="VSplitContainer"]
 unique_name_in_owner = true
-visible = false
+layout_mode = 2
+theme_type_variation = &"OutlinedPanel"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="VSplitContainer/ScaledPreview"]
 custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
+horizontal_scroll_mode = 4
+vertical_scroll_mode = 0
 
-[node name="Control" type="Control" parent="VSplitContainer/ScaledPreview"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VSplitContainer/ScaledPreview/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 0
+
+[node name="Control" type="Control" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TextureRect" type="TextureRect" parent="VSplitContainer/ScaledPreview"]
+[node name="TextureRect" type="TextureRect" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
 unique_name_in_owner = true
 texture_filter = 1
 custom_minimum_size = Vector2(0, 50)
 layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
 texture = ExtResource("4_rq20x")
 expand_mode = 2
 stretch_mode = 4
 
-[node name="Control2" type="Control" parent="VSplitContainer/ScaledPreview"]
+[node name="Control2" type="Control" parent="VSplitContainer/ScaledPreview/ScrollContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+
+[node name="SizeLabel" type="Label" parent="VSplitContainer/ScaledPreview"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 0
+text = "hi"

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -113,29 +113,31 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="ScaledPreview" type="PanelContainer" parent="SplitContainer"]
+[node name="ScaledPreview" type="VBoxContainer" parent="SplitContainer"]
 unique_name_in_owner = true
-layout_mode = 2
-theme_type_variation = &"OutlinedPanel"
-
-[node name="VBoxContainer" type="VBoxContainer" parent="SplitContainer/ScaledPreview"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="SizeLabel" type="Label" parent="SplitContainer/ScaledPreview/VBoxContainer"]
+[node name="SizeLabel" type="Label" parent="SplitContainer/ScaledPreview"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="SplitContainer/ScaledPreview/VBoxContainer"]
+[node name="ScaledPreviewPanel" type="PanelContainer" parent="SplitContainer/ScaledPreview"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+theme_type_variation = &"OutlinedPanel"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="SplitContainer/ScaledPreview/ScaledPreviewPanel"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/separation = 0
 
-[node name="TextureRect" type="TextureRect" parent="SplitContainer/ScaledPreview/VBoxContainer/HBoxContainer"]
+[node name="TextureRect" type="TextureRect" parent="SplitContainer/ScaledPreview/ScaledPreviewPanel/HBoxContainer"]
 unique_name_in_owner = true
 texture_filter = 1
 custom_minimum_size = Vector2(0, 50)

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -8,7 +8,6 @@
 [ext_resource type="PackedScene" uid="uid://bujllg1bqlub6" path="res://src/ui_widgets/color_swatch.tscn" id="4_rq20x"]
 
 [node name="IconView" type="Container"]
-anchors_preset = -1
 offset_bottom = 169.0
 size_flags_vertical = 3
 script = ExtResource("1_dyte2")

--- a/src/ui_parts/icon_view.tscn
+++ b/src/ui_parts/icon_view.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://ck1u5onyy0cdc"]
+[gd_scene load_steps=7 format=3 uid="uid://ck1u5onyy0cdc"]
 
 [ext_resource type="Script" uid="uid://dpn15qyr7xsds" path="res://src/ui_parts/icon_view.gd" id="1_dyte2"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="2_dyte2"]
+[ext_resource type="Texture2D" uid="uid://dw7ho4df0uh4p" path="res://assets/icons/Clear.svg" id="4_6rnci"]
 [ext_resource type="Texture2D" uid="uid://cvh3kwbucf2n1" path="res://assets/icons/Reload.svg" id="4_dyte2"]
 [ext_resource type="PackedScene" uid="uid://18urhivvngk" path="res://src/ui_widgets/icon_view_tile.tscn" id="4_gn3ji"]
 [ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="4_rq20x"]
@@ -34,6 +35,10 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
 icon = ExtResource("2_dyte2")
 
+[node name="Control" type="Control" parent="ActionContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
 [node name="ResetButton" type="Button" parent="ActionContainer"]
 unique_name_in_owner = true
 layout_mode = 2
@@ -45,7 +50,19 @@ mouse_default_cursor_shape = 2
 theme_type_variation = &"IconButton"
 icon = ExtResource("4_dyte2")
 
+[node name="ClearButton" type="Button" parent="ActionContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 0
+tooltip_text = "Clear all icon sizes"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_type_variation = &"IconButton"
+icon = ExtResource("4_6rnci")
+
 [node name="VSplitContainer" type="VSplitContainer" parent="."]
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 split_offset = 250
 

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -7,7 +7,7 @@
 [ext_resource type="Script" uid="uid://b04padjc3w1s8" path="res://src/ui_parts/move_to_overlay.gd" id="5_otlmf"]
 
 [node name="Inspector" type="Container"]
-anchors_preset = 9
+anchors_preset = -1
 anchor_bottom = 1.0
 offset_right = 460.0
 grow_vertical = 2

--- a/src/ui_parts/layout_popup.tscn
+++ b/src/ui_parts/layout_popup.tscn
@@ -15,6 +15,6 @@ theme_override_constants/margin_right = 2
 theme_override_constants/margin_bottom = 2
 
 [node name="LayoutConfiguration" type="Control" parent="MarginContainer"]
-custom_minimum_size = Vector2(160, 176)
+custom_minimum_size = Vector2(200, 200)
 layout_mode = 2
 script = ExtResource("2_lmeyv")

--- a/src/ui_widgets/LineEditButton.gd
+++ b/src/ui_widgets/LineEditButton.gd
@@ -5,8 +5,6 @@ class_name LineEditButton extends Control
 # A fake-out is drawn to avoid adding unnecessary nodes.
 # The real controls are only created when necessary, such as when hovered or focused.
 
-const BUTTON_WIDTH = 14.0
-
 signal pressed
 signal text_change_canceled
 signal text_changed(new_text: String)
@@ -64,6 +62,11 @@ var temp_button: Button
 @export var icon: Texture2D
 @export var button_visuals := true
 @export var mono_font_tooltip := false
+@export var button_width := 14.0:
+	set(new_value):
+		if not is_equal_approx(new_value, button_width):
+			button_width = new_value
+			queue_redraw()
 
 var ci := get_canvas_item()
 
@@ -107,7 +110,7 @@ func _setup() -> void:
 		return
 	active = true
 	temp_line_edit = BetterLineEdit.new()
-	temp_line_edit.size = Vector2(size.x - BUTTON_WIDTH, 22)
+	temp_line_edit.size = Vector2(size.x - button_width, 22)
 	temp_line_edit.tooltip_text = tooltip_text
 	temp_line_edit.mono_font_tooltip = mono_font_tooltip
 	temp_line_edit.placeholder_text = placeholder_text
@@ -125,8 +128,8 @@ func _setup() -> void:
 	add_child(temp_line_edit)
 	temp_button = Button.new()
 	temp_button.show_behind_parent = true  # Lets the icon draw in front.
-	temp_button.custom_minimum_size = Vector2(BUTTON_WIDTH, 22)
-	temp_button.position.x = size.x - BUTTON_WIDTH
+	temp_button.custom_minimum_size = Vector2(button_width, 22)
+	temp_button.position.x = size.x - button_width
 	temp_button.focus_mode = Control.FOCUS_NONE
 	temp_button.mouse_filter = Control.MOUSE_FILTER_PASS
 	temp_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
@@ -160,17 +163,17 @@ func _draw() -> void:
 	var horizontal_margin_width := sb.content_margin_left + sb.content_margin_right
 	if not active:
 		sb.draw(ci, Rect2(Vector2.ZERO, size))
-		draw_line(Vector2(size.x - BUTTON_WIDTH, 0), Vector2(size.x - BUTTON_WIDTH, size.y), sb.border_color, 2)
+		draw_line(Vector2(size.x - button_width, 0), Vector2(size.x - button_width, size.y), sb.border_color, 2)
 		# The default overrun behavior couldn't be changed for the simplest draw methods.
 		var text_obj := TextLine.new()
 		text_obj.text_overrun_behavior = TextServer.OVERRUN_TRIM_CHAR
-		text_obj.width = size.x - BUTTON_WIDTH - horizontal_margin_width
+		text_obj.width = size.x - button_width - horizontal_margin_width
 		text_obj.add_string(placeholder_text if text.is_empty() else text, _get_font(), get_theme_font_size("font_size", "LineEdit"))
 		text_obj.draw(ci, Vector2(5, 2), get_theme_color("font_placeholder_color", "LineEdit") if text.is_empty() else _get_font_color())
 	
 	if is_instance_valid(icon):
-		var icon_side := BUTTON_WIDTH - horizontal_margin_width + 2
-		icon.draw_rect(ci, Rect2(size.x - (BUTTON_WIDTH + 0.5 + icon_side) / 2, (size.y - icon_side) / 2,
+		var icon_side := button_width - horizontal_margin_width + 2
+		icon.draw_rect(ci, Rect2(size.x - (button_width + 0.5 + icon_side) / 2, (size.y - icon_side) / 2,
 				icon_side, icon_side), false, get_theme_color("icon_normal_color", "LeftConnectedButton"))
 
 
@@ -185,4 +188,4 @@ func _get_font_color() -> Color:
 func draw_button_border(theme_name: String) -> void:
 	var button_outline: StyleBoxFlat = get_theme_stylebox(theme_name, "LeftConnectedButton").duplicate()
 	button_outline.draw_center = false
-	button_outline.draw(ci, Rect2(size.x - BUTTON_WIDTH, 0, BUTTON_WIDTH, size.y))
+	button_outline.draw(ci, Rect2(size.x - button_width, 0, button_width, size.y))

--- a/src/ui_widgets/color_edit.gd
+++ b/src/ui_widgets/color_edit.gd
@@ -56,8 +56,8 @@ func _draw() -> void:
 	stylebox.corner_radius_bottom_right = 5
 	stylebox.bg_color = ColorParser.text_to_color(ColorParser.add_hash_if_hex(value),
 			Color(), enable_alpha)
-	draw_texture(checkerboard, Vector2(size.x - BUTTON_WIDTH, 1))
-	draw_style_box(stylebox, Rect2(size.x - BUTTON_WIDTH, 1, BUTTON_WIDTH - 1, size.y - 2))
+	draw_texture(checkerboard, Vector2(size.x - button_width, 1))
+	draw_style_box(stylebox, Rect2(size.x - button_width, 1, button_width - 1, size.y - 2))
 	if is_instance_valid(temp_button) and temp_button.button_pressed:
 		draw_button_border("pressed")
 	elif is_instance_valid(temp_button) and temp_button.get_global_rect().has_point(

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -99,7 +99,7 @@ func _on_pressed() -> void:
 
 func _draw() -> void:
 	super()
-	var h_offset := size.x - BUTTON_WIDTH
+	var h_offset := size.x - button_width
 	var r := 5
 	checkerboard.draw(ci, Vector2(h_offset, 1))
 	# Draw the color or gradient.
@@ -117,14 +117,14 @@ func _draw() -> void:
 			var initial_pts := PackedVector2Array([Vector2(0, 1), Vector2(0, size.y - 1)])
 			for deg in range(90, -1, -15):
 				var rad := deg_to_rad(deg)
-				initial_pts.append(Vector2(BUTTON_WIDTH - 1 - r + r * cos(rad), size.y - 1 - r + r * sin(rad)))
+				initial_pts.append(Vector2(button_width - 1 - r + r * cos(rad), size.y - 1 - r + r * sin(rad)))
 			for deg in range(0, -91, -15):
 				var rad := deg_to_rad(deg)
-				initial_pts.append(Vector2(BUTTON_WIDTH - 1 - r + r * cos(rad), r + 1 + r * sin(rad)))
+				initial_pts.append(Vector2(button_width - 1 - r + r * cos(rad), r + 1 + r * sin(rad)))
 			for pt in initial_pts:
 				points.append(pt + Vector2(h_offset, 0))
 				colors.append(Color.WHITE)
-				uvs.append(pt / Vector2(BUTTON_WIDTH - 1, size.y - 1))
+				uvs.append(pt / Vector2(button_width - 1, size.y - 1))
 			RenderingServer.canvas_item_add_polygon(ci, points, colors, uvs, gradient_texture)
 			drawn = true
 	
@@ -133,7 +133,7 @@ func _draw() -> void:
 		stylebox.corner_radius_top_right = r
 		stylebox.corner_radius_bottom_right = r
 		stylebox.bg_color = ColorParser.text_to_color(element.get_attribute_true_color(attribute_name), Color.TRANSPARENT)
-		stylebox.draw(ci, Rect2(h_offset, 1, BUTTON_WIDTH - 1, size.y - 2))
+		stylebox.draw(ci, Rect2(h_offset, 1, button_width - 1, size.y - 2))
 	# Draw the button border.
 	if is_instance_valid(temp_button) and temp_button.button_pressed:
 		draw_button_border("pressed")

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -4,6 +4,7 @@ extends PanelContainer
 signal selected
 signal remove_requested
 signal texture_changed
+signal texture_size_changed
 
 
 @onready var select_button: Button = %SelectButton
@@ -25,6 +26,7 @@ var texture_size: int:
 		if spin_box:
 			spin_box.set_value_no_signal(texture_size)
 		_update_texture()
+		texture_size_changed.emit()
 
 
 func _ready() -> void:
@@ -54,7 +56,3 @@ func _get_tex_scale(default_size: Vector2i) -> float:
 	var max_dim_size := texture_size as int
 	
 	return max_dim_size / float(default_size[default_size.max_axis_index()])
-
-
-func set_texture_size(new_size: int) -> void:
-	texture_size = new_size

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -1,0 +1,60 @@
+extends PanelContainer
+
+
+signal selected
+signal remove_requested
+signal texture_changed
+
+
+@onready var select_button: Button = %SelectButton
+@onready var texture_rect: TextureRect = %TextureRect
+@onready var spin_box: SpinBox = %SpinBox
+@onready var remove_button: Button = %RemoveButton
+
+
+var texture: Texture2D
+
+
+var svg_markup: String:
+	set(value):
+		svg_markup = value
+		_update_texture()
+var texture_size: int:
+	set(value):
+		texture_size = value
+		if spin_box:
+			spin_box.set_value_no_signal(texture_size)
+		_update_texture()
+
+
+func _ready() -> void:
+	select_button.pressed.connect(selected.emit)
+	remove_button.pressed.connect(remove_requested.emit)
+	spin_box.value = texture_size
+	spin_box.value_changed.connect(func(new_value: float) -> void:
+		texture_size = new_value as int
+	)
+	_update_texture()
+
+
+func _update_texture() -> void:
+	if not texture_rect:
+		return
+	var tex := SVGTexture.create_from_string(svg_markup)
+	var tex_size := _get_tex_scale(Vector2i(tex.get_size()))
+	if tex_size <= 0.0:
+		tex_size = 0.01
+	tex.base_scale = tex_size
+	texture_rect.texture = tex
+	texture_changed.emit()
+	texture = tex
+
+
+func _get_tex_scale(default_size: Vector2i) -> float:
+	var max_dim_size := texture_size as int
+	
+	return max_dim_size / float(default_size[default_size.max_axis_index()])
+
+
+func set_texture_size(new_size: int) -> void:
+	texture_size = new_size

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -50,6 +50,7 @@ func _update_texture() -> void:
 	texture_rect.texture = tex
 	texture_changed.emit()
 	texture = tex
+	spin_box.suffix = "(x%.1f)" % tex_size
 
 
 func _get_tex_scale(default_size: Vector2i) -> float:

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -24,13 +24,15 @@ var svg_markup: String:
 	set(value):
 		svg_markup = value
 		_update_texture()
+
 var texture_size: int:
 	set(value):
 		texture_size = value
-		if number_edit:
+		if is_instance_valid(number_edit):
 			number_edit.set_value(value, false)
 		_update_texture()
 		texture_size_changed.emit()
+
 var texture_size_string: String
 
 
@@ -47,19 +49,17 @@ func _ready() -> void:
 func _update_texture() -> void:
 	if not texture_rect:
 		return
-	var tex := DPITexture.create_from_string(svg_markup)
-	var tex_size := _get_tex_scale(Vector2i(tex.get_size()))
+	var new_texture := DPITexture.create_from_string(svg_markup)
+	var tex_size := _get_tex_scale(Vector2i(new_texture.get_size()))
 	if tex_size <= 0.0:
 		tex_size = 0.01
-	tex.base_scale = tex_size
-	texture_rect.texture = tex
-	texture = tex
+	new_texture.base_scale = tex_size
+	texture_rect.texture = new_texture
+	texture = new_texture
 	texture_changed.emit()
-	scale_label.text = "(%.1fx)" % tex_size
-	texture_size_string = "%sx%s %s" % [tex.get_width(), tex.get_height(), scale_label.text]
+	scale_label.text = "(%.1f×)" % tex_size
+	texture_size_string = "%s×%s %s" % [new_texture.get_width(), new_texture.get_height(), scale_label.text]
 
 
 func _get_tex_scale(default_size: Vector2i) -> float:
-	var max_dim_size := texture_size as int
-	
-	return max_dim_size / float(default_size[default_size.max_axis_index()])
+	return texture_size / float(default_size[default_size.max_axis_index()])

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -31,6 +31,7 @@ var texture_size: int:
 			number_edit.set_value(value, false)
 		_update_texture()
 		texture_size_changed.emit()
+var texture_size_string: String
 
 
 func _ready() -> void:
@@ -55,6 +56,7 @@ func _update_texture() -> void:
 	texture = tex
 	texture_changed.emit()
 	scale_label.text = "(%.1fx)" % tex_size
+	texture_size_string = "%sx%s %s" % [tex.get_width(), tex.get_height(), scale_label.text]
 
 
 func _get_tex_scale(default_size: Vector2i) -> float:

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -47,7 +47,7 @@ func _ready() -> void:
 func _update_texture() -> void:
 	if not texture_rect:
 		return
-	var tex := SVGTexture.create_from_string(svg_markup)
+	var tex := DPITexture.create_from_string(svg_markup)
 	var tex_size := _get_tex_scale(Vector2i(tex.get_size()))
 	if tex_size <= 0.0:
 		tex_size = 0.01

--- a/src/ui_widgets/icon_view_tile.gd
+++ b/src/ui_widgets/icon_view_tile.gd
@@ -1,6 +1,9 @@
 extends PanelContainer
 
 
+const NumberEdit = preload("res://src/ui_widgets/number_edit.gd")
+
+
 signal selected
 signal remove_requested
 signal texture_changed
@@ -9,7 +12,8 @@ signal texture_size_changed
 
 @onready var select_button: Button = %SelectButton
 @onready var texture_rect: TextureRect = %TextureRect
-@onready var spin_box: SpinBox = %SpinBox
+@onready var scale_label: Label = %ScaleLabel
+@onready var number_edit: NumberEdit = %NumberEdit
 @onready var remove_button: Button = %RemoveButton
 
 
@@ -23,8 +27,8 @@ var svg_markup: String:
 var texture_size: int:
 	set(value):
 		texture_size = value
-		if spin_box:
-			spin_box.set_value_no_signal(texture_size)
+		if number_edit:
+			number_edit.set_value(value, false)
 		_update_texture()
 		texture_size_changed.emit()
 
@@ -32,8 +36,8 @@ var texture_size: int:
 func _ready() -> void:
 	select_button.pressed.connect(selected.emit)
 	remove_button.pressed.connect(remove_requested.emit)
-	spin_box.value = texture_size
-	spin_box.value_changed.connect(func(new_value: float) -> void:
+	number_edit.set_value(texture_size)
+	number_edit.value_changed.connect(func(new_value: float) -> void:
 		texture_size = new_value as int
 	)
 	_update_texture()
@@ -48,9 +52,9 @@ func _update_texture() -> void:
 		tex_size = 0.01
 	tex.base_scale = tex_size
 	texture_rect.texture = tex
-	texture_changed.emit()
 	texture = tex
-	spin_box.suffix = "(x%.1f)" % tex_size
+	texture_changed.emit()
+	scale_label.text = "(%.1fx)" % tex_size
 
 
 func _get_tex_scale(default_size: Vector2i) -> float:

--- a/src/ui_widgets/icon_view_tile.gd.uid
+++ b/src/ui_widgets/icon_view_tile.gd.uid
@@ -1,0 +1,1 @@
+uid://do0fpk0t0rt6

--- a/src/ui_widgets/icon_view_tile.tscn
+++ b/src/ui_widgets/icon_view_tile.tscn
@@ -1,12 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://18urhivvngk"]
+[gd_scene load_steps=4 format=3 uid="uid://18urhivvngk"]
 
 [ext_resource type="Script" uid="uid://do0fpk0t0rt6" path="res://src/ui_widgets/icon_view_tile.gd" id="1_abkju"]
-[ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="2_qe8f5"]
 [ext_resource type="Texture2D" uid="uid://cj5x2ti8150ja" path="res://assets/icons/Delete.svg" id="4_jtilr"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_le2pg"]
 
 [node name="IconViewTile" type="PanelContainer"]
+size_flags_horizontal = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_le2pg")
 script = ExtResource("1_abkju")
 
@@ -35,7 +35,6 @@ mouse_filter = 2
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 2
-texture = ExtResource("2_qe8f5")
 stretch_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
@@ -44,6 +43,7 @@ mouse_filter = 2
 
 [node name="SpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 min_value = 1.0
@@ -54,5 +54,8 @@ allow_greater = true
 [node name="RemoveButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Delete this icon preview"
+focus_mode = 0
+mouse_default_cursor_shape = 2
+theme_type_variation = &"FlatButton"
 icon = ExtResource("4_jtilr")
-flat = true

--- a/src/ui_widgets/icon_view_tile.tscn
+++ b/src/ui_widgets/icon_view_tile.tscn
@@ -1,0 +1,58 @@
+[gd_scene load_steps=5 format=3 uid="uid://18urhivvngk"]
+
+[ext_resource type="Script" uid="uid://do0fpk0t0rt6" path="res://src/ui_widgets/icon_view_tile.gd" id="1_abkju"]
+[ext_resource type="Texture2D" uid="uid://barsurula6j8n" path="res://assets/logos/icon.svg" id="2_qe8f5"]
+[ext_resource type="Texture2D" uid="uid://cj5x2ti8150ja" path="res://assets/icons/Delete.svg" id="4_jtilr"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_le2pg"]
+
+[node name="IconViewTile" type="PanelContainer"]
+theme_override_styles/panel = SubResource("StyleBoxEmpty_le2pg")
+script = ExtResource("1_abkju")
+
+[node name="SelectButton" type="Button" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/margin_left = 4
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 4
+theme_override_constants/margin_bottom = 4
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+layout_mode = 2
+mouse_filter = 2
+
+[node name="CenterContainer" type="CenterContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+mouse_filter = 2
+
+[node name="TextureRect" type="TextureRect" parent="MarginContainer/VBoxContainer/CenterContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_filter = 2
+texture = ExtResource("2_qe8f5")
+stretch_mode = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+layout_mode = 2
+mouse_filter = 2
+
+[node name="SpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 1.0
+value = 1.0
+rounded = true
+allow_greater = true
+
+[node name="RemoveButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+icon = ExtResource("4_jtilr")
+flat = true

--- a/src/ui_widgets/icon_view_tile.tscn
+++ b/src/ui_widgets/icon_view_tile.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=3 uid="uid://18urhivvngk"]
+[gd_scene load_steps=5 format=3 uid="uid://18urhivvngk"]
 
 [ext_resource type="Script" uid="uid://do0fpk0t0rt6" path="res://src/ui_widgets/icon_view_tile.gd" id="1_abkju"]
+[ext_resource type="PackedScene" uid="uid://dad7fkhmsooc6" path="res://src/ui_widgets/number_edit.tscn" id="2_le2pg"]
 [ext_resource type="Texture2D" uid="uid://cj5x2ti8150ja" path="res://assets/icons/Delete.svg" id="4_jtilr"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_le2pg"]
@@ -13,6 +14,8 @@ script = ExtResource("1_abkju")
 [node name="SelectButton" type="Button" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+focus_mode = 0
+mouse_default_cursor_shape = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -41,15 +44,18 @@ stretch_mode = 2
 layout_mode = 2
 mouse_filter = 2
 
-[node name="SpinBox" type="SpinBox" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="NumberEdit" parent="MarginContainer/VBoxContainer/HBoxContainer" instance=ExtResource("2_le2pg")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 min_value = 1.0
-value = 1.0
-rounded = true
-allow_greater = true
+allow_lower = false
+is_float = false
+
+[node name="ScaleLabel" type="Label" parent="MarginContainer/VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "(2x)"
 
 [node name="RemoveButton" type="Button" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -97,7 +97,7 @@ func _draw() -> void:
 	stylebox.corner_radius_top_right = 5
 	stylebox.corner_radius_bottom_right = 5
 	stylebox.bg_color = get_theme_stylebox("normal", "LineEdit").bg_color
-	stylebox.draw(ci, Rect2(size.x - BUTTON_WIDTH, 1, BUTTON_WIDTH - 2, size.y - 2))
+	stylebox.draw(ci, Rect2(size.x - button_width, 1, button_width - 2, size.y - 2))
 	var fill_height := (size.y - 4) * (element.get_attribute_num(attribute_name) - MIN_VALUE) / MAX_VALUE
 	# Create a stylebox that'll occupy the exact amount of space.
 	var fill_stylebox := StyleBoxFlat.new()
@@ -106,7 +106,7 @@ func _draw() -> void:
 		fill_stylebox.bg_color.a = 0.65
 	elif not slider_hovered:
 		fill_stylebox.bg_color.a = 0.5
-	fill_stylebox.draw(ci, Rect2(size.x - BUTTON_WIDTH, size.y - 2 - fill_height, BUTTON_WIDTH - 2, fill_height))
+	fill_stylebox.draw(ci, Rect2(size.x - button_width, size.y - 2 - fill_height, button_width - 2, fill_height))
 	if slider_dragged:
 		draw_button_border("pressed")
 	elif slider_hovered:

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -321,6 +321,20 @@ static func _setup_panelcontainer(theme: Theme) -> void:
 	contrast_panel_stylebox.bg_color = contrast_flat_panel_color
 	theme.set_stylebox("panel", "ContrastFlatPanel", contrast_panel_stylebox)
 	
+	theme.add_type("OutlinedPanel")
+	theme.set_type_variation("OutlinedPanel", "PanelContainer")
+	var outlined_panel_stylebox := StyleBoxFlat.new()
+	outlined_panel_stylebox.set_corner_radius_all(2)
+	outlined_panel_stylebox.set_border_width_all(2)
+	outlined_panel_stylebox.set_expand_margin_all(2)
+	outlined_panel_stylebox.content_margin_left = 0.0
+	outlined_panel_stylebox.content_margin_right = 0.0
+	outlined_panel_stylebox.content_margin_top = 0.0
+	outlined_panel_stylebox.content_margin_bottom = 0.0
+	outlined_panel_stylebox.bg_color = Color.TRANSPARENT
+	outlined_panel_stylebox.border_color = overlay_panel_border_color
+	theme.set_stylebox("panel", "OutlinedPanel", outlined_panel_stylebox)
+	
 	theme.add_type("OverlayPanel")
 	theme.set_type_variation("OverlayPanel", "PanelContainer")
 	var overlay_stylebox := StyleBoxFlat.new()

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -326,11 +326,8 @@ static func _setup_panelcontainer(theme: Theme) -> void:
 	var outlined_panel_stylebox := StyleBoxFlat.new()
 	outlined_panel_stylebox.set_corner_radius_all(2)
 	outlined_panel_stylebox.set_border_width_all(2)
-	outlined_panel_stylebox.set_expand_margin_all(2)
-	outlined_panel_stylebox.content_margin_left = 0.0
-	outlined_panel_stylebox.content_margin_right = 0.0
-	outlined_panel_stylebox.content_margin_top = 0.0
-	outlined_panel_stylebox.content_margin_bottom = 0.0
+	outlined_panel_stylebox.set_expand_margin_all(2.0)
+	outlined_panel_stylebox.set_content_margin_all(0.0)
 	outlined_panel_stylebox.bg_color = Color.TRANSPARENT
 	outlined_panel_stylebox.border_color = overlay_panel_border_color
 	theme.set_stylebox("panel", "OutlinedPanel", outlined_panel_stylebox)

--- a/src/utils/TranslationUtils.gd
+++ b/src/utils/TranslationUtils.gd
@@ -126,6 +126,7 @@ static func get_layout_part_name(layout_part: Utils.LayoutPart) -> String:
 		Utils.LayoutPart.CODE_EDITOR: return Translator.translate("Code editor")
 		Utils.LayoutPart.INSPECTOR: return Translator.translate("Inspector")
 		Utils.LayoutPart.VIEWPORT: return Translator.translate("Viewport")
+		Utils.LayoutPart.ICON_VIEW: return Translator.translate("Icon preview")
 		_: return ""
 
 ## Generates an alert text for unsupported file extensions.

--- a/src/utils/Utils.gd
+++ b/src/utils/Utils.gd
@@ -4,12 +4,13 @@ const MAX_NUMERIC_PRECISION = 6
 const MAX_ANGLE_PRECISION = 4
 
 enum InteractionType {NONE = 0, HOVERED = 1, SELECTED = 2, HOVERED_SELECTED = 3}
-enum LayoutPart {NONE, CODE_EDITOR, INSPECTOR, VIEWPORT}
+enum LayoutPart {NONE, CODE_EDITOR, INSPECTOR, VIEWPORT, ICON_VIEW}
 
 const _LAYOUT_ICONS: Dictionary[LayoutPart, Texture2D] = {
 	LayoutPart.CODE_EDITOR: preload("res://assets/icons/CodeEditor.svg"),
 	LayoutPart.INSPECTOR: preload("res://assets/icons/Inspector.svg"),
 	LayoutPart.VIEWPORT: preload("res://assets/icons/Viewport.svg"),
+	LayoutPart.ICON_VIEW: preload("res://assets/icons/Scale.svg"),
 }
 const _LAYOUT_PLACEHOLDER_ICON = preload("res://assets/icons/Placeholder.svg")
 


### PR DESCRIPTION
[Screencast_20250818_232237.webm](https://github.com/user-attachments/assets/e1084365-fba1-427c-a527-af5efca20398)

It works roughly like Inkscape's. You can add new views, remove existing ones, or change the rasterization size of existing ones. You can also select tiles to view them in a "blown up" view, all pixel interpolated. I'm not sure if there's a better way to get the current SVG markup of the current tab, I'm just remarkup-ifying the root XML node every time it changes. This PR might also need a rebase
