### PR TITLE
Tweak shift accelerator shortcut

### DIFF
--- a/src/ui_widgets/path_command_button.gd
+++ b/src/ui_widgets/path_command_button.gd
@@ -10,17 +10,7 @@ signal pressed_custom(cmd_char: String)
 func _ready() -> void:
 	text = ""
 	queue_redraw()
-	pressed.connect(emit_pressed_custom)
-	shortcut = Shortcut.new()
-	var shortcut_event := InputEventKey.new()
-	var shortcut_event_shift := InputEventKey.new()
-	shortcut_event.keycode = OS.find_keycode_from_string(command_char)
-	shortcut_event_shift.keycode = shortcut_event.keycode
-	shortcut_event_shift.shift_pressed = true
-	shortcut.events = [shortcut_event, shortcut_event_shift]
-
-func emit_pressed_custom() -> void:
-	pressed_custom.emit(command_char)
+	pressed.connect(pressed_custom.emit.bind(command_char))
 
 func set_invalid(new_state := true) -> void:
 	disabled = new_state
@@ -54,3 +44,8 @@ func _draw() -> void:
 		if text_obj.get_line_width() > max_size:
 			custom_minimum_size.x = size.x + 4 + text_obj.get_line_width() - max_size
 	text_obj.draw(get_canvas_item(), Vector2(left_margin + 2, 3), text_color)
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.is_pressed() and event.keycode == OS.find_keycode_from_string(command_char):
+		pressed.emit()

--- a/src/ui_widgets/path_popup.gd
+++ b/src/ui_widgets/path_popup.gd
@@ -44,3 +44,7 @@ func force_relativity(relative: bool) -> void:
 			command_button.queue_redraw()
 	await get_tree().process_frame
 	reset_size()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.is_pressed() and event.keycode == KEY_SHIFT:
+		relative_toggle.button_pressed = not relative_toggle.button_pressed

--- a/src/ui_widgets/path_popup.tscn
+++ b/src/ui_widgets/path_popup.tscn
@@ -1,14 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://bvnheiqqay5ke"]
+[gd_scene load_steps=3 format=3 uid="uid://bvnheiqqay5ke"]
 
 [ext_resource type="Script" uid="uid://l4ongcnemxuq" path="res://src/ui_widgets/path_popup.gd" id="1_j10aq"]
 [ext_resource type="PackedScene" uid="uid://co2btefrqrm0e" path="res://src/ui_widgets/path_command_button.tscn" id="2_1jd8y"]
-
-[sub_resource type="InputEventKey" id="InputEventKey_nhm5u"]
-device = -1
-keycode = 4194325
-
-[sub_resource type="Shortcut" id="Shortcut_boai5"]
-events = [SubResource("InputEventKey_nhm5u")]
 
 [node name="PathCommandPopup" type="PanelContainer"]
 custom_minimum_size = Vector2(236, 0)
@@ -32,7 +25,6 @@ size_flags_horizontal = 8
 focus_mode = 0
 mouse_default_cursor_shape = 2
 action_mode = 0
-shortcut = SubResource("Shortcut_boai5")
 flat = true
 alignment = 2
 


### PR DESCRIPTION
I got the strangest bug where if you dragged something, the Shift shortcut introduced by sockey-d recently wouldn't work. It even worked for the buttons using the same shortcut system. I don't have the energy to investigate further right now.