### PR TITLE
Add On and Off strings

### DIFF
--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -59,7 +59,7 @@ func set_optimizer_info(example_root: ElementRoot, optimizer: Optimizer, main_te
 func permanent_disable_checkbox(checkbox_state: bool) -> void:
 	disabled = true
 	widget.set_pressed_no_signal(checkbox_state)
-	widget.text = "On" if checkbox_state else "Off"
+	widget.text = Translator.translate("On") if checkbox_state else Translator.translate("Off")
 
 func setup_checkbox() -> void:
 	widget = CheckBox.new()
@@ -171,7 +171,7 @@ func post_modification() -> void:
 func update_widgets() -> void:
 	match type:
 		Type.CHECKBOX:
-			widget.text = "On" if getter.call() else "Off"
+			widget.text = Translator.translate("On") if getter.call() else Translator.translate("Off")
 			reset_button.visible = (not disabled and getter.call() != default)
 			if disabled:
 				widget.mouse_default_cursor_shape = Control.CURSOR_ARROW

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -780,6 +780,14 @@ msgid "Apply all of this preset's defaults"
 msgstr ""
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr ""
 

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -781,6 +781,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Приложи всички настройки по подразбиране на този шаблон"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "Изчисти"
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -802,6 +802,14 @@ msgid "Apply all of this preset's defaults"
 msgstr ""
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 #, fuzzy
 msgid "Clear"
 msgstr "SVG zurücksetzen"

--- a/translations/en.po
+++ b/translations/en.po
@@ -781,6 +781,14 @@ msgid "Apply all of this preset's defaults"
 msgstr ""
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr ""
 

--- a/translations/es.po
+++ b/translations/es.po
@@ -784,11 +784,11 @@ msgstr "Aplicar todos los valores predeterminados de este preajuste"
 
 #: src/ui_widgets/setting_frame.gd
 msgid "On"
-msgstr "Sí"
+msgstr "Act."
 
 #: src/ui_widgets/setting_frame.gd
 msgid "Off"
-msgstr "No"
+msgstr "Desact."
 
 #: src/ui_widgets/setting_frame.gd
 msgid "Clear"

--- a/translations/es.po
+++ b/translations/es.po
@@ -783,6 +783,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Aplicar todos los valores predeterminados de este preajuste"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr "Sí"
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr "No"
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "Borrar"
 

--- a/translations/et.po
+++ b/translations/et.po
@@ -783,6 +783,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Rakenda kõik selle eelseadistuse vaikeväärtused"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "Lähtesta"
 

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -802,6 +802,14 @@ msgid "Apply all of this preset's defaults"
 msgstr ""
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 #, fuzzy
 msgid "Clear"
 msgstr "Vider le SVG"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -800,6 +800,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Pas alle standaardwaardes van deze voorinstelling toe"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 #, fuzzy
 msgid "Clear"
 msgstr "SVG ontruimen"

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -795,6 +795,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Aplicar todos os padrões dessa pré-definição"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 #, fuzzy
 msgid "Clear"
 msgstr "Limpar tudo"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -784,6 +784,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Применить все стандартные значения этого пресета"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "Очистить все"
 

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -783,6 +783,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "Застосувати стандартні значення цього пресету"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "Очистити"
 

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -781,6 +781,14 @@ msgid "Apply all of this preset's defaults"
 msgstr "应用此预设的默认值"
 
 #: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr ""
+
+#: src/ui_widgets/setting_frame.gd
 msgid "Clear"
 msgstr "清空"
 


### PR DESCRIPTION
A small tweak to make the checkbox strings translatable.
In Spanish I've adapted them as "Yes" and "No" to use the same space.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/1e845079-0dae-45eb-b9e7-4b0a28bbf8e4" />
