### PR TITLE
Make pan strength configurable

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -100,6 +100,7 @@ func get_setting_default(setting: String) -> Variant:
 		# Other
 		"invert_zoom": return false
 		"wraparound_panning": return false
+		"panning_speed": return 20
 		"use_ctrl_for_zoom": return true
 		"ui_scale": return ScalingApproach.AUTO
 		"vsync": return true
@@ -480,6 +481,20 @@ const MAX_SELECTION_RECTANGLE_DASH_LENGTH = 600.0
 	set(new_value):
 		if wraparound_panning != new_value:
 			wraparound_panning = new_value
+			emit_changed()
+
+const PANNING_SPEED_MIN = 1
+const PANNING_SPEED_MAX = 400
+@export var panning_speed := 20:
+	set(new_value):
+		# Validation
+		if is_nan(new_value):
+			new_value = 20
+		else:
+			new_value = clampi(new_value, PANNING_SPEED_MIN, PANNING_SPEED_MAX)
+		# Main part
+		if panning_speed != new_value:
+			panning_speed = new_value
 			emit_changed()
 
 @export var use_ctrl_for_zoom := true:

--- a/src/ui_widgets/settings_content_generic.gd
+++ b/src/ui_widgets/settings_content_generic.gd
@@ -548,6 +548,12 @@ func setup_other_content() -> void:
 	if wraparound_panning_forced_off:
 		wraparound_panning.permanent_disable_checkbox(false)
 	
+	current_setup_setting = "panning_speed"
+	add_number_dropdown(Translator.translate("Panning speed"), [5, 10, 20, 30, 50], true, false,
+			SaveData.PANNING_SPEED_MIN, SaveData.PANNING_SPEED_MAX)
+	add_preview(SettingTextPreview.new(
+			Translator.translate("Determines how much the view moves for scroll-based panning inputs.")))
+	
 	current_setup_setting = "use_ctrl_for_zoom"
 	add_checkbox(Translator.translate("Use CTRL for zooming"))
 	add_preview(SettingTextPreview.new(

--- a/src/ui_widgets/viewport_controls.gd
+++ b/src/ui_widgets/viewport_controls.gd
@@ -24,11 +24,9 @@ func _unhandled_input(event: InputEvent) -> void:
 	
 	elif event is InputEventPanGesture and DisplayServer.get_name() != "Android":
 		if event.ctrl_pressed:
-			# Zooming with Ctrl + touch?
-			canvas.set_zoom(canvas.camera_zoom * (1.0 + event.delta.y / 2.0))
+			canvas.set_zoom(canvas.camera_zoom * (1.0 + event.delta.y / 2.0))  # Zooming with Ctrl + touch?
 		else:
-			# Panning with touch.
-			canvas.set_view(canvas.camera_center + event.delta * 32.0 / canvas.camera_zoom)
+			execute_panning(event.delta)  # Panning with touch.
 	elif event is InputEventMagnifyGesture:
 		# Zooming with touch.
 		canvas.set_zoom(canvas.camera_zoom * event.factor)
@@ -73,10 +71,13 @@ func _unhandled_input(event: InputEvent) -> void:
 		elif zoom_direction == -1:
 			canvas.set_zoom(canvas.camera_zoom / multiplied_factor, mouse_offset)
 		
-		canvas.set_view(canvas.camera_center + move_vec * factor / canvas.camera_zoom * 32)
+		execute_panning(move_vec, factor)
 	
 	else:
 		if not event.is_echo():
 			# Filter out fake mouse movement events.
 			if not (event is InputEventMouseMotion and event.relative == Vector2.ZERO):
 				_zoom_to = Vector2.ZERO  # Reset Ctrl + MMB zoom position if released.
+
+func execute_panning(move_vector: Vector2, factor := 1.0) -> void:
+	canvas.set_view(canvas.camera_center + move_vector * factor * Configs.savedata.panning_speed / canvas.camera_zoom)


### PR DESCRIPTION
Scroll-based panning sensitivity makes sense to be configurable, especially given how inconsistent it is between devices. It was already on the strong side, but if a device had a really sensitive touchpad, panning would become hard to use. So I made it configurable, and the new default panning went from 32 to 20.

Applies only to the viewport. I don't really know how good of an idea it is to make it apply to other things, and sadly I no longer have a device with a very sensitive touchpad to test with...