### PR TITLE
ci: build appimage with linuxdeploy

### DIFF
--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build AppImage
         run: ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
         env:
-          # `latest-all` includes pre-releases. Once MewPurPur leaves alpha, change it to `latest`.
+          # `latest-all` includes pre-releases. Once GodSVG leaves alpha, change it to `latest`.
           LDAI_UPDATE_INFORMATION: gh-releases-zsync|MewPurPur|GodSVG|latest-all|${{ env.PROJECT_NAME }}_v*-x86_64.AppImage.zsync
           LDAI_OUTPUT: ${{ env.FULL_NAME }}-x86_64.AppImage
 

--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -109,9 +109,9 @@ jobs:
           install -Dm644 godsvg/no_export/distribution/com.godsvg.GodSVG.metainfo.xml -t AppDir/usr/share/metainfo/
           install -Dm644 godsvg/assets/logos/icon.svg AppDir/usr/share/icons/hicolor/scalable/apps/godsvg.svg
 
-      - name: Download AppImageTool
+      - name: Download linuxdeploy
         run: |
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
+          wget -q https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
           chmod +x linuxdeploy-x86_64.AppImage
 
       - name: Build AppImage

--- a/.github/workflows/export-optimized.yml
+++ b/.github/workflows/export-optimized.yml
@@ -96,35 +96,36 @@ jobs:
           if-no-files-found: error
           retention-days: 28
 
-      - name: Create AppDir structure
+      - name: Install FUSE
         run: |
-          mkdir -p AppDir/usr/bin
-          mkdir -p AppDir/usr/share/metainfo
-          cp godsvg/build/${FULL_NAME}.x86_64 AppDir/usr/bin/godsvg
-          cp godsvg/no_export/distribution/com.godsvg.GodSVG.desktop AppDir/godsvg.desktop
-          cp godsvg/assets/logos/icon.png AppDir/godsvg.png
-          cp godsvg/no_export/distribution/com.godsvg.GodSVG.metainfo.xml AppDir/usr/share/metainfo
-          ln -sf godsvg.png AppDir/.DirIcon
-          cat > AppDir/AppRun <<EOL
-          #!/bin/sh
-          exec "\$APPDIR/usr/bin/godsvg" "\$@"
-          EOL
-          chmod +x AppDir/AppRun
+          sudo add-apt-repository universe
+          # Note: libfuse2 is renamed to libfuse2t64 in Ubuntu 24.04.
+          sudo apt-get install appstream libfuse2
+
+      - name: Prepare AppDir for AppImage
+        run: |
+          install -Dm755 godsvg/build/${{ env.FULL_NAME }}.x86_64 AppDir/usr/bin/godsvg
+          install -Dm644 godsvg/no_export/distribution/com.godsvg.GodSVG.desktop -t AppDir/usr/share/applications/
+          install -Dm644 godsvg/no_export/distribution/com.godsvg.GodSVG.metainfo.xml -t AppDir/usr/share/metainfo/
+          install -Dm644 godsvg/assets/logos/icon.svg AppDir/usr/share/icons/hicolor/scalable/apps/godsvg.svg
 
       - name: Download AppImageTool
         run: |
-          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
-          chmod +x appimagetool-x86_64.AppImage
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/latest/download/linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
 
       - name: Build AppImage
-        run: |
-          ARCH=x86_64 ./appimagetool-x86_64.AppImage AppDir ${{ env.FULL_NAME }}.AppImage
+        run: ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage
+        env:
+          # `latest-all` includes pre-releases. Once MewPurPur leaves alpha, change it to `latest`.
+          LDAI_UPDATE_INFORMATION: gh-releases-zsync|MewPurPur|GodSVG|latest-all|${{ env.PROJECT_NAME }}_v*-x86_64.AppImage.zsync
+          LDAI_OUTPUT: ${{ env.FULL_NAME }}-x86_64.AppImage
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.FULL_NAME }}.Linux.AppImage
-          path: ${{ env.FULL_NAME }}.AppImage
+          path: ${{ env.FULL_NAME }}*.AppImage*
           if-no-files-found: error
           retention-days: 28
 


### PR DESCRIPTION
Removes the manual low-level build steps from appimagetool (https://github.com/MewPurPur/GodSVG/issues/1598#issuecomment-4623575651).

It turns out I was mistaken saying the previous AppImage wasn't portable. No new libs are deemed necessary by linuxdeploy, so the two should be equivalently portable.

Some other changes:
- Switched to the SVG version of the icon which is generally preferred.
- Added [update information](https://github.com/AppImage/AppImageSpec/blob/master/draft.md#update-information) which is read by tools like Gear Lever and AppImageUpdate. For this to work, you need to upload the `.AppImage` and `.AppImage.zsync` separately to each GitHub release.

This is how the AppImage looks in Gear Lever before and after this change:

<img width="40%" alt="Screenshot From 2026-06-04 21-40-07" src="https://github.com/user-attachments/assets/f7ead4c3-b77b-43d4-8702-7f1743dfc5f4" />
<img width="40%" alt="Screenshot From 2026-06-04 23-08-17" src="https://github.com/user-attachments/assets/ab9654ab-06c6-40c2-8bdc-016ed6ceb319" />
