### PR TITLE
Expand UndoRedo operations in setting container

### DIFF
--- a/src/autoload/State.gd
+++ b/src/autoload/State.gd
@@ -768,7 +768,7 @@ func set_as_origin_selected() -> void:
 			
 			if not (selected_cmd is PathCommand.LineCommand or selected_cmd is PathCommand.HorizontalLineCommand\
 			or selected_cmd is PathCommand.VerticalLineCommand or (selected_cmd is PathCommand.EllipticalArcCommand and\
-			(selected_cmd.rx <= 0 or selected_cmd.ry <= 0))):
+			(selected_cmd.rx == 0.0 or selected_cmd.ry == 0.0))):
 				new_commands.append(selected_cmd)
 			new_commands.append(PathCommand.CloseCommand.new(true))
 		
@@ -844,7 +844,7 @@ func reverse_order_selected() -> void:
 				# A closed subpath beginning with a line-like command can omit it in favor of the closing Z performing the same segment.
 				if is_closed and (first_cmd is PathCommand.LineCommand or first_cmd is PathCommand.HorizontalLineCommand or\
 				first_cmd is PathCommand.VerticalLineCommand or (first_cmd is PathCommand.EllipticalArcCommand and\
-				(first_cmd.rx <= 0 or first_cmd.ry <= 0))):
+				(first_cmd.rx == 0.0 or first_cmd.ry == 0.0))):
 					reverse_start += 1
 				
 				# Runs of full curves, followed by shorthands, should get flipped around.

--- a/src/config_classes/Formatter.gd
+++ b/src/config_classes/Formatter.gd
@@ -66,7 +66,6 @@ func get_setting_default(setting: String) -> Variant:
 		"color_primary_syntax": return PrimaryColorSyntax.THREE_OR_SIX_DIGIT_HEX
 		"color_capital_hex": return false
 		
-		"xml_remove_comments": return preset == Preset.COMPACT
 		"xml_shorthand_tags": return ShorthandTags.ALWAYS if preset == Preset.COMPACT else ShorthandTags.ALL_EXCEPT_CONTAINERS
 		"xml_shorthand_tags_space_out_slash": return preset == Preset.PRETTY
 		"xml_formatting_style": return FormattingStyle.COMPACT if preset == Preset.COMPACT else FormattingStyle.PRETTY
@@ -113,12 +112,6 @@ func _init(new_preset := Preset.COMPACT) -> void:
 			emit_changed()
 
 
-@export var xml_remove_comments := true:
-	set(new_value):
-		if xml_remove_comments != new_value:
-			xml_remove_comments = new_value
-			emit_changed()
-
 @export var xml_add_trailing_newline := false:
 	set(new_value):
 		if xml_add_trailing_newline != new_value:
@@ -128,7 +121,7 @@ func _init(new_preset := Preset.COMPACT) -> void:
 @export var xml_shorthand_tags := ShorthandTags.ALWAYS:
 	set(new_value):
 		# Validation
-		if new_value < 0 || new_value >= ShorthandTags.size():
+		if new_value < 0 or new_value >= ShorthandTags.size():
 			new_value = get_setting_default("xml_shorthand_tags")
 		# Main part
 		if xml_shorthand_tags != new_value:
@@ -179,7 +172,7 @@ const INDENTS_MAX = 16
 @export var color_use_named_colors := NamedColorUse.WHEN_SHORTER:
 	set(new_value):
 		# Validation
-		if new_value < 0 || new_value >= NamedColorUse.size():
+		if new_value < 0 or new_value >= NamedColorUse.size():
 			new_value = get_setting_default("color_use_named_colors")
 		# Main part
 		if color_use_named_colors != new_value:
@@ -189,7 +182,7 @@ const INDENTS_MAX = 16
 @export var color_primary_syntax := PrimaryColorSyntax.THREE_OR_SIX_DIGIT_HEX:
 	set(new_value):
 		# Validation
-		if new_value < 0 || new_value >= PrimaryColorSyntax.size():
+		if new_value < 0 or new_value >= PrimaryColorSyntax.size():
 			new_value = get_setting_default("color_primary_syntax")
 		# Main part
 		if color_primary_syntax != new_value:

--- a/src/data_classes/AttributePathdata.gd
+++ b/src/data_classes/AttributePathdata.gd
@@ -165,11 +165,12 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 	var cmd := _commands[index]
 	if cmd is PathCommand.MoveCommand:
 		return conversion_method == Conversion.ANY_TO_MOVEMENT
-	elif cmd is PathCommand.LineCommand or (cmd is PathCommand.EllipticalArcCommand and (cmd.rx <= 0.0 or cmd.ry <= 0.0)):
+	elif cmd is PathCommand.LineCommand or (cmd is PathCommand.EllipticalArcCommand and (cmd.rx == 0.0 or cmd.ry == 0.0)):
 		match conversion_method:
 			Conversion.ANY_TO_LINE: return true
 			Conversion.ANY_TO_HORIZONTAL_LINE: return cmd.y == cmd.start_y
 			Conversion.ANY_TO_VERTICAL_LINE: return cmd.x == cmd.start_x
+			Conversion.ANY_TO_ELLIPTICAL_ARC: return cmd.start_x == cmd.x and cmd.start_y == cmd.y
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE: return ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)
 			Conversion.ANY_TO_SHORTHAND_QUADRATIC_BEZIER_CURVE:
 				return (ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)) and\
@@ -183,6 +184,7 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 		match conversion_method:
 			Conversion.ANY_TO_LINE, Conversion.ANY_TO_HORIZONTAL_LINE: return true
 			Conversion.ANY_TO_VERTICAL_LINE: return cmd.x == cmd.start_x
+			Conversion.ANY_TO_ELLIPTICAL_ARC: return cmd.start_x == cmd.x
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE: return ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)
 			Conversion.ANY_TO_SHORTHAND_QUADRATIC_BEZIER_CURVE:
 				return (ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)) and\
@@ -196,6 +198,7 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 		match conversion_method:
 			Conversion.ANY_TO_LINE, Conversion.ANY_TO_VERTICAL_LINE: return true
 			Conversion.ANY_TO_HORIZONTAL_LINE: return cmd.y == cmd.start_y
+			Conversion.ANY_TO_ELLIPTICAL_ARC: return cmd.start_y == cmd.y
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE: return ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)
 			Conversion.ANY_TO_SHORTHAND_QUADRATIC_BEZIER_CURVE:
 				return (ignore_subsequent_commands or not _has_following_shorthand_quadratic(index)) and\
@@ -208,7 +211,8 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 	elif cmd is PathCommand.CloseCommand:
 		return conversion_method == Conversion.ANY_TO_CLOSURE
 	elif cmd is PathCommand.EllipticalArcCommand:
-		return conversion_method == Conversion.ANY_TO_ELLIPTICAL_ARC
+		return conversion_method == Conversion.ANY_TO_ELLIPTICAL_ARC or (not conversion_method in [Conversion.ANY_TO_MOVEMENT, Conversion.ANY_TO_CLOSURE] and\
+		(cmd.x == cmd.start_x and cmd.y == cmd.start_y) or cmd.rx == 0.0 or cmd.ry == 0.0)
 	elif cmd is PathCommand.QuadraticBezierCommand:
 		match conversion_method:
 			Conversion.ANY_TO_LINE:
@@ -220,6 +224,7 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 			Conversion.ANY_TO_VERTICAL_LINE:
 				return cmd.x == cmd.start_x and is_point_on_segment(cmd.x1, cmd.y1, cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						(ignore_subsequent_commands or not _has_following_shorthand_quadratic(index))
+			Conversion.ANY_TO_ELLIPTICAL_ARC: return cmd.start_x == cmd.x and cmd.start_y == cmd.y and cmd.start_x == cmd.x1 and cmd.start_y == cmd.y1
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE: return true
 			Conversion.ANY_TO_SHORTHAND_QUADRATIC_BEZIER_CURVE:
 				var implied := get_implied_T_control(index)
@@ -244,6 +249,9 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 			Conversion.ANY_TO_VERTICAL_LINE:
 				return cmd.x == cmd.start_x and is_implied_T_control_on_segment(index, cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						(ignore_subsequent_commands or not _has_following_shorthand_quadratic(index))
+			Conversion.ANY_TO_ELLIPTICAL_ARC:
+				var implied := get_implied_T_control(index)
+				return cmd.start_x == cmd.x and cmd.start_y == cmd.y and cmd.start_x == implied[0] and cmd.start_y == implied[1]
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE, Conversion.ANY_TO_SHORTHAND_QUADRATIC_BEZIER_CURVE: return true
 			Conversion.ANY_TO_CUBIC_BEZIER_CURVE:
 				return ignore_subsequent_commands or not (_has_following_shorthand_cubic(index) or _has_following_shorthand_quadratic(index))
@@ -266,6 +274,7 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 				return cmd.x == cmd.start_x and is_point_on_segment(cmd.x1, cmd.y1, cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						is_point_on_segment(cmd.x2, cmd.y2, cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						(ignore_subsequent_commands or not _has_following_shorthand_cubic(index))
+			Conversion.ANY_TO_ELLIPTICAL_ARC: return cmd.start_x == cmd.x and cmd.start_y == cmd.y and cmd.start_x == cmd.x2 and cmd.start_y == cmd.y2
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE:
 				return is_equal_approx(3 * cmd.x1 - cmd.start_x, 3 * cmd.x2 - cmd.x) and is_equal_approx(3 * cmd.y1 - cmd.start_y, 3 * cmd.y2 - cmd.y) and\
 						(ignore_subsequent_commands or not _has_following_shorthand_quadratic(index))
@@ -297,6 +306,10 @@ func is_conversion_exact(index: int, conversion_method: Conversion, ignore_subse
 				return cmd.x == cmd.start_x and is_point_on_segment(implied[0], implied[1], cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						is_point_on_segment(cmd.x2, cmd.y2, cmd.start_x, cmd.start_y, cmd.start_x, cmd.y) and\
 						(ignore_subsequent_commands or not _has_following_shorthand_cubic(index))
+			Conversion.ANY_TO_ELLIPTICAL_ARC:
+				var implied := get_implied_S_control(index)
+				return cmd.start_x == cmd.x and cmd.start_y == cmd.y and cmd.start_x == implied[0] and cmd.start_y == implied[1] and\
+						cmd.start_x == cmd.x2 and cmd.start_y == cmd.y2
 			Conversion.ANY_TO_QUADRATIC_BEZIER_CURVE:
 				var implied := get_implied_S_control(index)
 				return is_equal_approx(3 * implied[0] - cmd.start_x, 3 * cmd.x2 - cmd.x) and is_equal_approx(3 * implied[1] - cmd.start_y, 3 * cmd.y2 - cmd.y) and\

--- a/src/data_classes/BasicXNode.gd
+++ b/src/data_classes/BasicXNode.gd
@@ -33,9 +33,8 @@ static func get_type_string(node_type: NodeType) -> String:
 
 func get_possible_conversions() -> Array[NodeType]:
 	var conversions: Array[NodeType] = []
-	if (_type == NodeType.TEXT or _type == NodeType.CDATA) and not Configs.savedata.editor_formatter.xml_remove_comments:
+	if _type == NodeType.TEXT or _type == NodeType.CDATA:
 		conversions.append(NodeType.COMMENT)
-	
 	if _type == NodeType.COMMENT or _type == NodeType.CDATA:
 		conversions.append(NodeType.TEXT)
 	if _type == NodeType.COMMENT or _type == NodeType.TEXT:

--- a/src/data_classes/SVGParser.gd
+++ b/src/data_classes/SVGParser.gd
@@ -85,9 +85,6 @@ static func _xnode_to_markup(xnode: XNode, formatter: Formatter, make_attributes
 		markup = formatter.get_indent_string().repeat(xnode.xid.size())
 	
 	if not xnode.is_element():
-		if (formatter.xml_remove_comments and xnode.get_type() == BasicXNode.NodeType.COMMENT):
-			return ""
-		
 		match xnode.get_type():
 			BasicXNode.NodeType.COMMENT: markup += "<!--%s-->" % xnode.get_text()
 			BasicXNode.NodeType.CDATA: markup += "<![CDATA[%s]]>" % xnode.get_text()
@@ -237,8 +234,7 @@ static func markup_to_root(markup: String) -> ParseResult:
 						break
 			
 			XMLParser.NODE_COMMENT:
-				if not Configs.savedata.editor_formatter.xml_remove_comments:
-					unclosed_element_stack.back().insert_child(-1, BasicXNode.new(BasicXNode.NodeType.COMMENT, parser.get_node_name()))
+				unclosed_element_stack.back().insert_child(-1, BasicXNode.new(BasicXNode.NodeType.COMMENT, parser.get_node_name()))
 			XMLParser.NODE_TEXT:
 				var node_offset := parser.get_node_offset()
 				# Trick to read XML text as is, without parsing stuff like "&lt;".

--- a/src/ui_parts/display.gd
+++ b/src/ui_parts/display.gd
@@ -30,7 +30,10 @@ func _ready() -> void:
 	zoom_widget.zoom_in_pressed.connect(canvas.zoom_in)
 	zoom_widget.zoom_out_pressed.connect(canvas.zoom_out)
 	zoom_widget.zoom_reset_pressed.connect(canvas.center_frame)
-	canvas.camera_zoom_changed.connect(func() -> void: zoom_widget.sync_to_value(canvas.camera_zoom))
+	canvas.camera_zoom_changed.connect(
+		func() -> void:
+			zoom_widget.sync_to_value(canvas.camera_zoom)
+	)
 	
 	reference_button.pressed.connect(_on_reference_button_pressed)
 	visuals_button.pressed.connect(_on_visuals_button_pressed)

--- a/src/ui_parts/editor_scene.gd
+++ b/src/ui_parts/editor_scene.gd
@@ -184,8 +184,10 @@ func _create_part_box(layout_parts: Array[Utils.LayoutPart]) -> Control:
 			btn.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
 			btn.button_group = btn_group
 			for node_part in layout_nodes:
-				btn.toggled.connect(func(_toggled_on: bool) -> void:
-						layout_nodes[node_part].visible = (node_part == part))
+				btn.toggled.connect(
+					func(_toggled_on: bool) -> void:
+						layout_nodes[node_part].visible = (node_part == part)
+				)
 			if part == Utils.LayoutPart.INSPECTOR:
 				State.requested_scroll_to_selection.connect(btn.set_pressed.bind(true).unbind(3))
 			buttons_hbox.add_child(btn)

--- a/src/ui_parts/export_menu.gd
+++ b/src/ui_parts/export_menu.gd
@@ -120,8 +120,7 @@ func set_current_format(new_format: String) -> void:
 	
 	if is_instance_valid(new_properties_scene_root):
 		content_container.add_child(new_properties_scene_root)
-		new_properties_scene_root.setup(get_edited_export_data(), dimensions)
-		new_properties_scene_root.undo_redo = undo_redo
+		new_properties_scene_root.setup(get_edited_export_data(), undo_redo, dimensions)
 	
 	var file_name := Utils.get_file_name(Configs.savedata.get_active_tab().svg_file_path)
 	if not file_name.is_empty():

--- a/src/ui_parts/main_canvas.gd
+++ b/src/ui_parts/main_canvas.gd
@@ -126,7 +126,7 @@ func sync_reference_image_filtering() -> void:
 		var image_size := active_tab.reference_image.get_size()
 		var factor := minf(checkerboard.size.x / image_size.x, checkerboard.size.y / image_size.y) * camera_zoom
 		RenderingServer.canvas_item_set_default_texture_filter(reference_image_ci,
-				RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_NEAREST if factor >= 2 else RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_LINEAR)
+				RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_NEAREST if factor >= 4 else RenderingServer.CANVAS_ITEM_TEXTURE_FILTER_LINEAR)
 
 func sync_camera() -> void:
 	var active_tab := Configs.savedata.get_active_tab()

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -4,6 +4,8 @@ const SettingsContentGeneric = preload("res://src/ui_widgets/settings_content_ge
 const SettingsContentPalettes = preload("res://src/ui_widgets/settings_content_palettes.tscn")
 const SettingsContentShortcuts = preload("res://src/ui_widgets/settings_content_shortcuts.tscn")
 
+var undo_redo := UndoRedoRef.new()
+
 @onready var language_button: Button = %LanguageButton
 @onready var settings_tab_container: GoodTabContainer = %SettingsTabContainer
 @onready var preview_panel: PanelContainer = %PreviewPanel
@@ -26,6 +28,8 @@ func _ready() -> void:
 	var shortcuts := ShortcutsRegistration.new()
 	shortcuts.add_shortcut("select_next_tab", select_next_tab)
 	shortcuts.add_shortcut("select_previous_tab", select_previous_tab)
+	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
+	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
 	close_button.pressed.connect(queue_free)
@@ -79,6 +83,8 @@ func get_content(index: TabIndex) -> Control:
 			current_content = SettingsContentPalettes.instantiate()
 		TabIndex.SHORTCUTS:
 			current_content = SettingsContentShortcuts.instantiate()
+			current_content.setup_undo_redo_utensils(undo_redo, settings_tab_container.scroll_vertical_to,
+					settings_tab_container.select_tab.bind(TabIndex.SHORTCUTS))
 		TabIndex.THEMING, TabIndex.TAB_BAR, TabIndex.OTHER:
 			current_content = SettingsContentGeneric.instantiate()
 			var callback := Callable()

--- a/src/ui_widgets/ContextButton.gd
+++ b/src/ui_widgets/ContextButton.gd
@@ -105,12 +105,13 @@ static func create_arrow(new_text: String, new_submenu_button_builders: Array[Ca
 			exit_timer.stop()
 			enter_timer.start()
 	)
-	enter_timer.timeout.connect(func() -> void:
-		if HandlerGUI.popup_submenu_source != context_button:
-			var options: Array[ContextButton] = []
-			for button_builder in context_button.submenu_button_builders:
-				options.append(button_builder.call())
-			HandlerGUI.popup_submenu_to_right_or_left_side(ContextPopup.create(options), context_button)
+	enter_timer.timeout.connect(
+		func() -> void:
+			if HandlerGUI.popup_submenu_source != context_button:
+				var options: Array[ContextButton] = []
+				for button_builder in context_button.submenu_button_builders:
+					options.append(button_builder.call())
+				HandlerGUI.popup_submenu_to_right_or_left_side(ContextPopup.create(options), context_button)
 	)
 	
 	context_button.ready.connect(
@@ -119,14 +120,15 @@ static func create_arrow(new_text: String, new_submenu_button_builders: Array[Ca
 			while is_instance_valid(popup) and not popup is ContextPopup:
 				popup = popup.get_parent()
 			
-			popup.gui_input.connect(func(event: InputEvent) -> void:
-				if not (enter_timer.is_stopped() or Rect2(Vector2.ZERO, context_button.size).has_point(context_button.get_local_mouse_position())):
-					enter_timer.stop()
-				
-				if HandlerGUI.popup_submenu_source == context_button and event is InputEventMouseMotion:
-					if not Rect2(Vector2.ZERO, context_button.size).has_point(context_button.get_local_mouse_position()):
-						if exit_timer.is_stopped() and Rect2(Vector2.ZERO, popup.size).grow(-2).has_point(event.position):
-							exit_timer.start()
+			popup.gui_input.connect(
+				func(event: InputEvent) -> void:
+					if not (enter_timer.is_stopped() or Rect2(Vector2.ZERO, context_button.size).has_point(context_button.get_local_mouse_position())):
+						enter_timer.stop()
+					
+					if HandlerGUI.popup_submenu_source == context_button and event is InputEventMouseMotion:
+						if not Rect2(Vector2.ZERO, context_button.size).has_point(context_button.get_local_mouse_position()):
+							if exit_timer.is_stopped() and Rect2(Vector2.ZERO, popup.size).grow(-2).has_point(event.position):
+								exit_timer.start()
 			)
 	)
 	

--- a/src/ui_widgets/GoodTabContainer.gd
+++ b/src/ui_widgets/GoodTabContainer.gd
@@ -192,6 +192,13 @@ func clear_all_tabs() -> void:
 func get_tab_count() -> int:
 	return _tab_names.size()
 
+func scroll_vertical_to(global_rect: Rect2, margin_proportion: float) -> void:
+	global_rect.position.y += _scroll_container.scroll_vertical - _scroll_container.global_position.y
+	var buffer := roundi(_scroll_container.size.y * margin_proportion)
+	_scroll_container.scroll_vertical = clampi(_scroll_container.scroll_vertical,
+			maxi(0, roundi(global_rect.end.y) - roundi(_scroll_container.size.y) + buffer),
+			maxi(0, roundi(global_rect.position.y) - buffer))
+
 
 func _on_base_class_tab_selected(index: int) -> void:
 	for child in _content_container.get_children():

--- a/src/ui_widgets/UndoRedoRef.gd
+++ b/src/ui_widgets/UndoRedoRef.gd
@@ -32,8 +32,8 @@ func add_do_reference(object: Object) -> void:
 func add_undo_reference(object: Object) -> void:
 	_undo_redo.add_undo_reference(object)
 
-func commit_action() -> void:
-	_undo_redo.commit_action()
+func commit_action(execute := true) -> void:
+	_undo_redo.commit_action(execute)
 
 func undo() -> bool:
 	return _undo_redo.undo()

--- a/src/ui_widgets/choose_name_dialog.gd
+++ b/src/ui_widgets/choose_name_dialog.gd
@@ -30,7 +30,10 @@ func _on_name_edit_text_submitted(_text: String) -> void:
 func setup(title: String, action: Callable, error_callable := Callable(),
 warning_callable := Callable()) -> void:
 	title_label.text = title
-	action_button.pressed.connect(func() -> void: action.call(name_edit.text))
+	action_button.pressed.connect(
+		func() -> void:
+			action.call(name_edit.text)
+	)
 	name_edit.custom_minimum_size.x = 240.0
 	warning_callback = warning_callable
 	error_callback = error_callable

--- a/src/ui_widgets/color_utilities_area.tscn
+++ b/src/ui_widgets/color_utilities_area.tscn
@@ -30,7 +30,7 @@ script = ExtResource("3_korb8")
 layout_mode = 2
 theme_type_variation = &"SmallHSeparator"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="." unique_id=1509890288]
+[node name="ScrollContainer" type="ScrollContainer" parent="." unique_id=789039555]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0

--- a/src/ui_widgets/export_properties_jpg.gd
+++ b/src/ui_widgets/export_properties_jpg.gd
@@ -18,28 +18,26 @@ func _ready() -> void:
 	background_label.text = Translator.translate("Background") + ":"
 	HandlerGUI.register_focus_sequence(self, [quality_edit, background_edit, export_scale_config])
 
-func setup(new_export_data_object: ImageExportDataJPG, dimensions: Vector2) -> void:
+func setup(new_export_data_object: ImageExportDataJPG, new_undo_redo: UndoRedoRef, dimensions: Vector2) -> void:
 	export_data_object = new_export_data_object
+	undo_redo = new_undo_redo
 	
 	quality_edit.initial_value = export_data_object.quality * 100
 	quality_edit.value_changed.connect(
 		func(new_value: float) -> void:
 			var new_quality := new_value / 100
 			quality_edit.text = String.num_uint64(roundi(new_quality * 100))
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "quality", new_quality)
-				undo_redo.add_undo_property(export_data_object, "quality", export_data_object.quality)
-				undo_redo.commit_action()
-			else:
-				export_data_object.undo_redo = new_quality
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "quality", new_quality)
+			undo_redo.add_undo_property(export_data_object, "quality", export_data_object.quality)
+			undo_redo.commit_action()
 	)
 	
 	background_edit.setup(true, export_data_object.background_color)
 	background_edit.color_picked.connect(
 		func(new_value: String, is_final: bool, old_final_value: String) -> void:
 			var new_background_color := ColorParser.text_to_color(new_value, Color.BLACK, true)
-			if is_instance_valid(undo_redo) and is_final:
+			if is_final:
 				undo_redo.create_action()
 				undo_redo.add_do_property(export_data_object, "background_color", new_background_color)
 				undo_redo.add_undo_property(export_data_object, "background_color", old_final_value)
@@ -51,13 +49,10 @@ func setup(new_export_data_object: ImageExportDataJPG, dimensions: Vector2) -> v
 	export_scale_config.setup(dimensions, export_data_object.upscale_amount)
 	export_scale_config.scale_changed.connect(
 		func(new_value: float) -> void:
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
-				undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
-				undo_redo.commit_action()
-			else:
-				export_data_object.upscale_amount = new_value
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
+			undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
+			undo_redo.commit_action()
 	)
 	
 	var _on_changed :=\

--- a/src/ui_widgets/export_properties_raster_lossless.gd
+++ b/src/ui_widgets/export_properties_raster_lossless.gd
@@ -14,14 +14,15 @@ func _ready() -> void:
 	background_label.text = Translator.translate("Background") + ":"
 	HandlerGUI.register_focus_sequence(self, [background_edit, export_scale_config])
 
-func setup(new_export_data_object: ImageExportDataRaster, dimensions: Vector2) -> void:
+func setup(new_export_data_object: ImageExportDataRaster, new_undo_redo: UndoRedoRef, dimensions: Vector2) -> void:
 	export_data_object = new_export_data_object
+	undo_redo = new_undo_redo
 	
 	background_edit.setup(true, export_data_object.background_color)
 	background_edit.color_picked.connect(
 		func(new_value: String, is_final: bool, old_final_value: String) -> void:
 			var new_background_color := ColorParser.text_to_color(new_value, Color.BLACK, true)
-			if is_instance_valid(undo_redo) and is_final:
+			if is_final:
 				undo_redo.create_action()
 				undo_redo.add_do_property(export_data_object, "background_color", new_background_color)
 				undo_redo.add_undo_property(export_data_object, "background_color", old_final_value)
@@ -36,13 +37,10 @@ func setup(new_export_data_object: ImageExportDataRaster, dimensions: Vector2) -
 		export_scale_config.max_dimension = 65535
 	export_scale_config.scale_changed.connect(
 		func(new_value: float) -> void:
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
-				undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
-				undo_redo.commit_action()
-			else:
-				export_data_object.upscale_amount = new_value
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
+			undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
+			undo_redo.commit_action()
 	)
 	
 	var _on_changed :=\

--- a/src/ui_widgets/export_properties_webp.gd
+++ b/src/ui_widgets/export_properties_webp.gd
@@ -21,18 +21,16 @@ func _ready() -> void:
 	lossless_checkbox.text = Translator.translate("Lossless")
 	HandlerGUI.register_focus_sequence(self, [lossless_checkbox, quality_edit, background_edit, export_scale_config])
 
-func setup(new_export_data_object: ImageExportDataWEBP, dimensions: Vector2) -> void:
+func setup(new_export_data_object: ImageExportDataWEBP, new_undo_redo: UndoRedoRef, dimensions: Vector2) -> void:
 	export_data_object = new_export_data_object
+	undo_redo = new_undo_redo
 	
 	lossless_checkbox.toggled.connect(
 		func(toggled_on: bool) -> void:
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "lossy", not toggled_on)
-				undo_redo.add_undo_property(export_data_object, "lossy", export_data_object.lossy)
-				undo_redo.commit_action()
-			else:
-				export_data_object.lossy = not toggled_on
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "lossy", not toggled_on)
+			undo_redo.add_undo_property(export_data_object, "lossy", export_data_object.lossy)
+			undo_redo.commit_action()
 	)
 	
 	quality_edit.initial_value = export_data_object.quality * 100
@@ -40,20 +38,17 @@ func setup(new_export_data_object: ImageExportDataWEBP, dimensions: Vector2) -> 
 		func(new_value: float) -> void:
 			var new_quality := new_value / 100
 			quality_edit.text = String.num_uint64(roundi(new_quality * 100))
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "quality", new_quality)
-				undo_redo.add_undo_property(export_data_object, "quality", export_data_object.quality)
-				undo_redo.commit_action()
-			else:
-				export_data_object.undo_redo = new_quality
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "quality", new_quality)
+			undo_redo.add_undo_property(export_data_object, "quality", export_data_object.quality)
+			undo_redo.commit_action()
 	)
 	
 	background_edit.setup(true, export_data_object.background_color)
 	background_edit.color_picked.connect(
 		func(new_value: String, is_final: bool, old_final_value: String) -> void:
 			var new_background_color := ColorParser.text_to_color(new_value, Color.BLACK, true)
-			if is_instance_valid(undo_redo) and is_final:
+			if is_final:
 				undo_redo.create_action()
 				undo_redo.add_do_property(export_data_object, "background_color", new_background_color)
 				undo_redo.add_undo_property(export_data_object, "background_color", old_final_value)
@@ -65,13 +60,10 @@ func setup(new_export_data_object: ImageExportDataWEBP, dimensions: Vector2) -> 
 	export_scale_config.setup(dimensions, export_data_object.upscale_amount)
 	export_scale_config.scale_changed.connect(
 		func(new_value: float) -> void:
-			if is_instance_valid(undo_redo):
-				undo_redo.create_action()
-				undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
-				undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
-				undo_redo.commit_action()
-			else:
-				export_data_object.upscale_amount = new_value
+			undo_redo.create_action()
+			undo_redo.add_do_property(export_data_object, "upscale_amount", new_value)
+			undo_redo.add_undo_property(export_data_object, "upscale_amount", export_data_object.upscale_amount)
+			undo_redo.commit_action()
 	)
 	
 	var _on_changed :=\

--- a/src/ui_widgets/options_dialog.gd
+++ b/src/ui_widgets/options_dialog.gd
@@ -41,11 +41,12 @@ action_when_checkbox_checked := Callable(), disabled_when_checkbox_pressed := fa
 	button.size_flags_horizontal = Control.SIZE_EXPAND | Control.SIZE_SHRINK_CENTER
 	
 	if action_when_checkbox_checked.is_valid():
-		button.pressed.connect(func() -> void:
-			if checkbox.button_pressed:
-				action_when_checkbox_checked.call()
-			else:
-				action.call()
+		button.pressed.connect(
+			func() -> void:
+				if checkbox.button_pressed:
+					action_when_checkbox_checked.call()
+				else:
+					action.call()
 		)
 	else:
 		button.pressed.connect(action)

--- a/src/ui_widgets/pathdata_field.gd
+++ b/src/ui_widgets/pathdata_field.gd
@@ -60,7 +60,7 @@ func setup() -> void:
 	line_edit.tooltip_text = attribute_name
 	line_edit.text_submitted.connect(set_value.bind(true))
 	line_edit.text_changed.connect(setup_font)
-	line_edit.text_change_canceled.connect(func() -> void: setup_font(line_edit.text))
+	line_edit.text_change_canceled.connect(setup_font_with_current_text)
 	line_edit.text_change_canceled.connect(sync)
 	line_edit.focus_entered.connect(_on_line_edit_focus_entered)
 	commands_container.draw.connect(_commands_draw)
@@ -95,6 +95,9 @@ func sync_theming() -> void:
 
 func _on_line_edit_focus_entered() -> void:
 	focused.emit()
+
+func setup_font_with_current_text() -> void:
+	setup_font(line_edit.text)
 
 func setup_font(new_text: String) -> void:
 	if new_text.is_empty():

--- a/src/ui_widgets/points_field.gd
+++ b/src/ui_widgets/points_field.gd
@@ -59,7 +59,7 @@ func setup() -> void:
 	line_edit.tooltip_text = attribute_name
 	line_edit.text_submitted.connect(set_value.bind(true))
 	line_edit.text_changed.connect(setup_font)
-	line_edit.text_change_canceled.connect(func() -> void: setup_font(line_edit.text))
+	line_edit.text_change_canceled.connect(setup_font_with_current_text)
 	line_edit.focus_entered.connect(_on_line_edit_focus_entered)
 	points_container.draw.connect(points_draw)
 	points_container.gui_input.connect(_on_points_gui_input)
@@ -93,6 +93,9 @@ func sync_theming() -> void:
 
 func _on_line_edit_focus_entered() -> void:
 	focused.emit()
+
+func setup_font_with_current_text() -> void:
+	setup_font(line_edit.text)
 
 func setup_font(new_text: String) -> void:
 	if new_text.is_empty():

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -47,10 +47,11 @@ func set_optimizer_info(example_root: ElementRoot, optimizer: Optimizer, main_te
 	info_button.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	info_button.focus_mode = Control.FOCUS_NONE
 	add_child(info_button)
-	info_button.pressed.connect(func() -> void:
-		var info := OptimizerSettingInfoScene.instantiate()
-		info.setup(example_root.duplicate(), optimizer, main_text)
-		HandlerGUI.popup_under_rect_center(info, info_button.get_global_rect(), get_viewport())
+	info_button.pressed.connect(
+		func() -> void:
+			var info := OptimizerSettingInfoScene.instantiate()
+			info.setup(example_root.duplicate(), optimizer, main_text)
+			HandlerGUI.popup_under_rect_center(info, info_button.get_global_rect(), get_viewport())
 	)
 	var margin_size := (size.y - info_button.size.y) / 2.0
 	info_button.position = Vector2(margin_size, margin_size)

--- a/src/ui_widgets/setting_shortcut.gd
+++ b/src/ui_widgets/setting_shortcut.gd
@@ -105,7 +105,7 @@ func enter_listening_mode(idx: int, show_delete_button := false) -> void:
 			activation_event.keycode = KEY_CTRL
 		elif is_meta_pressed:
 			activation_event.keycode = KEY_META
-
+		
 		set_shortcut_button_text(btn, activation_event.as_text_keycode())
 		pending_event = activation_event
 	else:
@@ -155,8 +155,7 @@ func _input(event: InputEvent) -> void:
 		set_shortcut_button_text(shortcut_button, event.as_text_keycode())
 		pending_event = event
 		if pending_event.keycode & KEY_MODIFIER_MASK != 0:
-			setup_shortcut_button_font_colors(shortcut_button,
-					Configs.savedata.basic_color_warning)
+			setup_shortcut_button_font_colors(shortcut_button, Configs.savedata.basic_color_warning)
 		else:
 			setup_shortcut_button_font_colors(shortcut_button, ThemeUtils.editable_text_color)
 		accept_event()
@@ -165,8 +164,7 @@ func _input(event: InputEvent) -> void:
 			# Makes sure the saved event is clean.
 			var saved_event := InputEventKey.new()
 			saved_event.device = -1
-			saved_event.command_or_control_autoremap = (pending_event.ctrl_pressed or\
-					pending_event.meta_pressed)
+			saved_event.command_or_control_autoremap = (pending_event.ctrl_pressed or pending_event.meta_pressed)
 			saved_event.keycode = pending_event.keycode
 			saved_event.unicode = pending_event.unicode
 			saved_event.alt_pressed = pending_event.alt_pressed
@@ -200,8 +198,7 @@ func set_shortcut_button_text(button: Button, new_text: String) -> void:
 	button.remove_theme_font_size_override("font_size")
 	while button.get_theme_font("font").get_string_size(new_text, HORIZONTAL_ALIGNMENT_LEFT,
 	-1, button.get_theme_font_size("font_size")).x > button.custom_minimum_size.x:
-		button.add_theme_font_size_override("font_size",
-				button.get_theme_font_size("font_size") - 1)
+		button.add_theme_font_size_override("font_size", button.get_theme_font_size("font_size") - 1)
 	button.text = new_text
 
 func check_shortcuts_validity() -> void:
@@ -210,8 +207,7 @@ func check_shortcuts_validity() -> void:
 		var event := events[i]
 		var shortcut_btn := shortcut_buttons[i]
 		if not Configs.savedata.is_shortcut_valid(event):
-			setup_shortcut_button_font_colors(shortcut_btn,
-					Configs.savedata.basic_color_error)
+			setup_shortcut_button_font_colors(shortcut_btn, Configs.savedata.basic_color_error)
 			var conflicts := Configs.savedata.get_actions_with_shortcut(event)
 			var action_pos := conflicts.find(action)
 			if action_pos != -1:
@@ -221,8 +217,7 @@ func check_shortcuts_validity() -> void:
 			if conflicts.size() > 8:
 				conflicts.resize(8)
 				conflicts.append("...")
-			shortcut_btn.tooltip_text = Translator.translate("Also used by") +\
-					":\n" + "\n".join(conflicts)
+			shortcut_btn.tooltip_text = Translator.translate("Also used by") + ":\n" + "\n".join(conflicts)
 		else:
 			var already_used := false
 			for ii in events.size():
@@ -231,8 +226,7 @@ func check_shortcuts_validity() -> void:
 					break
 			
 			if already_used:
-				setup_shortcut_button_font_colors(shortcut_btn,
-						Configs.savedata.basic_color_warning)
+				setup_shortcut_button_font_colors(shortcut_btn, Configs.savedata.basic_color_warning)
 			else:
 				shortcut_btn.begin_bulk_theme_override()
 				shortcut_btn.remove_theme_color_override("font_color")

--- a/src/ui_widgets/settings_content_generic.gd
+++ b/src/ui_widgets/settings_content_generic.gd
@@ -141,18 +141,6 @@ func setup_formatting_content() -> void:
 			"Determines the default values of the formatter configs.")))
 	
 	add_section("XML")
-	current_setup_setting = "xml_remove_comments"
-	add_checkbox(Translator.translate("Remove comments"))
-	var xml_remove_comments_root_element := ElementRoot.new()
-	xml_remove_comments_root_element.insert_child(0, BasicXNode.new(BasicXNode.NodeType.COMMENT, " Comment "))
-	var xml_remove_comments_circle_element := ElementCircle.new()
-	xml_remove_comments_circle_element.set_attribute("cx", 6)
-	xml_remove_comments_circle_element.set_attribute("cy", 8)
-	xml_remove_comments_circle_element.set_attribute("r", 4)
-	xml_remove_comments_circle_element.set_attribute("fill", "plum")
-	xml_remove_comments_root_element.insert_child(1, xml_remove_comments_circle_element)
-	add_preview(SettingFormatterPreview.new(current_setup_resource, xml_remove_comments_root_element, true))
-	
 	current_setup_setting = "xml_add_trailing_newline"
 	add_checkbox(Translator.translate("Add trailing newline"))
 	var xml_add_trailing_newline_root_element := ElementRoot.new()
@@ -169,8 +157,7 @@ func setup_formatting_content() -> void:
 	
 	current_setup_setting = "xml_shorthand_tags"
 	add_dropdown(Translator.translate("Use shorthand tag syntax"),
-			range(Formatter.ShorthandTags.size()),
-			Formatter.get_shorthand_tags_value_text_map())
+			range(Formatter.ShorthandTags.size()), Formatter.get_shorthand_tags_value_text_map())
 	var xml_shorthand_tags_root_element := ElementRoot.new()
 	var xml_shorthand_tags_linear_gradient_element := ElementLinearGradient.new()
 	xml_shorthand_tags_linear_gradient_element.set_attribute("id", "a")
@@ -199,9 +186,7 @@ func setup_formatting_content() -> void:
 	
 	current_setup_setting = "xml_formatting_style"
 	add_dropdown(Translator.translate("Formatting style"),
-		range(Formatter.FormattingStyle.size()),
-		Formatter.get_formatting_style_value_text_map()
-	)
+			range(Formatter.FormattingStyle.size()), Formatter.get_formatting_style_value_text_map())
 	var xml_formatting_style_root_element := ElementRoot.new()
 	var xml_formatting_style_linear_gradient_element := ElementLinearGradient.new()
 	xml_formatting_style_linear_gradient_element.set_attribute("id", "a")
@@ -275,8 +260,7 @@ func setup_formatting_content() -> void:
 	add_section(Translator.translate("Colors"))
 	current_setup_setting = "color_use_named_colors"
 	add_dropdown(Translator.translate("Use named colors"),
-			range(Formatter.NamedColorUse.size()),
-			Formatter.get_named_color_use_value_text_map())
+			range(Formatter.NamedColorUse.size()), Formatter.get_named_color_use_value_text_map())
 	var color_use_named_colors_root_element := ElementRoot.new()
 	var color_use_named_colors_circle_1 := ElementCircle.new()
 	color_use_named_colors_circle_1.set_attribute("cx", 6)
@@ -295,8 +279,7 @@ func setup_formatting_content() -> void:
 	
 	current_setup_setting = "color_primary_syntax"
 	add_dropdown(Translator.translate("Primary syntax"),
-			range(Formatter.PrimaryColorSyntax.size()),
-			Formatter.get_primary_color_syntax_value_text_map())
+			range(Formatter.PrimaryColorSyntax.size()), Formatter.get_primary_color_syntax_value_text_map())
 	var color_primary_syntax_root_element := ElementRoot.new()
 	var color_primary_syntax_circle_element := ElementCircle.new()
 	color_primary_syntax_circle_element.set_attribute("cx", 6)

--- a/src/ui_widgets/settings_content_shortcuts.gd
+++ b/src/ui_widgets/settings_content_shortcuts.gd
@@ -7,9 +7,12 @@ const ShortcutShowcaseWidgetScene = preload("res://src/ui_widgets/presented_shor
 @onready var shortcuts_container: VBoxContainer = $ShortcutsContainer
 
 const shortcut_categories: PackedStringArray = ["file", "edit", "view", "tool", "help"]
-var category_buttons: Dictionary[String, Button]
+var category_buttons: Dictionary[String, Button] = {}
+var action_configs: Dictionary[String, Control] = {}
 
-var undo_redo := UndoRedoRef.new()
+var undo_redo: UndoRedoRef
+var scroll_to_callback: Callable
+var settings_tab_change_callable: Callable
 
 func get_translated_shortcut_tab(tab_idx: String) -> String:
 	match tab_idx:
@@ -21,14 +24,9 @@ func get_translated_shortcut_tab(tab_idx: String) -> String:
 	return ""
 
 func _ready() -> void:
-	var shortcuts := ShortcutsRegistration.new()
-	shortcuts.add_shortcut("ui_undo", undo_redo.undo)
-	shortcuts.add_shortcut("ui_redo", undo_redo.redo)
-	HandlerGUI.register_shortcuts(self, shortcuts)
-	
-	category_buttons.clear()
 	var button_group := ButtonGroup.new()
-	for category in shortcut_categories:
+	for i in shortcut_categories.size():
+		var category := shortcut_categories[i]
 		var btn := Button.new()
 		btn.toggle_mode = true
 		btn.button_group = button_group
@@ -47,16 +45,28 @@ func _ready() -> void:
 		btn.focus_mode = Control.FOCUS_NONE
 		btn.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
 		categories_container.add_child(btn)
-	categories_container.get_child(0).button_pressed = true
-	categories_container.get_child(0).pressed.emit()
+		if i == 0:
+			btn.button_pressed = true
+			btn.pressed.emit()
 
-func activate_category(category: String) -> void:
-	category_buttons[category].button_pressed = true
+func setup_undo_redo_utensils(new_undo_redo: UndoRedoRef, new_scroll_to_callback: Callable, new_settings_tab_change_callable: Callable) -> void:
+	undo_redo = new_undo_redo
+	scroll_to_callback = new_scroll_to_callback
+	settings_tab_change_callable = new_settings_tab_change_callable
+
+
+func highlight_action(category: String, action: String) -> void:
+	var category_button := category_buttons[category]
+	if not category_button.button_pressed:
+		category_button.button_pressed = true
+		await get_tree().process_frame
+	scroll_to_callback.call(action_configs[action].get_global_rect(), 0.16)
 
 
 func show_shortcuts_from_category(category: String) -> void:
 	for child in shortcuts_container.get_children():
 		child.queue_free()
+	action_configs.clear()
 	
 	for action in ShortcutUtils.get_actions(category):
 		var shortcut_config: Control
@@ -71,11 +81,16 @@ func show_shortcuts_from_category(category: String) -> void:
 		
 		shortcut_config.action = action
 		shortcuts_container.add_child(shortcut_config)
+		action_configs[action] = shortcut_config
 
 func _on_shortcuts_modified(action: String, new_shortcuts: Array[InputEvent], category: String) -> void:
 	undo_redo.create_action()
 	undo_redo.add_do_method(Configs.savedata.action_modify_shortcuts.bind(action, new_shortcuts))
-	undo_redo.add_do_method(activate_category.bind(category))
+	undo_redo.add_do_method(highlight_action.bind(category, action))
+	undo_redo.add_do_method(settings_tab_change_callable)
 	undo_redo.add_undo_method(Configs.savedata.action_modify_shortcuts.bind(action, Configs.savedata.action_get_shortcuts(action)))
-	undo_redo.add_undo_method(activate_category.bind(category))
-	undo_redo.commit_action()
+	undo_redo.add_undo_method(highlight_action.bind(category, action))
+	undo_redo.add_undo_method(settings_tab_change_callable)
+	undo_redo.commit_action(false)
+	# Only this method needs to run, so commit execution was disabled.
+	Configs.savedata.action_modify_shortcuts(action, new_shortcuts)


### PR DESCRIPTION
This PR does a few things. It fixes an issue where elliptical arcs <0 were treated incorrectly. The "Remove Comments" formatting setting is removed as it alters information, which isn't what the formatters should do. Style changes. Zero-length path segments without curve geometry now list elliptical arcs as an exact conversion. Other small tweaks. Improvements to UndoRedo in the shortcut settings.