### PR TITLE
Add undo/redo support to settings menu

### DIFF
--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -73,11 +73,13 @@ func get_content(index: TabIndex) -> Control:
 	match index:
 		TabIndex.FORMATTING:
 			current_content = SettingsContentGeneric.instantiate()
+			current_content.undo_redo = undo_redo
 			current_content.setup([Configs.savedata.editor_formatter,
 					Configs.savedata.export_formatter] as Array[ConfigResource], current_content.setup_formatting_content)
 			current_content.preview_changed.connect(set_preview)
 		TabIndex.OPTIMIZER:
 			current_content = SettingsContentGeneric.instantiate()
+			current_content.undo_redo = undo_redo
 			current_content.setup([Configs.savedata.default_optimizer] as Array[ConfigResource], current_content.setup_optimizer_content)
 		TabIndex.PALETTES:
 			current_content = SettingsContentPalettes.instantiate()
@@ -87,6 +89,7 @@ func get_content(index: TabIndex) -> Control:
 					settings_tab_container.select_tab.bind(TabIndex.SHORTCUTS))
 		TabIndex.THEMING, TabIndex.TAB_BAR, TabIndex.OTHER:
 			current_content = SettingsContentGeneric.instantiate()
+			current_content.undo_redo = undo_redo
 			var callback := Callable()
 			match index:
 				TabIndex.THEMING: callback = current_content.setup_theming_content

--- a/src/ui_widgets/UndoRedoRef.gd
+++ b/src/ui_widgets/UndoRedoRef.gd
@@ -11,8 +11,8 @@ var _undo_redo := UndoRedo.new()
 func _init() -> void:
 	_undo_redo.version_changed.connect(version_changed.emit)
 
-func create_action(name := "") -> void:
-	_undo_redo.create_action(name)
+func create_action(name := "", merge_mode := UndoRedo.MERGE_DISABLE, backward_undo_ops := false) -> void:
+	_undo_redo.create_action(name, merge_mode, backward_undo_ops)
 
 func add_do_method(callable: Callable) -> void:
 	_undo_redo.add_do_method(callable)
@@ -46,6 +46,9 @@ func has_undo() -> bool:
 
 func has_redo() -> bool:
 	return _undo_redo.has_redo()
+
+func is_committing_action() -> bool:
+	return _undo_redo.is_committing_action()
 
 func clear_history() -> void:
 	_undo_redo.clear_history()

--- a/src/ui_widgets/settings_content_generic.gd
+++ b/src/ui_widgets/settings_content_generic.gd
@@ -10,6 +10,8 @@ const ProfileFrameScene = preload("res://src/ui_widgets/profile_frame.tscn")
 var current_setup_resources: Array[ConfigResource]
 var setup_method: Callable
 
+var undo_redo: UndoRedoRef
+
 var current_setup_setting := ""
 var current_setup_resource_index := 0
 var current_setup_container: VBoxContainer
@@ -75,6 +77,8 @@ class SettingCanvasPreview:
 
 func _ready() -> void:
 	Configs.language_changed.connect(setup_content)
+	undo_redo.version_changed.connect(_on_undo_redo_version_changed)
+	tree_exiting.connect(undo_redo.version_changed.disconnect.bind(_on_undo_redo_version_changed), CONNECT_ONE_SHOT)
 	if current_setup_resources.size() > 1:
 		var categories := HFlowContainer.new()
 		categories.alignment = FlowContainer.ALIGNMENT_CENTER
@@ -119,6 +123,10 @@ func setup_content() -> void:
 	current_setup_container = setting_container
 	setup_method.call()
 	HandlerGUI.throw_mouse_motion_event()
+
+func _on_undo_redo_version_changed() -> void:
+	if not undo_redo.is_committing_action():
+		setup_content()
 
 func setup_formatting_content() -> void:
 	var current_setup_resource: Formatter = _get_current_setup_resource()
@@ -829,7 +837,12 @@ func _add_file_path_edit(text: String, extensions_list: PackedStringArray) -> Co
 func setup_frame(frame: Control, has_default := true) -> void:
 	var bind := current_setup_setting
 	var resource_ref := _get_current_setup_resource()
-	frame.setter = func(p: Variant) -> void: resource_ref.set(bind, p)
+	frame.setter = func(p: Variant) -> void:
+		if resource_ref.get(bind) != p:
+			undo_redo.create_action(bind, UndoRedo.MERGE_ENDS, false)
+			undo_redo.add_do_method(resource_ref.set.bind(bind, p))
+			undo_redo.add_undo_method(resource_ref.set.bind(bind, resource_ref.get(bind)))
+			undo_redo.commit_action()
 	frame.getter = resource_ref.get.bind(bind)
 	if has_default:
 		frame.default = resource_ref.get_setting_default(current_setup_setting)


### PR DESCRIPTION
Closes #1615.

Undo and redo (Ctrl+Z / Ctrl+Y) previously only worked in the shortcuts section of the settings menu. This change routes all setting changes through the menu's `undo_redo` so they can be undone/redone.

Changes:
- `UndoRedoRef` now passes `merge_mode`/`backward_undo_ops` through to `create_action()`, and exposes `is_committing_action()`.
- `settings_menu.gd` passes its `undo_redo` to every `SettingsContentGeneric` instance.
- `settings_content_generic.gd` wraps the setting setter in an undo/redo action:
  - `MERGE_ENDS` is used so continuous edits (e.g. dragging a color) merge into a single undo step.
  - Actions are only created when the value actually changes, since widget initialization during content rebuilds otherwise creates no-op actions that pollute the history.
  - The content rebuilds after undo/redo (but not during commits, checked via `is_committing_action()`) so widgets reflect reverted values.
  - The `version_changed` connection is cleaned up on `tree_exiting`.

Verified with Godot 4.6 stable (headless): checkbox/dropdown/numeric settings all set -> undo -> redo correctly, merged color edits undo in one step, and no stale UI state after reverting.