### PR TITLE
Hotfix three fairly bad bugs

### DIFF
--- a/src/config_classes/TabData.gd
+++ b/src/config_classes/TabData.gd
@@ -74,6 +74,7 @@ func save_to_bound_path() -> void:
 func set_initial_svg_text(new_text: String) -> void:
 	_svg_text = new_text
 	_save_svg_text()
+	undo_redo.clear_history()
 
 func get_svg_text() -> String:
 	return _svg_text
@@ -160,7 +161,6 @@ func _sync() -> void:
 		empty_unsaved = false
 		marked_unsaved = false
 		presented_name = "[ %s ]" % Translator.translate("Unsaved")
-
 
 func activate() -> void:
 	active = true

--- a/src/ui_parts/previews.gd
+++ b/src/ui_parts/previews.gd
@@ -309,6 +309,7 @@ func _delete_tile(tile: IconPreviewTileData) -> void:
 	if index >= 0:
 		sizes.remove_at(index)
 		Configs.savedata.preview_sizes = sizes
+		selected_tile_index = -1
 		sync_tiles()
 
 func are_tiles_default() -> bool:

--- a/src/ui_widgets/file_path_field.gd
+++ b/src/ui_widgets/file_path_field.gd
@@ -23,6 +23,12 @@ func _ready() -> void:
 	value_changed.connect(sync_line_edit.unbind(1))
 	sync_line_edit()
 
+func permanently_disable() -> void:
+	line_edit.editable = false
+	button.disabled = true
+	button.mouse_default_cursor_shape = Control.CURSOR_ARROW
+
+
 func sync_line_edit() -> void:
 	if is_instance_valid(line_edit):
 		line_edit.text = Utils.simplify_file_path(value)

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -181,12 +181,19 @@ func update_widgets() -> void:
 			var setting_str := setting_value.to_html(show_alpha)
 			widget.value = setting_str
 			reset_button.visible = (not disabled and getter.call().to_html() != default.to_html())
-		Type.DROPDOWN, Type.FILE_PATH:
+		Type.DROPDOWN:
 			widget.set_value(getter.call())
 			reset_button.visible = (not disabled and getter.call() != default)
 		Type.NUMERIC_DROPDOWN:
 			widget.set_value(getter.call())
 			reset_button.visible = not (disabled or is_equal_approx(getter.call(), default))
+		Type.FILE_PATH:
+			if OS.has_feature("web"):
+				widget.permanently_disable()
+				reset_button.hide()
+			else:
+				widget.set_value(getter.call())
+				reset_button.visible = (not disabled and getter.call() != default)
 	queue_redraw()
 
 func _on_mouse_entered() -> void:


### PR DESCRIPTION
Fixes regression when deleting tiles in the new previews area. Fixes issue where an asterisk would show up if you did undo on a just imported SVG. Fixes font file path settings still being visible on web.