### PR TITLE
Translate 'Window' and 'Help' for global mac menu

### DIFF
--- a/src/ui_parts/mac_menu.gd
+++ b/src/ui_parts/mac_menu.gd
@@ -70,10 +70,15 @@ func _generate_main_menus() -> void:
 	_add_many_items(tool_rid, ShortcutUtils.get_actions("tool"))
 	_add_many_items(view_rid, ShortcutUtils.get_actions("view"))
 
+	await get_tree().process_frame
+	NativeMenu.set_system_menu_text(NativeMenu.WINDOW_MENU_ID, Translator.translate("Window"))
+	NativeMenu.set_system_menu_text(NativeMenu.HELP_MENU_ID, Translator.translate("Help"))
+
 
 func _add_many_items(menu_rid: RID, actions: PackedStringArray) -> void:
 	for action in actions:
 		_add_item(menu_rid, action)
+
 
 func _add_item(menu_rid: RID, action_name: String) -> int:
 	return NativeMenu.add_item(menu_rid, TranslationUtils.get_action_description(action_name),

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -446,6 +446,14 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr ""
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr ""
@@ -1130,10 +1138,6 @@ msgstr ""
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
-msgstr ""
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
 msgstr ""
 
 #: src/ui_widgets/transform_field.gd

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -447,6 +447,14 @@ msgstr "Инструмент"
 msgid "View"
 msgstr "Гледка"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Помощ"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "Добави нова гледка"
@@ -1132,10 +1140,6 @@ msgstr "Импортирай XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Постави XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Помощ"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/de.po
+++ b/translations/de.po
@@ -450,6 +450,14 @@ msgstr "Werkzeuge"
 msgid "View"
 msgstr "Ansicht"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Hilfe"
+
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add new preview"
@@ -1162,10 +1170,6 @@ msgstr "XML importieren"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "XML einfügen"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Hilfe"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/en.po
+++ b/translations/en.po
@@ -447,6 +447,14 @@ msgstr ""
 msgid "View"
 msgstr ""
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr ""
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr ""
@@ -1131,10 +1139,6 @@ msgstr ""
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
-msgstr ""
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
 msgstr ""
 
 #: src/ui_widgets/transform_field.gd

--- a/translations/es.po
+++ b/translations/es.po
@@ -447,6 +447,14 @@ msgstr "Herramientas"
 msgid "View"
 msgstr "Ver"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Ayuda"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "Añadir nueva vista previa"
@@ -1134,10 +1142,6 @@ msgstr "Importar XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Pegar XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Ayuda"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/et.po
+++ b/translations/et.po
@@ -447,6 +447,14 @@ msgstr "Tööriist"
 msgid "View"
 msgstr "Vaade"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Abi"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "Lisa uus eelvaade"
@@ -1134,10 +1142,6 @@ msgstr "Impordi XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Kleebi XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Abi"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -450,6 +450,14 @@ msgstr "Outils"
 msgid "View"
 msgstr "Affichage"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Aide"
+
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add new preview"
@@ -1163,10 +1171,6 @@ msgstr "Importer un fichier XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Coller du XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Aide"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -449,6 +449,14 @@ msgstr "Gereedschap"
 msgid "View"
 msgstr "Zicht"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Help"
+
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add new preview"
@@ -1147,10 +1155,6 @@ msgstr "XML Importeren"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "XML Plakken"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Help"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -448,6 +448,14 @@ msgstr "Ferramenta"
 msgid "View"
 msgstr "Visualizar"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Ajuda"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "Adicionar nova prévia"
@@ -1135,10 +1143,6 @@ msgstr "Importar XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Colar XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Ajuda"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -448,6 +448,14 @@ msgstr "Инструмент"
 msgid "View"
 msgstr "Просмотр"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Помощь"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "Добавить новый предпросмотр"
@@ -1136,10 +1144,6 @@ msgstr "Импортировать XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Вставить XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Помощь"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -449,6 +449,14 @@ msgstr "Інструмент"
 msgid "View"
 msgstr "Перегляд"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr ""
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "Допомога"
+
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add new preview"
@@ -1151,10 +1159,6 @@ msgstr "Імпортувати XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "Вставити XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "Допомога"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -447,6 +447,14 @@ msgstr "工具"
 msgid "View"
 msgstr "视图"
 
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr "窗口"
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "帮助"
+
 #: src/ui_parts/previews.gd
 msgid "Add new preview"
 msgstr "添加新预览"
@@ -1132,10 +1140,6 @@ msgstr "导入 XML"
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
 msgstr "粘贴 XML"
-
-#: src/ui_widgets/settings_content_shortcuts.gd
-msgid "Help"
-msgstr "帮助"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"


### PR DESCRIPTION
Both are these are not yet translated for mac's global menu

https://github.com/user-attachments/assets/783000b2-8f61-4dc4-bbf3-2b0622428793

