### PR TITLE
Remove extreme dimensions warning

### DIFF
--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -737,25 +737,14 @@ func open_export() -> void:
 	var width := State.root_element.width
 	var height := State.root_element.height
 	
-	var dimensions_valid := (is_finite(width) and is_finite(height) and width > 0.0 and height > 0.0)
-	var dimensions_too_different := false
-	
-	if dimensions_valid:
-		dimensions_too_different = (1 / minf(width, height) > 16384 / maxf(width, height))
-		if not dimensions_too_different:
-			add_menu(ExportMenuScene.instantiate())
-			return
-	
-	var message: String
-	if dimensions_too_different:
-		message = Translator.translate("The graphic can be exported only as SVG because its proportions are too extreme.")
-	else:
-		message = Translator.translate("The graphic can be exported only as SVG because its size is not defined.")
-	message += "\n\n" + Translator.translate("Do you want to proceed?")
+	if is_finite(width) and is_finite(height) and width > 0.0 and height > 0.0:
+		add_menu(ExportMenuScene.instantiate())
+		return
 	
 	var confirm_dialog := ConfirmDialogScene.instantiate()
 	add_menu(confirm_dialog)
-	confirm_dialog.setup(Translator.translate("Export SVG"), message,
+	confirm_dialog.setup(Translator.translate("Export SVG"), "%s\n\n%s" %\
+			[Translator.translate("The graphic can only be exported as SVG because its size is undefined."), Translator.translate("Do you want to proceed?")],
 			Translator.translate("Export"), FileUtils.open_export_dialog.bind(ImageExportDataSVG.new()))
 
 

--- a/src/ui_widgets/export_scale_config.gd
+++ b/src/ui_widgets/export_scale_config.gd
@@ -27,10 +27,12 @@ func setup(new_original_width: float, new_original_height: float, initial_scale:
 		await ready
 	original_width = new_original_width
 	original_height = new_original_height
-	scale_edit.min_value = 1 / minf(original_width, new_original_height)
-	scale_edit.max_value = max_dimension / maxf(new_original_width, new_original_height)
-	width_edit.max_value = max_dimension
-	height_edit.max_value = max_dimension
+	var bigger_dimension := maxf(original_width, original_height)
+	var max_scale := max_dimension / bigger_dimension
+	scale_edit.min_value = 1 / bigger_dimension
+	scale_edit.max_value = max_dimension / bigger_dimension
+	width_edit.max_value = floori(original_width * max_scale)
+	height_edit.max_value = floori(original_height * max_scale)
 	scale_edit.value_changed.connect(_on_scale_edit_value_changed)
 	width_edit.value_changed.connect(_on_width_edit_value_changed)
 	height_edit.value_changed.connect(_on_height_edit_value_changed)

--- a/translations/GodSVG.pot
+++ b/translations/GodSVG.pot
@@ -41,10 +41,6 @@ msgid "OK"
 msgstr ""
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr ""
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 
@@ -491,10 +487,6 @@ msgstr ""
 
 #: src/ui_parts/previews.gd
 msgid "Add preview"
-msgstr ""
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr ""
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd

--- a/translations/bg.po
+++ b/translations/bg.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "Добре"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Графиката може да бъде експортирана само като SVG защото височината и широчината са твърде различни."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Графиката може да бъде експортирана само като SVG защото размерът не е определен."
 
@@ -493,10 +489,6 @@ msgstr "Помощ"
 #: src/ui_parts/previews.gd
 msgid "Add preview"
 msgstr "Добави гледка"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
-msgstr "Добави нова гледка"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
 #: src/ui_widgets/setting_shortcut.gd src/ui_widgets/transform_popup.gd

--- a/translations/de.po
+++ b/translations/de.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "OK"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Die Grafik kann nur als SVG exportiert werden, da ihre Proportionen zu extrem sind."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Die Grafik kann nur als SVG exportiert werden, da ihre Größe nicht definiert ist."
 
@@ -501,11 +497,6 @@ msgstr "Hilfe"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Farbe hinzufügen"
-
-#: src/ui_parts/previews.gd
-#, fuzzy
-msgid "Add new preview"
 msgstr "Farbe hinzufügen"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1746,6 +1737,13 @@ msgstr ""
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr ""
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Die Grafik kann nur als SVG exportiert werden, da ihre Proportionen zu extrem sind."
+
+#, fuzzy
+#~ msgid "Add new preview"
+#~ msgstr "Farbe hinzufügen"
 
 #, fuzzy
 #~ msgid "Add new color"

--- a/translations/en.po
+++ b/translations/en.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr ""
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr ""
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr ""
 
@@ -492,10 +488,6 @@ msgstr ""
 
 #: src/ui_parts/previews.gd
 msgid "Add preview"
-msgstr ""
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr ""
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd

--- a/translations/es.po
+++ b/translations/es.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "Aceptar"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "El gráfico solo se puede exportar como SVG porque sus proporciones son demasiado extremas."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "El gráfico solo se puede exportar como SVG porque su tamaño no está definido."
 
@@ -494,10 +490,6 @@ msgstr "Ayuda"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Añadir nueva vista previa"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr "Añadir nueva vista previa"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1699,6 +1691,12 @@ msgstr "Una aplicación de gráficos vectoriales para edición SVG estructurada"
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "svg;vector;gráficos;dibujo;diseño;ilustración;imagen;arte;diagrama;icono;logo;editor;ruta;forma;2D;código;azul;zorro"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "El gráfico solo se puede exportar como SVG porque sus proporciones son demasiado extremas."
+
+#~ msgid "Add new preview"
+#~ msgstr "Añadir nueva vista previa"
 
 #~ msgid "Add new color"
 #~ msgstr "Añadir nuevo color"

--- a/translations/et.po
+++ b/translations/et.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "Okei"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Graafika saab eksportida ainult SVG-na, sest selle proportsioonid on liiga ekstreemsed."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Graafika saab eksportida ainult SVG-na, sest selle suurus pole defineeritud."
 
@@ -494,10 +490,6 @@ msgstr "Abi"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Lisa uus eelvaade"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr "Lisa uus eelvaade"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1700,6 +1692,12 @@ msgstr "Vektorkraafika rakendus SVG struktureeritud redigeerimiseks"
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "svg;vektor;graafika;joonista;disain;illustratsioon;pilt;kunst;skeem;diagramm;logo;ikoon;redigeerija;kuju;2D;kood;sinine;rebane"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Graafika saab eksportida ainult SVG-na, sest selle proportsioonid on liiga ekstreemsed."
+
+#~ msgid "Add new preview"
+#~ msgstr "Lisa uus eelvaade"
 
 #~ msgid "Add new color"
 #~ msgstr "Lisa värv"

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "OK"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Le graphique ne peut être exporté qu'en SVG car ses proportions sont trop extrêmes."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Le graphique ne peut être exporté qu'en SVG car sa taille n'a pas été pas définie."
 
@@ -501,11 +497,6 @@ msgstr "Aide"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Couleur de texte"
-
-#: src/ui_parts/previews.gd
-#, fuzzy
-msgid "Add new preview"
 msgstr "Couleur de texte"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1747,6 +1738,13 @@ msgstr ""
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr ""
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Le graphique ne peut être exporté qu'en SVG car ses proportions sont trop extrêmes."
+
+#, fuzzy
+#~ msgid "Add new preview"
+#~ msgstr "Couleur de texte"
 
 #, fuzzy
 #~ msgid "Add new color"

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "OK"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "De afbeelding kan alleen maar als SVG geëxporteerd worden door zijn extreme verhoudingen."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "De afbeelding kan alleen maar als SVG geëxporteerd worden want zijn maat is niet gedefiniëerd."
 
@@ -500,11 +496,6 @@ msgstr "Help"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Voeg nieuwe kleur toe"
-
-#: src/ui_parts/previews.gd
-#, fuzzy
-msgid "Add new preview"
 msgstr "Voeg nieuwe kleur toe"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1732,6 +1723,13 @@ msgstr ""
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr ""
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "De afbeelding kan alleen maar als SVG geëxporteerd worden door zijn extreme verhoudingen."
+
+#, fuzzy
+#~ msgid "Add new preview"
+#~ msgstr "Voeg nieuwe kleur toe"
 
 #~ msgid "Add new color"
 #~ msgstr "Voeg nieuwe kleur toe"

--- a/translations/pt_BR.po
+++ b/translations/pt_BR.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "OK"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Esse gráfico pode ser exportado apenas como um SVG pois as suas proporções são extremas."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Esse gráfico pode ser exportado apenas como SVG pois o seu tamanho não foi definido."
 
@@ -499,10 +495,6 @@ msgstr "Ajuda"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Adicionar nova prévia"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr "Adicionar nova prévia"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1719,6 +1711,12 @@ msgstr "Um aplicativo de gráficos vetoriais para edição estruturada de SVG"
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "svg;vetor;gráficos;desenho;design;ilustração;imagem;arte;diagrama;ícone;logo;editor;arte;caminho;forma;2D;código;azul;raposa"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Esse gráfico pode ser exportado apenas como um SVG pois as suas proporções são extremas."
+
+#~ msgid "Add new preview"
+#~ msgstr "Adicionar nova prévia"
 
 #~ msgid "Add new color"
 #~ msgstr "Adicionar nova cor"

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -43,10 +43,6 @@ msgid "OK"
 msgstr "Хорошо"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Изображение можно экспортировать только как SVG, поскольку его пропорции слишком экстремальные."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Изображение можно экспортировать только как SVG, поскольку его размеры не заданы."
 
@@ -495,10 +491,6 @@ msgstr "Помощь"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Добавить новый предпросмотр"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr "Добавить новый предпросмотр"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1701,6 +1693,12 @@ msgstr "Графическое приложение для структурир�
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "свг;вектор;графика;рисование;дизайн;иллюстрация;изображение;искусство;диаграмма;иконка;лого;редактор;путь;форма;2д;код;синий;лис"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Изображение можно экспортировать только как SVG, поскольку его пропорции слишком экстремальные."
+
+#~ msgid "Add new preview"
+#~ msgstr "Добавить новый предпросмотр"
 
 #~ msgid "Add new color"
 #~ msgstr "Добавить новый цвет"

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "Добре"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "Це зображення може бути експортоване тільки як SVG, оскільки його пропорції занадто екстремальні."
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "Це зображення може бути експортоване тільки як SVG, оскільки його розмір не завданий."
 
@@ -494,10 +490,6 @@ msgstr "Допомога"
 #: src/ui_parts/previews.gd
 #, fuzzy
 msgid "Add preview"
-msgstr "Додати новий попередній перегляд"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
 msgstr "Додати новий попередній перегляд"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
@@ -1705,6 +1697,12 @@ msgstr "Графічний додаток для структурованого 
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "свг;вектор;графіка;малювання;дизайн;ілюстрація;зображення;мистецтво;діаграма;іконка;лого;редактор;шлях;форма;2д;код;синій;лис"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "Це зображення може бути експортоване тільки як SVG, оскільки його пропорції занадто екстремальні."
+
+#~ msgid "Add new preview"
+#~ msgstr "Додати новий попередній перегляд"
 
 #, fuzzy
 #~ msgid "Add new color"

--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -42,10 +42,6 @@ msgid "OK"
 msgstr "确定"
 
 #: src/autoload/HandlerGUI.gd
-msgid "The graphic can be exported only as SVG because its proportions are too extreme."
-msgstr "此图像只能以 SVG 格式导出，因为其大小过于极端。"
-
-#: src/autoload/HandlerGUI.gd
 msgid "The graphic can be exported only as SVG because its size is not defined."
 msgstr "此图像只能以 SVG 格式导出，因为其大小未定义。"
 
@@ -493,10 +489,6 @@ msgstr "帮助"
 #: src/ui_parts/previews.gd
 msgid "Add preview"
 msgstr "添加预览"
-
-#: src/ui_parts/previews.gd
-msgid "Add new preview"
-msgstr "添加新预览"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
 #: src/ui_widgets/setting_shortcut.gd src/ui_widgets/transform_popup.gd
@@ -1695,6 +1687,12 @@ msgstr "结构化SVG编辑应用"
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
 msgstr "svg;矢量;图形;绘制;设计;插画;图像;艺术;图表;图标;标志;编辑器;路径;形狀;二维;代码;蓝色;狐狸"
+
+#~ msgid "The graphic can be exported only as SVG because its proportions are too extreme."
+#~ msgstr "此图像只能以 SVG 格式导出，因为其大小过于极端。"
+
+#~ msgid "Add new preview"
+#~ msgstr "添加新预览"
 
 #~ msgid "Add new color"
 #~ msgstr "添加新颜色"


### PR DESCRIPTION
Looks like it was unnecessary all along, it's better to instead assume that the conversion will ensure the tiny dimension is at least one pixel wide.