### PR TITLE
fix(flatpak): remove `file://` prefix

### DIFF
--- a/src/utils/FileUtils.gd
+++ b/src/utils/FileUtils.gd
@@ -225,7 +225,7 @@ static func _start_file_import_process(file_paths: PackedStringArray, completion
 allowed_extensions: PackedStringArray, show_incorrect_extension_errors := true) -> void:
 	for i in range(file_paths.size()):
 		var file_path = file_paths[i]
-		if file_path.begins_with("file://"):  # Flatpak may encode the file path as a URI
+		if file_path.begins_with("file://"):  # Flatpak may encode the file path as a URI.
 			file_paths[i] = file_path.trim_prefix("file://").uri_file_decode()
 
 	if not show_incorrect_extension_errors:


### PR DESCRIPTION
This is a fix for the flatpak I'm packaging.
I'm already backporting this patch to the latest v1.0-alpha13, so this PR isn't urgent.

When you right click an SVG in the file manager, and "Open with" GodSVG, you get an error that the file doesn't exist.

This is because the file path looks like `file:///run/user/1000/doc/3f199291/icon.svg` which Godot doesn't see as a valid file.

Removing the `file://` prefix turns this back into a real file path, fixing the issue.

More context here:
- https://github.com/adil192/flathub/pull/2
- #1598 
