### PR TITLE
Simplify signals in State

### DIFF
--- a/src/data_classes/XNode.gd
+++ b/src/data_classes/XNode.gd
@@ -1,4 +1,4 @@
-# Abstract base class for XML nodes.
+## Abstract base class for XML nodes.
 @abstract class_name XNode
 
 var xid: PackedInt32Array

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -50,8 +50,8 @@ func _ready() -> void:
 	pressed.connect(_on_pressed)
 	button_gui_input.connect(_on_button_gui_input)
 	# URLs and currentColor require to always listen for changes to the SVG.
-	element.root.any_attribute_changed.connect(_on_svg_changed.unbind(1))
-	element.root.xnode_layout_changed.connect(_on_svg_changed)
+	State.any_attribute_changed.connect(_on_svg_changed.unbind(1))
+	State.xnode_layout_changed.connect(_on_svg_changed)
 	tooltip_text = attribute_name
 	setup_placeholder()
 


### PR DESCRIPTION
Some cleanup as I'll be working on this part of GodSVG's infrastructure soon. The exact layout changes shouldn't need to be known by anything persistent, as all aspects of the editor should react very fast to arbitrary changes too. More specificity can be brought back in the future if needed, but I don't foresee that. Hover and selection-related things need to be synced to root_element signals, which will always be based on the current root element itself and not require the persistence that State signals have.