### PR TITLE
Fix number field sliders causing frames to drag

### DIFF
--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -128,16 +128,17 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 			slider_dragged = true
 			initial_slider_value = element.get_attribute_value(attribute_name)
 			set_num(get_slider_value_at_y(event.position.y))
-		accept_event()
+			accept_event()
 	else:
 		if Utils.is_event_drag(event):
 			set_num(get_slider_value_at_y(event.position.y))
+			accept_event()
 		elif Utils.is_event_drag_end(event):
 			slider_dragged = false
 			var final_slider_value := get_slider_value_at_y(event.position.y)
 			if initial_slider_value != element.get_attribute(attribute_name).num_to_text(final_slider_value):
 				set_num(final_slider_value, true)
-		accept_event()
+			accept_event()
 
 func _unhandled_input(event: InputEvent) -> void:
 	if slider_dragged and Utils.is_event_drag_cancel(event):

--- a/src/ui_widgets/number_field_with_slider.gd
+++ b/src/ui_widgets/number_field_with_slider.gd
@@ -122,11 +122,13 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 	
 	if event is InputEventMouseMotion and event.button_mask == 0:
 		slider_hovered = true
+		accept_event()
 	if not slider_dragged:
 		if Utils.is_event_drag_start(event):
 			slider_dragged = true
 			initial_slider_value = element.get_attribute_value(attribute_name)
 			set_num(get_slider_value_at_y(event.position.y))
+		accept_event()
 	else:
 		if Utils.is_event_drag(event):
 			set_num(get_slider_value_at_y(event.position.y))
@@ -135,6 +137,7 @@ func _on_slider_gui_input(event: InputEvent) -> void:
 			var final_slider_value := get_slider_value_at_y(event.position.y)
 			if initial_slider_value != element.get_attribute(attribute_name).num_to_text(final_slider_value):
 				set_num(final_slider_value, true)
+		accept_event()
 
 func _unhandled_input(event: InputEvent) -> void:
 	if slider_dragged and Utils.is_event_drag_cancel(event):


### PR DESCRIPTION
Fixes a pesky bug where inspector element frames were being drag around when a `number_field_with_slider` was being interacted with via the slider.

https://github.com/user-attachments/assets/2e96ae37-3524-4f2d-924d-6174d3c4ea08

Usually bugs like these always happen because an input event isn't being swallowed somewhere where it should be.
In this case, two nodes were visibly trying to use events from the mouse at the same time, and adding `accept_event()` to a few cases of `InputEventMouseMotion` in `_on_slider_gui_input` fixed the bug for me.

