### PR TITLE
Small code simplifications and contributing guidelines tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,22 +31,28 @@ After submitting your pull request, I (MewPurPur) will review your changes and m
 
 Editing translations is explained [here](translations/README.md)
 
-## Code guidelines
+## Code guidelines and style
 
-To document some quirks of our code that we've decided on:
+As usual, look around and try to copy the things you find in surrounding code.
 
-- StringNames are avoided when possible. We do this because it makes the codebase simpler, although if something is actually shown to be performance-critical, it can be reconsidered.
-- Nodes may only be exported if their runtime structure isn't known.
+Guidelines:
+
+- StringNames are avoided when possible.
+  - Rationale: This makes the codebase simpler, and StringNames aren't a universal optimization. I've heard of a lot of cases where they counterintuitively make performance worse, and I don't currently understand them well-enough to not fall into traps. If performance benefits for using StringName somewhere are arduously benchmarked, it can be considered.
+- We avoid exporting nodes, unless their runtime structure isn't known.
 - Strings are always translated with `Translator.translate()`, not `tr()`.
 
-## Code style
+Follow the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html). Almost all this guide's rules are enforced here.
 
-For scripts, only GDScript code is allowed. Follow the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html). Most of its rules are enforced here. Additionally:
+We have some additional style rules:
 
-- Static typing is used as much as possible.
+- Always use static typing. And if possible, use inferred typing, i.e., `var f := 4.0` instead of `var f: float = 4.0`
 - Comments are typically written like sentences with punctuation.
-- Two spaces are used to separate inline comments and code.
+- Inline comments are separated from the code by two spaces.
+- Documentation comments are written like normal comments, without modifiers like `[param]` or `[code]`.
+  - Rationale: The amount by which they improve the readability of the documentation isn't enough to outweigh how much worse they are when you look at them in code. I believe they aren't suitable in a project where only developers will be reading them.
 - For empty lines in the middle of indented blocks, the scope's indentation is kept.
+  - Rationale: I don't really know why this isn't conventional, I find that it just gets in the way when you want to add code where there were previously empty spaces.
 - Class names use `class_name X extends Y` syntax.
 
 Don't make pull requests for code style changes without discussing them first (unless it's for corrections to abide by the ones described here). The same generally applies to making style changes unrelated to a PR's main goal. Pull requests may also get production tweaks to tweak their style before being merged.

--- a/assets/icons/Checkerboard.svg
+++ b/assets/icons/Checkerboard.svg
@@ -1,1 +1,1 @@
-<svg height="128" width="128" xmlns="http://www.w3.org/2000/svg"><g opacity=".4"><path d="M128 0H64v64h64zM64 64H0v64h64z" fill="#666"/><path d="M128 64H64v64h64zm-64 0V0H0v64z" fill="#999"/></g></svg>
+<svg height="128" width="128" xmlns="http://www.w3.org/2000/svg"><g opacity=".4"><path d="M0 0h128v128h-128z" fill="#999"/><path d="M128 0H64v64h64zM64 64H0v64h64z" fill="#666"/></g></svg>

--- a/assets/icons/CheckerboardMini.svg
+++ b/assets/icons/CheckerboardMini.svg
@@ -1,1 +1,1 @@
-<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M16 0H8v8h8zM8 8H0v8h8z" fill="#888"/><path d="M16 8H8v8h8zM8 8V0H0v8z" fill="#ccc"/></svg>
+<svg height="16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h16v16h-16z" fill="#ccc"/><path d="M16 0H8v8h8zM8 8H0v8h8z" fill="#888"/></svg>

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -63,7 +63,7 @@ func _on_svg_changed() -> void:
 		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
 	
 	_current_svg_size = root_element.get_size()
-	queue_texture_update(true)
+	queue_texture_update()
 	handles_manager.queue_update_handles()
 
 func _on_hover_changed() -> void:


### PR DESCRIPTION
Tweaks contributing guidelines to address how documentation comments - which were recently introduced into the codebase - should be written.

Tweaks (and slightly improves) two of the three checkerboard textures, now no matter how they are scaled there won't be little gaps.

Simplifies the inner markup caching optimization.