### PR TITLE
Fix polyline simplification loop range and step

### DIFF
--- a/src/data_classes/ElementPolyline.gd
+++ b/src/data_classes/ElementPolyline.gd
@@ -81,7 +81,7 @@ func simplify() -> void:
 	
 	new_list_points.append(list[0])
 	new_list_points.append(list[1])
-	for i in range(1, list_size - 2):
+	for i in range(2, list_size - 2, 2):
 		var prev_point := Vector2(list[i - 2], list[i - 1])
 		if not is_equal_approx(prev_point.angle_to_point(Vector2(list[i], list[i + 1])),
 		prev_point.angle_to_point(Vector2(list[i + 2], list[i + 3]))):


### PR DESCRIPTION
In ElementPolyline.gd simplify(), range(1, list_size - 2) was using step 1 starting at index 1 instead of step 2 starting at index 2. This caused float coordinate swapping across (x, y) pairs and out-of-bounds array access on list[i + 3] during the final iteration.