### PR TITLE
Small bugfixes, code tweaks, and shutting up the stupid integer division warning

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -34,6 +34,10 @@ Configs="*res://src/autoload/Configs.gd"
 State="*res://src/autoload/State.gd"
 HandlerGUI="*res://src/autoload/HandlerGUI.gd"
 
+[debug]
+
+gdscript/warnings/integer_division=0
+
 [display]
 
 window/size/viewport_width=1040

--- a/src/config_classes/SaveData.gd
+++ b/src/config_classes/SaveData.gd
@@ -971,8 +971,7 @@ func add_empty_tab() -> void:
 	Configs.tabs_changed.emit()
 	set_active_tab_index(_tabs.size() - 1)
 
-# Adds a new path with the given path.
-# If a tab with the path already exists, it's set as the active tab instead.
+## Adds a new path with the given path. If a tab with the path already exists, it's set as the active tab instead.
 func add_tab_with_path(new_file_path: String) -> void:
 	for idx in _tabs.size():
 		if _tabs[idx].svg_file_path == new_file_path:

--- a/src/data_classes/AttributeList.gd
+++ b/src/data_classes/AttributeList.gd
@@ -53,11 +53,10 @@ static func text_to_list(string: String) -> PackedFloat64Array:
 	var comma_exhausted := false
 	var pos := 0
 	while pos < string.length():
-		@warning_ignore("shadowed_global_identifier")
-		var char := string[pos]
+		var current_char := string[pos]
 		match char:
 			"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "-", "+", ".", "e", "E":
-				current_num_string += char
+				current_num_string += current_char
 			" ":
 				if current_num_string.is_empty():
 					pos += 1

--- a/src/data_classes/ElementPolygon.gd
+++ b/src/data_classes/ElementPolygon.gd
@@ -23,7 +23,6 @@ func get_bounding_box() -> Rect2:
 	var max_x := -INF
 	var max_y := -INF
 	
-	@warning_ignore("integer_division")
 	for idx in list.get_list_size() / 2:
 		var x_coord := list.get_list_element(idx * 2)
 		var y_coord := list.get_list_element(idx * 2 + 1)
@@ -86,7 +85,6 @@ func simplify() -> void:
 	var list := get_attribute_list("points")
 	var new_list_points := PackedFloat64Array()
 	
-	@warning_ignore("integer_division")
 	for idx in list.size() / 2 - 1:
 		var prev_point := Vector2(list[idx * 2 - 2], list[idx * 2 - 2])
 		if not is_equal_approx(prev_point.angle_to_point(

--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -25,7 +25,6 @@ func get_bounding_box() -> Rect2:
 	var max_x := -INF
 	var max_y := -INF
 	
-	@warning_ignore("integer_division")
 	for idx in list.get_list_size() / 2:
 		var x_coord := list.get_list_element(idx * 2)
 		var y_coord := list.get_list_element(idx * 2 + 1)
@@ -79,7 +78,6 @@ func simplify() -> void:
 	
 	new_list_points.append(list[0])
 	new_list_points.append(list[1])
-	@warning_ignore("integer_division")
 	for idx in range(1, list.size() / 2 - 1):
 		var prev_point := Vector2(list[idx * 2 - 2], list[idx * 2 - 1])
 		if not is_equal_approx(prev_point.angle_to_point(Vector2(list[idx * 2], list[idx * 2 + 1])),

--- a/src/data_classes/ListParser.gd
+++ b/src/data_classes/ListParser.gd
@@ -8,7 +8,6 @@ static func rect_to_list(rect: Rect2) -> PackedFloat64Array:
 ## Converts a list of floats into a Vector2 array.
 static func list_to_points(list: PackedFloat64Array) -> PackedVector2Array:
 	var points := PackedVector2Array()
-	@warning_ignore("integer_division")
 	points.resize(list.size() / 2)
 	for idx in points.size():
 		points[idx] = Vector2(list[idx * 2], list[idx * 2 + 1])

--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -20,7 +20,6 @@ var mode: FileMode
 
 var current_dir := ""
 var extensions := PackedStringArray()
-var item_height := 16.0
 var search_text := ""
 
 var default_saved_file := ""  # The file you opened this dialog with.
@@ -241,6 +240,9 @@ func open_dir(dir: String, only_filtering_update := false) -> void:
 			continue
 		
 		var item_idx := file_list.add_item(file, null)
+		if "xml":
+			file_list.set_item_icon(item_idx, text_file_icon)
+			file_list.set_item_icon_modulate(item_idx, ThemeUtils.text_file_color)
 		file_list.set_item_metadata(item_idx, Actions.new(select_files, sync_to_selection, open_file_context))
 	# If we don't await this stuff, sometimes the item_rect we get is all wrong.
 	await file_list.draw
@@ -273,8 +275,6 @@ func _setup_file_images() -> void:
 		if not is_instance_valid(file_list.get_item_icon(item_idx)) and file_rect.end.y > visible_start and file_rect.position.y < visible_end:
 			var file := file_list.get_item_text(item_idx)
 			match file.get_extension():
-				"xml":
-					file_list.set_item_icon(item_idx, text_file_icon)
 				"svg":
 					# Setup a clean SVG graphic by using the scaling parameter.
 					var svg_text := FileAccess.get_file_as_string(current_dir.path_join(file))
@@ -283,7 +283,8 @@ func _setup_file_images() -> void:
 					if not is_instance_valid(img) or img.is_empty():
 						file_list.set_item_icon(item_idx, broken_file_icon)
 					else:
-						var svg_texture := DPITexture.create_from_string(svg_text, minf(item_height / img.get_width(), item_height / img.get_height()))
+						var svg_texture := DPITexture.create_from_string(svg_text,
+								minf(file_list.fixed_icon_size.x / img.get_width(), file_list.fixed_icon_size.y / img.get_height()))
 						file_list.set_item_icon(item_idx, svg_texture)
 				_:
 					var img := Image.load_from_file(current_dir.path_join(file))

--- a/src/ui_parts/good_file_dialog.tscn
+++ b/src/ui_parts/good_file_dialog.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://mp1nxm8i8tv8"]
+[gd_scene load_steps=9 format=3 uid="uid://bf0tfj1eo5ap"]
 
 [ext_resource type="Script" uid="uid://cdlrqylqsmc22" path="res://src/ui_parts/good_file_dialog.gd" id="1_awdto"]
 [ext_resource type="Script" uid="uid://1hox6gd5pxku" path="res://src/ui_widgets/BetterLineEdit.gd" id="2_52puw"]

--- a/src/ui_parts/tab_bar.gd
+++ b/src/ui_parts/tab_bar.gd
@@ -81,7 +81,7 @@ func _draw() -> void:
 			var text_line_width := rect.size.x - size.y
 			if text_line_width > 0:
 				var text_line := TextLine.new()
-				text_line.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+				text_line.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS_FORCE
 				text_line.add_string(current_tab_name, ThemeUtils.regular_font, 13)
 				text_line.width = text_line_width - 2
 				text_line.draw(ci, rect.position + Vector2(4, 3), get_theme_color("font_selected_color", "TabContainer"))

--- a/src/ui_widgets/Canvas.gd
+++ b/src/ui_widgets/Canvas.gd
@@ -242,7 +242,6 @@ func _draw() -> void:
 	var minor_points := PackedVector2Array()
 	var draw_minor_lines := (camera_zoom >= 8.0)
 	var mark_pixel_lines := (camera_zoom >= 128.0)
-	@warning_ignore("integer_division")
 	var rate := nearest_po2(roundi(maxf(128.0 / (TICKS_INTERVAL * camera_zoom), 2.0))) / 2
 	
 	var i := fmod(-snapped_pos.x, 1.0)
@@ -297,13 +296,11 @@ func _draw() -> void:
 	
 	if not major_points.is_empty():
 		var pca := PackedColorArray()
-		@warning_ignore("integer_division")
 		pca.resize(major_points.size() / 2)
 		pca.fill(major_grid_color)
 		RenderingServer.canvas_item_add_multiline(grid_ci, major_points, pca)
 	if not minor_points.is_empty():
 		var pca := PackedColorArray()
-		@warning_ignore("integer_division")
 		pca.resize(minor_points.size() / 2)
 		pca.fill(minor_grid_color)
 		RenderingServer.canvas_item_add_multiline(grid_ci, minor_points, pca)

--- a/src/ui_widgets/PanelGrid.gd
+++ b/src/ui_widgets/PanelGrid.gd
@@ -41,13 +41,10 @@ func _draw() -> void:
 	custom_minimum_size.y = box_height * ceili(item_count / float(effective_columns))
 	
 	# One big filled rect for everything but the last row.
-	@warning_ignore("integer_division")
-	RenderingServer.canvas_item_add_rect(ci, Rect2(0, 0, size.x,
-			box_height * (item_count / effective_columns)), inner_color)
+	RenderingServer.canvas_item_add_rect(ci, Rect2(0, 0, size.x, box_height * (item_count / effective_columns)), inner_color)
 	
 	for idx in item_count:
 		var pos_x := (size.x / effective_columns) * (idx % effective_columns)
-		@warning_ignore("integer_division")
 		var pos_y := box_height * (idx / effective_columns)
 		
 		# Sigh...

--- a/src/ui_widgets/PolyHandle.gd
+++ b/src/ui_widgets/PolyHandle.gd
@@ -20,7 +20,6 @@ func set_pos(new_pos: PackedFloat64Array) -> void:
 
 func sync() -> void:
 	var list := element.get_attribute_list(points_name)
-	@warning_ignore("integer_division")
 	if point_index >= list.size() / 2:
 		# Handle might have been removed.
 		return

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -17,6 +17,7 @@ static var black_or_white_counter_accent_color: Color
 static var warning_icon_color: Color
 static var info_icon_color: Color
 static var folder_color: Color
+static var text_file_color: Color
 
 static var hover_selected_inspector_frame_inner_color: Color
 static var hover_selected_inspector_frame_title_color: Color
@@ -122,6 +123,7 @@ static func recalculate_colors() -> void:
 	warning_icon_color = Color("fca") if is_theme_dark else Color("96592c")
 	info_icon_color = Color("acf") if is_theme_dark else Color("3a6ab0")
 	folder_color = Color("88b6dd") if is_theme_dark else Color("528fcc")
+	text_file_color = Color("fec") if is_theme_dark else Color("cc9629")
 	
 	hover_selected_inspector_frame_inner_color = Color.from_hsv(0.625, 0.48, 0.27) if ThemeUtils.is_theme_dark else Color.from_hsv(0.625, 0.27, 0.925)
 	hover_selected_inspector_frame_title_color = hover_selected_inspector_frame_inner_color.lerp(max_contrast_color, 0.02)
@@ -859,6 +861,7 @@ static func _setup_checkbutton(theme: Theme) -> void:
 	)
 
 static func _setup_itemlist(theme: Theme) -> void:
+	# TODO Keep track of https://github.com/godotengine/godot/issues/56045
 	theme.add_type("ItemList")
 	theme.set_color("font_color", "ItemList", text_color)
 	theme.set_color("font_hovered_color", "ItemList", highlighted_text_color)


### PR DESCRIPTION
Fixes tab bar eclipse not showing up if the tabs are squished, fixes text file icon not working well with light theme, tweaks the hardcoded item height to instead use the fixed icon size. Removes that stupid integer division warning.