### PR TITLE
A lot of enhancements and bugfixes

### DIFF
--- a/src/ui_parts/good_file_dialog.gd
+++ b/src/ui_parts/good_file_dialog.gd
@@ -202,6 +202,11 @@ func update_filtering() -> void:
 	open_dir(current_dir, false, true)
 
 func open_dir(dir: String, add_to_history := true, only_filtering_update := false) -> void:
+	dir_cursor = DirAccess.open(dir)
+	if not is_instance_valid(dir_cursor):
+		# TODO implement a fallback.
+		return
+	
 	if dir != current_dir and search_button.button_pressed:
 		search_button.button_pressed = false
 	
@@ -210,11 +215,6 @@ func open_dir(dir: String, add_to_history := true, only_filtering_update := fals
 		navigation_history.resize(navigation_index)
 		navigation_history.append(dir)
 		update_navigation_buttons()
-	
-	dir_cursor = DirAccess.open(dir)
-	if not is_instance_valid(dir_cursor):
-		# TODO implement a fallback.
-		return
 	
 	file_list.clear()
 	file_list.get_v_scroll_bar().value = 0

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -1,14 +1,19 @@
 extends VTitledPanel
 
+const InvalidSyntaxWarning = preload("res://src/ui_widgets/invalid_syntax_warning.tscn")
+
 @onready var xnodes_container: VBoxContainer = %RootChildren
 @onready var add_button: Button = $ActionContainer/AddButton
 
+var is_unstable := false
 
 func _ready() -> void:
 	Configs.theme_changed.connect(sync_theming)
-	Configs.language_changed.connect(sync_localization)
 	sync_theming()
+	Configs.language_changed.connect(sync_localization)
 	sync_localization()
+	State.parsing_finished.connect(react_to_last_parsing)
+	react_to_last_parsing()
 	State.xnode_layout_changed.connect(full_rebuild)
 	State.svg_unknown_change.connect(full_rebuild)
 	State.svg_switched_to_another.connect(full_rebuild)
@@ -28,8 +33,12 @@ func sync_localization() -> void:
 func full_rebuild() -> void:
 	for node in xnodes_container.get_children():
 		node.queue_free()
-	for xnode_editor in XNodeChildrenBuilder.create(State.root_element):
-		xnodes_container.add_child(xnode_editor)
+	
+	if is_unstable:
+		xnodes_container.add_child(InvalidSyntaxWarning.instantiate())
+	else:
+		for xnode_editor in XNodeChildrenBuilder.create(State.root_element):
+			xnodes_container.add_child(xnode_editor)
 
 func add_element(element_name: String) -> void:
 	var new_element := DB.element_with_setup(element_name, [])
@@ -55,3 +64,9 @@ func _on_add_button_pressed() -> void:
 	var add_popup := ContextPopup.new()
 	add_popup.setup(btn_array, true, add_button.size.x, -1, separator_indices)
 	HandlerGUI.popup_under_rect(add_popup, add_button.get_global_rect(), get_viewport())
+
+
+func react_to_last_parsing() -> void:
+	var new_is_unstable := (State.last_parse_error != SVGParser.ParseError.OK and State.stable_editor_markup.is_empty())
+	if is_unstable != new_is_unstable:
+		is_unstable = new_is_unstable

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -34,7 +34,9 @@ func _ready() -> void:
 	shortcuts.add_shortcut("view_rasterized_svg", toggle_view_rasterized, ShortcutsRegistration.Behavior.PASS_THROUGH_AND_PRESERVE_POPUPS)
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
-	State.parsing_finished.connect(_on_parsing_finished)
+	State.parsing_finished.connect(react_to_last_parsing)
+	react_to_last_parsing()
+	
 	State.svg_edited.connect(_on_svg_changed.bind(true))
 	State.svg_switched_to_another.connect(_on_svg_changed.bind(false))
 	State.hover_changed.connect(_on_hover_changed)
@@ -65,13 +67,13 @@ func _on_root_element_attribute_changed(attribute_name: String) -> void:
 	if attribute_name in ["width", "height", "viewBox"]:
 		sync_svg_size(true)
 
-func _on_parsing_finished(error: SVGParser.ParseError) -> void:
-	if error == SVGParser.ParseError.OK:
+func react_to_last_parsing() -> void:
+	if State.last_parse_error == SVGParser.ParseError.OK:
 		root_element = State.root_element
 		sync_svg_size()
 		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
 	else:
-		if not is_instance_valid(State.root_element):
+		if State.stable_editor_markup.is_empty():
 			root_element = ElementRoot.new()
 
 func _on_svg_changed(is_edit: bool) -> void:

--- a/src/ui_widgets/Canvas.gd
+++ b/src/ui_widgets/Canvas.gd
@@ -101,7 +101,6 @@ func _init() -> void:
 func _enter_tree() -> void:
 	viewport.size_2d_override_stretch = true
 	viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
-	viewport.disable_3d = true
 	viewport.gui_snap_controls_to_pixels = false
 	viewport.canvas = self
 	add_child(viewport)

--- a/src/ui_widgets/invalid_syntax_warning.gd
+++ b/src/ui_widgets/invalid_syntax_warning.gd
@@ -1,0 +1,15 @@
+extends MarginContainer
+
+@onready var invalid_syntax_label: Label = $InvalidSyntaxLabel
+
+func _ready() -> void:
+	Configs.basic_colors_changed.connect(sync_invalid_syntax_label_color)
+	sync_invalid_syntax_label_color()
+	Configs.language_changed.connect(sync_localization)
+	sync_localization()
+
+func sync_invalid_syntax_label_color() -> void:
+	invalid_syntax_label.add_theme_color_override("font_color", Configs.savedata.basic_color_error)
+
+func sync_localization() -> void:
+	invalid_syntax_label.text = Translator.translate("The SVG has invalid syntax. Any edit not made through the code editor will reset it.")

--- a/src/ui_widgets/invalid_syntax_warning.gd.uid
+++ b/src/ui_widgets/invalid_syntax_warning.gd.uid
@@ -1,0 +1,1 @@
+uid://nu3gu2q28w8b

--- a/src/ui_widgets/invalid_syntax_warning.tscn
+++ b/src/ui_widgets/invalid_syntax_warning.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=3 uid="uid://of6s1h2n4s55"]
+
+[ext_resource type="Script" uid="uid://nu3gu2q28w8b" path="res://src/ui_widgets/invalid_syntax_warning.gd" id="1_n5tba"]
+
+[node name="InvalidSyntaxWarning" type="MarginContainer"]
+theme_override_constants/margin_left = 16
+theme_override_constants/margin_top = 4
+theme_override_constants/margin_right = 16
+script = ExtResource("1_n5tba")
+
+[node name="InvalidSyntaxLabel" type="Label" parent="."]
+layout_mode = 2
+autowrap_mode = 3

--- a/src/utils/ThemeUtils.gd
+++ b/src/utils/ThemeUtils.gd
@@ -103,6 +103,8 @@ static var mini_line_edit_normal_border_color: Color
 static var line_edit_inner_color_disabled: Color
 static var line_edit_border_color_disabled: Color
 
+static var text_edit_alternative_inner_color: Color
+
 static var selected_tab_color: Color
 static var selected_tab_border_color: Color
 
@@ -194,8 +196,7 @@ static func recalculate_colors() -> void:
 	basic_panel_inner_color = softer_base_color
 	basic_panel_border_color = base_color.lerp(max_contrast_color, 0.24)
 	basic_panel_border_color.s = minf(basic_panel_border_color.s * 2.0, lerpf(basic_panel_border_color.s, 1.0, 0.2))
-	subtle_panel_border_color = basic_panel_border_color.lerp(basic_panel_inner_color, 0.4)
-	subtle_panel_border_color.s = minf(subtle_panel_border_color.s * 2.0, lerpf(subtle_panel_border_color.s, 1.0, 0.2))
+	subtle_panel_border_color = basic_panel_border_color.lerp(extreme_theme_color, 0.24)
 	
 	caret_color = Color(tinted_contrast_color, 0.875)
 	selection_color = Color(accent_color, 0.375)
@@ -225,11 +226,14 @@ static func recalculate_colors() -> void:
 	
 	line_edit_focus_color = Color(accent_color, 0.4)
 	line_edit_inner_color = desaturated_color.lerp(extreme_theme_color, 0.74)
-	line_edit_normal_border_color = desaturated_color.lerp(extreme_theme_color, 0.42)
+	line_edit_normal_border_color = desaturated_color.lerp(extreme_theme_color, 0.42 if is_theme_dark else 0.35)
 	mini_line_edit_inner_color = desaturated_color.lerp(extreme_theme_color, 0.78)
 	mini_line_edit_normal_border_color = desaturated_color.lerp(max_contrast_color, 0.04)
 	line_edit_inner_color_disabled = desaturated_color.lerp(gray_color, 0.4).lerp(extreme_theme_color, 0.88)
 	line_edit_border_color_disabled = desaturated_color.lerp(gray_color, 0.4).lerp(extreme_theme_color, 0.68)
+	
+	text_edit_alternative_inner_color = base_color.lerp(extreme_theme_color, 0.2)
+	text_edit_alternative_inner_color.s *= 0.6
 	
 	connected_button_inner_color_hover = line_edit_inner_color.blend(hover_overlay_color)
 	connected_button_border_color_hover = line_edit_normal_border_color.blend(strong_hover_overlay_color)

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -578,6 +578,10 @@ msgstr ""
 msgid "New shape"
 msgstr ""
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 msgid "Add new color"
 msgstr ""

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -579,6 +579,10 @@ msgstr "Пипета"
 msgid "New shape"
 msgstr "Нова фигура"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr "SVG-то е синтактично грешно. Всяка редакция която не е направена през редактора за код ще го рестартира."
+
 #: src/ui_widgets/palette_config.gd:
 msgid "Add new color"
 msgstr "Добави нов цвят"

--- a/translations/de.po
+++ b/translations/de.po
@@ -582,6 +582,10 @@ msgstr "Pipette"
 msgid "New shape"
 msgstr "Neue Form"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/en.po
+++ b/translations/en.po
@@ -579,6 +579,10 @@ msgstr ""
 msgid "New shape"
 msgstr ""
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 msgid "Add new color"
 msgstr ""

--- a/translations/es.po
+++ b/translations/es.po
@@ -582,6 +582,10 @@ msgstr "Cuentagotas"
 msgid "New shape"
 msgstr "Nueva forma"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/et.po
+++ b/translations/et.po
@@ -582,6 +582,10 @@ msgstr "Värvipipett"
 msgid "New shape"
 msgstr "Uus kujund"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -582,6 +582,10 @@ msgstr "Pipette"
 msgid "New shape"
 msgstr "Nouvelle forme"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -580,6 +580,10 @@ msgstr "Druppelaar"
 msgid "New shape"
 msgstr "Nieuwe vorm"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 msgid "Add new color"
 msgstr "Voeg nieuwe kleur toe"

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -583,6 +583,10 @@ msgstr "Conta-gotas"
 msgid "New shape"
 msgstr "Nova forma"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -581,6 +581,10 @@ msgstr "Пипетка"
 msgid "New shape"
 msgstr "Новая привязка"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -580,6 +580,10 @@ msgstr "Піпетка"
 msgid "New shape"
 msgstr "Нова форма"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 #, fuzzy
 msgid "Add new color"

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -580,6 +580,10 @@ msgstr "吸管工具"
 msgid "New shape"
 msgstr "新形状"
 
+#: src/ui_widgets/invalid_syntax_warning.gd:
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr ""
+
 #: src/ui_widgets/palette_config.gd:
 msgid "Add new color"
 msgstr "添加新颜色"


### PR DESCRIPTION
Implements a warning for unstable markup in the inspector.

Fixes and tweaks the core systems a little to fix the following issues:
- Unstable markup could often cause crashes
- Code editor errors in unstable markup didn't show after layout changes

Fixes code editor errors in unstable markup not being affected by changes to the error color. Fixes folders not opening in the custom file dialog triggering navigation updates and hiding the search bar. Fixes Android builds broken by disable_3d SubViewport property not being available for some reason.

Enhances a few colors, namely the code editor, the line edits in light theme, and the subtle panels' border color.