### PR TITLE
Migrate to Godot 4.5 and fix a bug

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -11,11 +11,11 @@ env:
   # Which godot version to use for exporting (e.g., 4.4.1, 4.5)
   GODOT_VERSION: 4.5
   # Which godot release to use for exporting (e.g., stable, dev5, rc2)
-  GODOT_RELEASE: rc1
+  GODOT_RELEASE: stable
   # Used in the editor config file name (e.g., 4.4, 4.5, but NOT 4.4.1)
   GODOT_FEATURE_VERSION: 4.5
   # Commit hash
-  GODOT_COMMIT_HASH: 6c9aa4c7d
+  GODOT_COMMIT_HASH: 2dd26a027
   PROJECT_NAME: GodSVG
   # deprecated=no disables deprecated Godot features, which exist for compat and we don't use.
   # vulkan=no, use_volk=no since we use Compatibility Renderer. TODO for 4.5 disable rendering_device too.

--- a/src/config_classes/TabData.gd
+++ b/src/config_classes/TabData.gd
@@ -146,10 +146,11 @@ func _sync() -> void:
 			marked_unsaved = false
 		else:
 			var edited_text_parse_result := SVGParser.markup_to_root(FileAccess.get_file_as_string(get_edited_file_path()))
+			var file_text := FileAccess.get_file_as_string(svg_file_path)
 			if edited_text_parse_result.error == SVGParser.ParseError.OK:
-				marked_unsaved = FileAccess.get_file_as_string(svg_file_path) != SVGParser.root_to_export_markup(edited_text_parse_result.svg)
+				marked_unsaved = (file_text != SVGParser.root_to_export_markup(edited_text_parse_result.svg))
 			else:
-				marked_unsaved = FileAccess.get_file_as_string(svg_file_path) != FileAccess.get_file_as_string(get_edited_file_path())
+				marked_unsaved = (file_text != FileAccess.get_file_as_string(get_edited_file_path()))
 	
 	elif not FileAccess.file_exists(get_edited_file_path()) or SVGParser.markup_check_is_root_empty(get_true_svg_text()):
 		empty_unsaved = true

--- a/src/data_classes/AttributeList.gd
+++ b/src/data_classes/AttributeList.gd
@@ -31,7 +31,7 @@ func set_list_element(idx: int, new_value: float) -> void:
 func get_list_element(idx: int) -> float:
 	return _list[idx] if idx < _list.size() else NAN
 
-func delete_elements(indices: Array[int]) -> void:
+func delete_elements(indices: PackedInt64Array) -> void:
 	if indices.is_empty():
 		return
 	

--- a/src/ui_parts/code_editor.gd
+++ b/src/ui_parts/code_editor.gd
@@ -120,7 +120,7 @@ func _on_svg_code_edit_focus_entered() -> void:
 	State.clear_all_selections()
 
 func _on_svg_code_edit_focus_exited() -> void:
-	State.queue_svg_save()
+	State.save_svg()
 	if not State.stable_editor_markup.is_empty():
 		State.apply_markup(State.stable_editor_markup, true)
 

--- a/src/ui_parts/element_container.gd
+++ b/src/ui_parts/element_container.gd
@@ -117,7 +117,7 @@ func _gui_input(event: InputEvent) -> void:
 func add_element(element_name: String, element_idx: int) -> void:
 	State.root_element.add_xnode(DB.element_with_setup(element_name, []),
 			PackedInt32Array([element_idx]))
-	State.queue_svg_save()
+	State.save_svg()
 
 
 func get_xnode_editor_rect(xid: PackedInt32Array, inner_index := -1) -> Rect2:

--- a/src/ui_parts/inspector.gd
+++ b/src/ui_parts/inspector.gd
@@ -48,7 +48,7 @@ func add_element(element_name: String) -> void:
 	else:
 		loc = PackedInt32Array([State.root_element.get_child_count()])
 	State.root_element.add_xnode(new_element, loc)
-	State.queue_svg_save()
+	State.save_svg()
 
 
 func _on_add_button_pressed() -> void:

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -53,32 +53,27 @@ func sync_camera_center_in_tab() -> void:
 func sync_camera_zoom_in_tab() -> void:
 	Configs.savedata.get_active_tab().camera_zoom = camera_zoom
 
-func sync_svg_size(center_if_changed := false) -> void:
+func sync_svg_size() -> void:
 	if _current_svg_size != root_element.get_size():
 		_current_svg_size = root_element.get_size()
-		if center_if_changed:
-			sync_checkerboard()
-			center_frame()
-			queue_redraw()
+		sync_checkerboard()
+		center_frame()
+		queue_redraw()
 
 var _current_svg_size: Vector2
-
-func _on_root_element_attribute_changed(attribute_name: String) -> void:
-	if attribute_name in ["width", "height", "viewBox"]:
-		sync_svg_size(true)
 
 func react_to_last_parsing() -> void:
 	if State.last_parse_error == SVGParser.ParseError.OK:
 		root_element = State.root_element
-		sync_svg_size()
-		root_element.attribute_changed.connect(_on_root_element_attribute_changed)
 	else:
 		if State.stable_editor_markup.is_empty():
 			root_element = ElementRoot.new()
 
 func _on_svg_changed(is_edit: bool) -> void:
 	if is_edit:
-		sync_svg_size(true)
+		sync_svg_size()
+	else:
+		_current_svg_size = root_element.get_size()
 	queue_texture_update()
 	handles_manager.queue_update_handles()
 

--- a/src/ui_parts/move_to_overlay.gd
+++ b/src/ui_parts/move_to_overlay.gd
@@ -16,4 +16,4 @@ func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 func _drop_data(_at_position: Vector2, data: Variant) -> void:
 	if data is Array[PackedInt32Array]:
 		State.root_element.move_xnodes_to(data, State.proposed_drop_xid)
-		State.queue_svg_save()
+		State.save_svg()

--- a/src/ui_parts/root_element_editor.gd
+++ b/src/ui_parts/root_element_editor.gd
@@ -104,7 +104,7 @@ func _on_width_edit_value_changed(new_value: float) -> void:
 		State.root_element.set_attribute("width", new_value)
 	else:
 		State.root_element.set_attribute("width", State.root_element.width)
-	State.queue_svg_save()
+	State.save_svg()
 
 func _on_height_edit_value_changed(new_value: float) -> void:
 	if is_finite(new_value) and State.root_element.get_attribute_num("height") != new_value:
@@ -112,51 +112,51 @@ func _on_height_edit_value_changed(new_value: float) -> void:
 		State.root_element.set_attribute("height", new_value)
 	else:
 		State.root_element.set_attribute("height", State.root_element.height)
-	State.queue_svg_save()
+	State.save_svg()
 
 func _on_viewbox_edit_x_value_changed(new_value: float) -> void:
 	if State.root_element.has_attribute("viewBox"):
 		State.root_element.viewbox.position.x = new_value
 		State.root_element.get_attribute("viewBox").set_list_element(0, new_value)
-		State.queue_svg_save()
+		State.save_svg()
 
 func _on_viewbox_edit_y_value_changed(new_value: float) -> void:
 	if State.root_element.has_attribute("viewBox"):
 		State.root_element.viewbox.position.y = new_value
 		State.root_element.get_attribute("viewBox").set_list_element(1, new_value)
-		State.queue_svg_save()
+		State.save_svg()
 
 func _on_viewbox_edit_w_value_changed(new_value: float) -> void:
 	if State.root_element.has_attribute("viewBox") and State.root_element.get_attribute("viewBox").get_list_element(2) != new_value:
 		State.root_element.viewbox.size.x = new_value
 		State.root_element.get_attribute("viewBox").set_list_element(2, new_value)
-		State.queue_svg_save()
+		State.save_svg()
 
 func _on_viewbox_edit_h_value_changed(new_value: float) -> void:
 	if State.root_element.has_attribute("viewBox") and State.root_element.get_attribute("viewBox").get_list_element(3) != new_value:
 		State.root_element.viewbox.size.y = new_value
 		State.root_element.get_attribute("viewBox").set_list_element(3, new_value)
-		State.queue_svg_save()
+		State.save_svg()
 
 func _on_width_button_toggled(toggled_on: bool) -> void:
 	if toggled_on:
 		State.root_element.set_attribute("width", State.root_element.width)
-		State.queue_svg_save()
+		State.save_svg()
 	else:
 		if State.root_element.get_attribute("viewBox").get_list_size() == 4:
 			State.root_element.set_attribute("width", "")
-			State.queue_svg_save()
+			State.save_svg()
 		else:
 			width_button.set_pressed_no_signal(true)
 
 func _on_height_button_toggled(toggled_on: bool) -> void:
 	if toggled_on:
 		State.root_element.set_attribute("height", State.root_element.height)
-		State.queue_svg_save()
+		State.save_svg()
 	else:
 		if State.root_element.get_attribute("viewBox").get_list_size() == 4:
 			State.root_element.set_attribute("height", "")
-			State.queue_svg_save()
+			State.save_svg()
 		else:
 			height_button.set_pressed_no_signal(true)
 
@@ -164,10 +164,10 @@ func _on_viewbox_button_toggled(toggled_on: bool) -> void:
 	if toggled_on:
 		State.root_element.set_attribute("viewBox",
 				ListParser.rect_to_list(State.root_element.viewbox))
-		State.queue_svg_save()
+		State.save_svg()
 	else:
 		if State.root_element.has_attribute("width") and State.root_element.has_attribute("height"):
 			State.root_element.set_attribute("viewBox", "")
-			State.queue_svg_save()
+			State.save_svg()
 		else:
 			viewbox_button.set_pressed_no_signal(true)

--- a/src/ui_widgets/color_field.gd
+++ b/src/ui_widgets/color_field.gd
@@ -31,7 +31,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 func setup_placeholder() -> void:
 	placeholder_text = element.get_default(attribute_name).trim_prefix("#")

--- a/src/ui_widgets/enum_field.gd
+++ b/src/ui_widgets/enum_field.gd
@@ -10,7 +10,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 func setup_placeholder() -> void:
 	placeholder_text = element.get_default(attribute_name)

--- a/src/ui_widgets/handles_manager.gd
+++ b/src/ui_widgets/handles_manager.gd
@@ -808,7 +808,7 @@ func _unhandled_input(event: InputEvent) -> void:
 							Utils64Bit.get_transform_affine_inverse(dragged_handle.precise_transform),
 							canvas.root_element.world_to_canvas_64_bit(event_pos))
 					dragged_handle.set_pos(new_pos)
-					State.queue_svg_save()
+					State.save_svg()
 					was_handle_moved = false
 				dragged_handle = null
 			elif not is_instance_valid(hovered_handle) and event.is_pressed():
@@ -870,14 +870,14 @@ func _on_handle_added() -> void:
 	if not get_viewport_rect().has_point(get_viewport().get_mouse_position()):
 		if not State.semi_selected_xid.is_empty():
 			canvas.root_element.get_xnode(State.semi_selected_xid).get_attribute("d").sync_after_commands_change()
-			State.queue_svg_save()
+			State.save_svg()
 		return
 	
 	update_handles()
 	var first_inner_selection := State.inner_selections[0]
 	if canvas.root_element.get_xnode(State.semi_selected_xid).get_attribute("d").get_commands()[first_inner_selection].command_char in "Zz":
 		dragged_handle = null
-		State.queue_svg_save()
+		State.save_svg()
 		return
 	
 	for handle in handles:
@@ -906,4 +906,4 @@ func create_element_context(precise_pos: PackedFloat64Array) -> ContextPopup:
 
 func add_shape_at_pos(element_name: String, precise_pos: PackedFloat64Array) -> void:
 	canvas.root_element.add_xnode(DB.element_with_setup(element_name, [precise_pos]), PackedInt32Array([canvas.root_element.get_child_count()]))
-	State.queue_svg_save()
+	State.save_svg()

--- a/src/ui_widgets/href_field.gd
+++ b/src/ui_widgets/href_field.gd
@@ -7,7 +7,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func _ready() -> void:

--- a/src/ui_widgets/id_field.gd
+++ b/src/ui_widgets/id_field.gd
@@ -8,7 +8,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func _ready() -> void:

--- a/src/ui_widgets/number_field.gd
+++ b/src/ui_widgets/number_field.gd
@@ -23,7 +23,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 func setup_placeholder() -> void:
 	placeholder_text = element.get_default(attribute_name)

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -27,7 +27,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 func set_num(new_number: float, save := false) -> void:
 	set_value(element.get_attribute(attribute_name).num_to_text(new_number), save)

--- a/src/ui_widgets/pathdata_field.gd
+++ b/src/ui_widgets/pathdata_field.gd
@@ -47,7 +47,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func setup() -> void:
@@ -138,15 +138,15 @@ func sync() -> void:
 
 func update_parameter(new_value: float, property: String, idx: int) -> void:
 	element.get_attribute(attribute_name).set_command_property(idx, property, new_value)
-	State.queue_svg_save()
+	State.save_svg()
 
 func _on_relative_button_pressed() -> void:
 	element.get_attribute(attribute_name).toggle_relative_command(hovered_idx)
-	State.queue_svg_save()
+	State.save_svg()
 
 func _on_add_move_button_pressed() -> void:
 	element.get_attribute(attribute_name).insert_command(0, "M")
-	State.queue_svg_save()
+	State.save_svg()
 
 
 # Path commands editor orchestration.
@@ -240,8 +240,7 @@ func _commands_draw() -> void:
 				stylebox.bg_color = ThemeUtils.soft_pressed_overlay_color
 			elif hovered:
 				stylebox.bg_color = ThemeUtils.soft_hover_overlay_color
-			stylebox.draw(ci, Rect2(Vector2(0, v_offset), Vector2(commands_container.size.x,
-					STRIP_HEIGHT)))
+			stylebox.draw(ci, Rect2(Vector2(0, v_offset), Vector2(commands_container.size.x, STRIP_HEIGHT)))
 		# Draw the child controls. They are going to be drawn, not added as a node unless
 		# the mouse hovers them. This is a hack to significantly improve performance.
 		if i == hovered_idx or i == focused_idx:
@@ -372,8 +371,7 @@ func setup_path_command_controls(idx: int) -> Control:
 	relative_button.mouse_filter = Control.MOUSE_FILTER_PASS
 	relative_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	relative_button.add_theme_font_override("font", ThemeUtils.mono_font)
-	relative_button.theme_type_variation = "PathCommandAbsoluteButton" if is_absolute else\
-			"PathCommandRelativeButton"
+	relative_button.theme_type_variation = "PathCommandAbsoluteButton" if is_absolute else "PathCommandRelativeButton"
 	relative_button.text = cmd_char
 	relative_button.tooltip_text = TranslationUtils.get_path_command_description(cmd_char)
 	container.add_child(relative_button)
@@ -409,14 +407,11 @@ func setup_path_command_controls(idx: int) -> Control:
 			var field_sweep := FlagFieldScene.instantiate()
 			field_large_arc.gui_input.connect(_eat_double_clicks.bind(field_large_arc))
 			field_sweep.gui_input.connect(_eat_double_clicks.bind(field_sweep))
-			fields = [field_rx, field_ry, field_rot, field_large_arc, field_sweep,
-					numfield(idx), numfield(idx)]
+			fields = [field_rx, field_ry, field_rot, field_large_arc, field_sweep, numfield(idx), numfield(idx)]
 			spacings = PackedInt32Array([3, 4, 4, 4, 4, 3])
-			property_names = PackedStringArray(
-					["rx", "ry", "rot", "large_arc_flag", "sweep_flag", "x", "y"])
+			property_names = PackedStringArray(["rx", "ry", "rot", "large_arc_flag", "sweep_flag", "x", "y"])
 		"C":
-			fields = [numfield(idx), numfield(idx), numfield(idx), numfield(idx),
-					numfield(idx), numfield(idx)]
+			fields = [numfield(idx), numfield(idx), numfield(idx), numfield(idx), numfield(idx), numfield(idx)]
 			spacings = PackedInt32Array([3, 4, 3, 4, 3])
 			property_names = PackedStringArray(["x1", "y1", "x2", "y2", "x", "y"])
 		"Q":

--- a/src/ui_widgets/points_field.gd
+++ b/src/ui_widgets/points_field.gd
@@ -46,7 +46,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func setup() -> void:
@@ -138,17 +138,17 @@ func update_point_x_coordinate(new_value: float, idx: int) -> void:
 	var list := element.get_attribute_list(attribute_name)
 	list[idx * 2] = new_value
 	element.get_attribute(attribute_name).set_list(list)
-	State.queue_svg_save()
+	State.save_svg()
 
 func update_point_y_coordinate(new_value: float, idx: int) -> void:
 	var list := element.get_attribute_list(attribute_name)
 	list[idx * 2 + 1] = new_value
 	element.get_attribute(attribute_name).set_list(list)
-	State.queue_svg_save()
+	State.save_svg()
 
 func _on_add_move_button_pressed() -> void:
 	element.get_attribute(attribute_name).set_list(PackedFloat64Array([0.0, 0.0]))
-	State.queue_svg_save()
+	State.save_svg()
 
 
 # Points editor orchestration.
@@ -243,8 +243,7 @@ func points_draw() -> void:
 				stylebox.bg_color = ThemeUtils.soft_pressed_overlay_color
 			elif hovered:
 				stylebox.bg_color = ThemeUtils.soft_hover_overlay_color
-			stylebox.draw(ci, Rect2(Vector2(0, v_offset), Vector2(points_container.size.x,
-					STRIP_HEIGHT)))
+			stylebox.draw(ci, Rect2(Vector2(0, v_offset), Vector2(points_container.size.x, STRIP_HEIGHT)))
 		# Draw the child controls. They are going to be drawn, not added as a node unless
 		# the mouse hovers them. This is a hack to significantly improve performance.
 		if i == hovered_idx or i == focused_idx:

--- a/src/ui_widgets/transform_field.gd
+++ b/src/ui_widgets/transform_field.gd
@@ -10,7 +10,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func _ready() -> void:

--- a/src/ui_widgets/transform_popup.gd
+++ b/src/ui_widgets/transform_popup.gd
@@ -41,7 +41,7 @@ func _ready() -> void:
 	sync_localization()
 
 func _exit_tree() -> void:
-	State.queue_svg_save()
+	State.save_svg()
 
 func sync_localization() -> void:
 	apply_matrix.tooltip_text = Translator.translate("Apply the matrix")

--- a/src/ui_widgets/unrecognized_field.gd
+++ b/src/ui_widgets/unrecognized_field.gd
@@ -8,7 +8,7 @@ func set_value(new_value: String, save := false) -> void:
 	element.set_attribute(attribute_name, new_value)
 	sync()
 	if save:
-		State.queue_svg_save()
+		State.save_svg()
 
 
 func _ready() -> void:

--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -16,7 +16,7 @@ static func reset_svg() -> void:
 	var file_path := Configs.savedata.get_active_tab().svg_file_path
 	if FileAccess.file_exists(file_path):
 		State.apply_markup(FileAccess.get_file_as_string(file_path), true)
-		State.queue_svg_save()
+		State.save_svg()
 
 static func apply_svgs_from_paths(paths: PackedStringArray, show_incorrect_extension_errors := true) -> void:
 	_start_file_import_process(paths, _apply_svg, PackedStringArray(["svg"]), show_incorrect_extension_errors)


### PR DESCRIPTION
Migrates to Godot 4.5, fixes a small bug that made empty tabs not register in the edited files, fixes an issue with not re-centering for some types of SVG edits.