### PR TITLE
Fix dropdown popup height

### DIFF
--- a/src/ui_widgets/ContextPopup.gd
+++ b/src/ui_widgets/ContextPopup.gd
@@ -239,7 +239,7 @@ func setup(buttons: Array[Button], align_left := false, min_width := -1.0, separ
 	if min_width > 0:
 		custom_minimum_size.x = min_width
 	
-	var max_height := get_window().size.y / (get_tree().root.content_scale_factor * 2.0) - 16.0
+	var max_height := get_window().size.y / (get_tree().root.content_scale_factor * 2.0) - 16.0 * get_tree().root.content_scale_factor
 	if get_minimum_size().y > max_height:
 		custom_minimum_size.y = max_height
 		main_container.get_parent().vertical_scroll_mode = ScrollContainer.SCROLL_MODE_AUTO


### PR DESCRIPTION
Fixes the dropdown context popup by considering content scale factor for height calculation.
Issue is visible when content scale factor is more than 1.

Before and after image respectively,
<p align="center">
<img src=https://github.com/user-attachments/assets/775bd5d1-a83a-4414-b423-9fc9ece4d38d height="400" hspace="20">
<img src=https://github.com/user-attachments/assets/a43ae9ca-ba86-4e35-80a2-a82e101babc5 height="400">

</p>
