### PR TITLE
Add accelerator shortcuts to the "insert after" menu

### DIFF
--- a/src/ui_widgets/path_command_button.gd
+++ b/src/ui_widgets/path_command_button.gd
@@ -11,6 +11,13 @@ func _ready() -> void:
 	text = ""
 	queue_redraw()
 	pressed.connect(emit_pressed_custom)
+	shortcut = Shortcut.new()
+	var shortcut_event := InputEventKey.new()
+	var shortcut_event_shift := InputEventKey.new()
+	shortcut_event.keycode = OS.find_keycode_from_string(command_char)
+	shortcut_event_shift.keycode = shortcut_event.keycode
+	shortcut_event_shift.shift_pressed = true
+	shortcut.events = [shortcut_event, shortcut_event_shift]
 
 func emit_pressed_custom() -> void:
 	pressed_custom.emit(command_char)

--- a/src/ui_widgets/path_popup.tscn
+++ b/src/ui_widgets/path_popup.tscn
@@ -1,7 +1,14 @@
-[gd_scene load_steps=3 format=3 uid="uid://bvnheiqqay5ke"]
+[gd_scene load_steps=5 format=3 uid="uid://bvnheiqqay5ke"]
 
 [ext_resource type="Script" uid="uid://l4ongcnemxuq" path="res://src/ui_widgets/path_popup.gd" id="1_j10aq"]
 [ext_resource type="PackedScene" uid="uid://co2btefrqrm0e" path="res://src/ui_widgets/path_command_button.tscn" id="2_1jd8y"]
+
+[sub_resource type="InputEventKey" id="InputEventKey_nhm5u"]
+device = -1
+keycode = 4194325
+
+[sub_resource type="Shortcut" id="Shortcut_boai5"]
+events = [SubResource("InputEventKey_nhm5u")]
 
 [node name="PathCommandPopup" type="PanelContainer"]
 custom_minimum_size = Vector2(236, 0)
@@ -25,6 +32,7 @@ size_flags_horizontal = 8
 focus_mode = 0
 mouse_default_cursor_shape = 2
 action_mode = 0
+shortcut = SubResource("Shortcut_boai5")
 flat = true
 alignment = 2
 


### PR DESCRIPTION
I just found out that you can press keys to insert a command without going through the menu, but this makes it so that you can press keys to insert a command in the menu. <kbd>Shift</kbd> toggles relativity.

[Screencast_20251024_164544.webm](https://github.com/user-attachments/assets/c4c02871-efa2-4edc-9a63-096d8c3d92db)
