### PR TITLE
Add distinction between editing and switching SVGs

### DIFF
--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -800,7 +800,7 @@ func set_palettes(new_palettes: Array[Palette]) -> void:
 			editor_formatter = new_value
 			emit_changed()
 			editor_formatter.changed.connect(emit_changed)
-			editor_formatter.changed_deferred.connect(State.sync_to_editor_formatter)
+			editor_formatter.changed_deferred.connect(State.sync_stable_editor_markup)
 
 @export var export_formatter: Formatter = null:
 	set(new_value):
@@ -955,7 +955,6 @@ func _add_new_tab() -> void:
 		new_id += 1
 	
 	var new_tab := TabData.new(new_id)
-	new_tab.fully_loaded = false
 	new_tab.changed.connect(emit_changed)
 	new_tab.status_changed.connect(_on_tab_status_changed.bind(new_id))
 	

--- a/src/ui_parts/export_menu.tscn
+++ b/src/ui_parts/export_menu.tscn
@@ -159,6 +159,7 @@ size_flags_horizontal = 0
 focus_mode = 0
 mouse_default_cursor_shape = 2
 button_pressed = true
+action_mode = 0
 
 [node name="QualityHBox" type="HBoxContainer" parent="MarginContainer/VBoxContainer/TitledPanel/VBoxContainer/CenterContainer/VBoxContainer/QualityRelatedContainer"]
 unique_name_in_owner = true

--- a/src/ui_parts/global_actions.gd
+++ b/src/ui_parts/global_actions.gd
@@ -71,7 +71,7 @@ func open_savedata_folder() -> void:
 
 
 func update_size_button() -> void:
-	var svg_text_size := State.svg_text.length()
+	var svg_text_size := State.stable_export_markup.length()
 	size_button.text = String.humanize_size(svg_text_size)
 	size_button.tooltip_text = String.num_uint64(svg_text_size) + " B"
 	if State.root_element.optimize(true):

--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -98,7 +98,12 @@ func _ready() -> void:
 	shortcuts.add_shortcut("ui_accept", func() -> void:
 			var selected_item_indices := file_list.get_selected_items()
 			if not selected_item_indices.is_empty():
-				call_activation_callback(file_list.get_item_metadata(selected_item_indices[0])))
+				call_activation_callback(file_list.get_item_metadata(selected_item_indices[0]))
+	)
+	shortcuts.add_shortcut("open_in_folder", func() -> void:
+			var selected_paths := get_selected_file_paths()
+			OS.shell_show_in_file_manager(current_dir if selected_paths.is_empty() else selected_paths[0])
+	)
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
 	# Signal connections.
@@ -374,8 +379,9 @@ func open_dir_context(dir: String) -> void:
 		ContextPopup.create_shortcut_button("ui_accept", false,
 				Translator.translate("Open"), load("res://assets/icons/OpenFolder.svg")),
 		ContextPopup.create_button(Translator.translate("Copy path"),
-				DisplayServer.clipboard_set.bind(dir), false,
-				load("res://assets/icons/Copy.svg"))]
+				DisplayServer.clipboard_set.bind(dir), false, load("res://assets/icons/Copy.svg")),
+		ContextPopup.create_shortcut_button("open_in_folder", false),
+	]
 	context_popup.setup(btn_arr, true)
 	var vp := get_viewport()
 	HandlerGUI.popup_under_pos(context_popup, vp.get_mouse_position(), vp)
@@ -395,6 +401,7 @@ func open_file_context() -> void:
 	if selected_file_paths.size() == 1:
 		btn_arr.append(ContextPopup.create_button(Translator.translate("Copy path"),
 				copy_file_path, false, load("res://assets/icons/Copy.svg")))
+	btn_arr.append(ContextPopup.create_shortcut_button("open_in_folder", false))
 	
 	var context_popup := ContextPopup.new()
 	context_popup.setup(btn_arr, true)

--- a/src/ui_parts/good_file_dialog.tscn
+++ b/src/ui_parts/good_file_dialog.tscn
@@ -10,7 +10,6 @@
 [ext_resource type="Script" uid="uid://ynx3s1jc6bwq" path="res://src/ui_widgets/BetterButton.gd" id="7_ejhg0"]
 
 [node name="GoodFileDialog" type="PanelContainer"]
-anchors_preset = -1
 offset_right = 684.0
 offset_bottom = 386.0
 theme_type_variation = &"OverlayPanel"

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -11,6 +11,7 @@ func _ready() -> void:
 	sync_localization()
 	State.xnode_layout_changed.connect(full_rebuild)
 	State.svg_unknown_change.connect(full_rebuild)
+	State.svg_switched_to_another.connect(full_rebuild)
 	full_rebuild()
 	add_button.pressed.connect(_on_add_button_pressed)
 

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -26,46 +26,52 @@ var reference_texture_rect: TextureRect
 
 func _ready() -> void:
 	super()
-	camera_center_changed.connect(func() -> void: Configs.savedata.get_active_tab().camera_center = camera_center)
-	camera_zoom_changed.connect(func() -> void: Configs.savedata.get_active_tab().camera_zoom = camera_zoom)
+	camera_center_changed.connect(sync_camera_center_in_tab)
+	camera_zoom_changed.connect(sync_camera_zoom_in_tab)
 	var shortcuts := ShortcutsRegistration.new()
 	shortcuts.add_shortcut("view_show_grid", toggle_show_grid, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	shortcuts.add_shortcut("view_show_handles", toggle_show_handles, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	shortcuts.add_shortcut("view_rasterized_svg", toggle_view_rasterized, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
-	State.svg_changed.connect(_on_svg_changed)
-	_on_svg_changed()
+	State.parsing_finished.connect(_on_parsing_finished)
+	State.svg_edited.connect(_on_svg_changed.bind(true))
+	State.svg_switched_to_another.connect(_on_svg_changed.bind(false))
 	State.hover_changed.connect(_on_hover_changed)
 	State.selection_changed.connect(_on_selection_changed)
 	
 	Configs.active_tab_changed.connect(sync_reference_image)
-	Configs.active_tab_changed.connect(_on_svg_changed)
 	Configs.active_tab_changed.connect(sync_camera.call_deferred)
 	await get_tree().process_frame
 	center_frame()
 
-func _on_svg_resized() -> void:
-	sync_checkerboard()
-	center_frame()
-	queue_redraw()
+func sync_camera_center_in_tab() -> void:
+	Configs.savedata.get_active_tab().camera_center = camera_center
+
+func sync_camera_zoom_in_tab() -> void:
+	Configs.savedata.get_active_tab().camera_zoom = camera_zoom
+
+func sync_svg_size() -> void:
+	if _current_svg_size != root_element.get_size():
+		_current_svg_size = root_element.get_size()
+		sync_checkerboard()
+		center_frame()
+		queue_redraw()
 
 var _current_svg_size: Vector2
 
 func _on_root_element_attribute_changed(attribute_name: String) -> void:
-	if attribute_name in ["width", "height", "viewBox"] and _current_svg_size != root_element.get_size():
-		_current_svg_size = root_element.get_size()
-		_on_svg_resized()
+	if attribute_name in ["width", "height", "viewBox"]:
+		sync_svg_size()
 
-func _on_svg_changed() -> void:
-	if root_element != State.root_element:
+func _on_parsing_finished(error: SVGParser.ParseError) -> void:
+	if error == SVGParser.ParseError.OK:
 		root_element = State.root_element
 		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
-	
-	if _current_svg_size != root_element.get_size():
-		_current_svg_size = root_element.get_size()
-		_on_svg_resized()
-	
+
+func _on_svg_changed(is_edit: bool) -> void:
+	if is_edit:
+		sync_svg_size()
 	queue_texture_update()
 	handles_manager.queue_update_handles()
 
@@ -117,3 +123,6 @@ func sync_camera() -> void:
 		adjust_view()
 	else:
 		center_frame()
+		# Make sure to sync them in case they didn't change after the centering.
+		sync_camera_center_in_tab()
+		sync_camera_zoom_in_tab()

--- a/src/ui_parts/root_element_editor.gd
+++ b/src/ui_parts/root_element_editor.gd
@@ -19,7 +19,7 @@ const NumberEdit = preload("res://src/ui_widgets/number_edit.gd")
 
 func _ready() -> void:
 	State.any_attribute_changed.connect(_on_any_attribute_changed)
-	State.svg_unknown_change.connect(update_attributes)
+	State.svg_changed.connect(update_attributes)
 	update_attributes()
 	width_edit.value_changed.connect(_on_width_edit_value_changed)
 	height_edit.value_changed.connect(_on_height_edit_value_changed)

--- a/src/ui_parts/update_menu.tscn
+++ b/src/ui_parts/update_menu.tscn
@@ -38,6 +38,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 focus_mode = 0
 disabled = true
+action_mode = 0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer"]
 layout_mode = 2

--- a/src/ui_widgets/ContextPopup.gd
+++ b/src/ui_widgets/ContextPopup.gd
@@ -1,5 +1,5 @@
-class_name ContextPopup extends PanelContainer
 ## Standard popup for actions with methods for easy setup.
+class_name ContextPopup extends PanelContainer
 
 const arrow = preload("res://assets/icons/PopupArrow.svg")
 
@@ -116,6 +116,7 @@ static func create_checkbox(text: String, toggle_action: Callable, start_pressed
 		checkbox.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	
 	checkbox.text = text
+	checkbox.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
 	checkbox.button_pressed = start_pressed
 	checkbox.toggled.connect(toggle_action.unbind(1))
 	

--- a/src/ui_widgets/Handle.gd
+++ b/src/ui_widgets/Handle.gd
@@ -1,4 +1,4 @@
-# Base class for handles.
+## Base class for handles.
 @abstract class_name Handle
 
 enum Display {BIG, SMALL}

--- a/src/ui_widgets/XYHandle.gd
+++ b/src/ui_widgets/XYHandle.gd
@@ -1,4 +1,4 @@
-# A handle that binds to two numeric attributes.
+## A handle whose x and y coordinates bind to two numeric attributes.
 class_name XYHandle extends Handle
 
 var x_name: String

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -50,8 +50,7 @@ func _ready() -> void:
 	pressed.connect(_on_pressed)
 	button_gui_input.connect(_on_button_gui_input)
 	# URLs and currentColor require to always listen for changes to the SVG.
-	State.any_attribute_changed.connect(_on_svg_changed.unbind(1))
-	State.xnode_layout_changed.connect(_on_svg_changed)
+	State.svg_edited.connect(_on_svg_modified)
 	tooltip_text = attribute_name
 	setup_placeholder()
 
@@ -66,7 +65,7 @@ func _on_element_ancestor_attribute_changed(attribute_changed: String) -> void:
 		sync()
 
 # Redraw in case the gradient might have changed.
-func _on_svg_changed() -> void:
+func _on_svg_modified() -> void:
 	if cached_allow_url and ColorParser.is_valid_url(element.get_implied_attribute_value(attribute_name)):
 		update_gradient_texture()
 		queue_redraw()

--- a/src/ui_widgets/options_dialog.tscn
+++ b/src/ui_widgets/options_dialog.tscn
@@ -58,6 +58,7 @@ visible = false
 layout_mode = 2
 focus_mode = 0
 mouse_default_cursor_shape = 2
+action_mode = 0
 
 [node name="OptionsContainer" type="HBoxContainer" parent="MainContainer"]
 layout_mode = 2

--- a/src/ui_widgets/path_popup.tscn
+++ b/src/ui_widgets/path_popup.tscn
@@ -24,6 +24,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 focus_mode = 0
 mouse_default_cursor_shape = 2
+action_mode = 0
 flat = true
 alignment = 2
 

--- a/src/ui_widgets/preview_rect.gd
+++ b/src/ui_widgets/preview_rect.gd
@@ -6,7 +6,11 @@ const MAX_IMAGE_DIMENSION = 512
 @onready var texture_preview: TextureRect = $Checkerboard/TexturePreview
 
 func setup_svg_without_dimensions(svg_text: String) -> void:
-	setup_svg(svg_text, SVGParser.markup_to_root(svg_text).svg.get_size())
+	var root := SVGParser.markup_to_root(svg_text).svg
+	if is_instance_valid(root):
+		setup_svg(svg_text, root.get_size())
+	else:
+		hide()
 
 func setup_svg(svg_text: String, dimensions: Vector2) -> void:
 	if not is_node_ready():

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -39,6 +39,7 @@ func permanent_disable_checkbox(checkbox_state: bool) -> void:
 func setup_checkbox() -> void:
 	widget = CheckBox.new()
 	widget.focus_mode = Control.FOCUS_NONE
+	widget.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
 	widget.mouse_filter = Control.MOUSE_FILTER_PASS
 	widget.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	add_child(widget)


### PR DESCRIPTION
Up until now, editing the SVG markup and switching to a new tab were treated as the exact same operation on the SVG's end. But now, there's a distinction that can be used by anything that connects to State signals. The main canvas uses it to decide if it should re-center the graphic when its dimensions change.

TODO - this PR was also aiming to make unstable markup much better supported, but I didn't do much work on that.