### PR TITLE
metainfo: support tablet/stylus and replace deprecated developer_name

### DIFF
--- a/no_export/distribution/com.godsvg.GodSVG.metainfo.xml
+++ b/no_export/distribution/com.godsvg.GodSVG.metainfo.xml
@@ -39,5 +39,13 @@
 		</screenshot>
 	</screenshots>
 
-	<developer_name>The GodSVG community</developer_name>
+	<developer id="com.godsvg">
+		<name>The GodSVG community</name>
+	</developer>
+
+	<supports>
+		<control>pointing</control>
+		<control>keyboard</control>
+		<control>tablet</control>
+	</supports>
 </component>


### PR DESCRIPTION
- Replaces the deprecated [`<developer_name/>`](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer_name) with `<developer/>`.
- Adds graphics tablet to the supported input methods. (I don't think GodSVG uses pressure/tilt values currently but that's not an issue.) https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control
