### PR TITLE
Fix palette config labels not updating when language changes

### DIFF
--- a/src/ui_widgets/palette_config.gd
+++ b/src/ui_widgets/palette_config.gd
@@ -42,7 +42,11 @@ func _ready() -> void:
 	name_edit.text_submitted.connect(_on_name_edit_text_submitted)
 	Configs.theme_changed.connect(sync_theming)
 	sync_theming()
+	Configs.language_changed.connect(sync_localization)
 
+func sync_localization() -> void:
+	set_label_text("")
+	display_warnings()
 
 func display_warnings() -> void:
 	var warnings := PackedStringArray()


### PR DESCRIPTION
fix for these labels not updating when language changes

<img width="789" height="118" alt="image" src="https://github.com/user-attachments/assets/6545aa68-f442-4f5a-9c20-7d7db013430f" />