### PR TITLE
This PR is a bunch of things

### DIFF
--- a/src/autoload/HandlerGUI.gd
+++ b/src/autoload/HandlerGUI.gd
@@ -160,6 +160,9 @@ func add_suppressed_focus(control: Control) -> void:
 	)
 
 func _on_menus_or_popups_cleared() -> void:
+	# This method is connected to by tree_exited signals, it can run as the window is being closed
+	if not is_inside_tree():
+		return
 	for control in suppressed_focused_controls:
 		if is_node_on_top_menu_or_popup(control):
 			suppressed_focused_controls.erase(control)

--- a/src/data_classes/AttributeTransformList.gd
+++ b/src/data_classes/AttributeTransformList.gd
@@ -24,7 +24,7 @@ func set_transform_property(index: int, property: String, new_value: float) -> v
 		_transform_list[index].set(property, new_value)
 		sync_after_transforms_change()
 
-func get_transform_list() -> Array[Transform]:
+func get_transforms() -> Array[Transform]:
 	return _transform_list.duplicate()
 
 func get_transform_count() -> int:

--- a/src/data_classes/Transform.gd
+++ b/src/data_classes/Transform.gd
@@ -1,6 +1,12 @@
 @abstract class_name Transform
 
+@abstract func compute_transform() -> Transform2D
+@abstract func compute_precise_transform() -> PackedFloat64Array
+@abstract func is_redundant() -> bool
+
 class TransformMatrix extends Transform:
+	const name = "matrix"
+	
 	var x1: float
 	var x2: float
 	var y1: float
@@ -24,8 +30,31 @@ class TransformMatrix extends Transform:
 	
 	func is_redundant() -> bool:
 		return x1 == 1.0 and x2 == 0.0 and y1 == 0.0 and y2 == 1.0 and o1 == 0.0 and o2 == 0.0
+	
+	func get_equivalent_basic_transform() -> Transform:
+		if x1 == 1.0 and x2 == 0.0 and y1 == 0.0 and y2 == 1.0:
+			if o1 == 0.0 and o2 == 0.0:
+				return null  # The matrix is redundant.
+			return TransformTranslate.new(o1, o2)
+		
+		if o1 == 0.0 and o2 == 0.0:
+			if x2 == 0.0 and y1 == 0.0:
+				return TransformScale.new(x1, y2)
+			if x1 == 1.0 and y2 == 1.0:
+				if x2 == 0.0:
+					return TransformSkewX.new(rad_to_deg(atan(y1)))
+				if y1 == 0.0:
+					return TransformSkewY.new(rad_to_deg(atan(x2)))
+		
+		# For rotation, we need determinant and scale in both directions to be 1.
+		if is_equal_approx(x1 * y2 - x2 * y1, 1.0) and is_equal_approx(sqrt(x1 * x1 + x2 * x2), 1.0) and is_equal_approx(sqrt(y1 * y1 + y2 * y2), 1.0):
+			return TransformRotate.new(rad_to_deg(atan2(x2, x1)), o1, o2)
+		
+		return null
 
 class TransformTranslate extends Transform:
+	const name = "translate"
+	
 	var x: float
 	var y: float
 	
@@ -43,6 +72,8 @@ class TransformTranslate extends Transform:
 		return x == 0.0 and y == 0.0
 
 class TransformRotate extends Transform:
+	const name = "rotate"
+	
 	var deg: float
 	var x: float
 	var y: float
@@ -60,14 +91,14 @@ class TransformRotate extends Transform:
 		var rad := deg_to_rad(deg)
 		var cos_val := cos(rad)
 		var sin_val := sin(rad)
-		var ox := x - x * cos_val + y * sin_val
-		var oy := y - x * sin_val - y * cos_val
-		return PackedFloat64Array([cos_val, sin_val, -sin_val, cos_val, ox, oy])
+		return PackedFloat64Array([cos_val, sin_val, -sin_val, cos_val, x - x * cos_val + y * sin_val, y - x * sin_val - y * cos_val])
 	
 	func is_redundant() -> bool:
 		return fmod(deg, 360.0) == 0.0
 
 class TransformScale extends Transform:
+	const name = "scale"
+	
 	var x: float
 	var y: float
 	
@@ -85,6 +116,8 @@ class TransformScale extends Transform:
 		return x == 1.0 and y == 1.0
 
 class TransformSkewX extends Transform:
+	const name = "skewX"
+	
 	var x: float
 	
 	func _init(new_x: float) -> void:
@@ -101,6 +134,8 @@ class TransformSkewX extends Transform:
 
 
 class TransformSkewY extends Transform:
+	const name = "skewY"
+	
 	var y: float
 	
 	func _init(new_y: float) -> void:

--- a/src/ui_parts/global_actions.gd
+++ b/src/ui_parts/global_actions.gd
@@ -64,8 +64,7 @@ func _on_more_options_pressed() -> void:
 	
 	separator_indices.append(btn_arr.size())
 	
-	var about_btn := ContextButton.create_from_action("about_info").add_custom_icon(preload("res://assets/logos/icon.svg")).set_icon_unmodulated()
-	btn_arr.append(about_btn)
+	btn_arr.append(ContextButton.create_from_action("about_info").add_custom_icon(preload("res://assets/logos/icon.svg")).set_icon_unmodulated())
 	btn_arr.append(ContextButton.create_from_action("about_donate"))
 	
 	separator_indices.append(btn_arr.size())

--- a/src/ui_parts/settings_menu.gd
+++ b/src/ui_parts/settings_menu.gd
@@ -73,13 +73,13 @@ func get_content(index: TabIndex) -> Control:
 	match index:
 		TabIndex.FORMATTING:
 			current_content = SettingsContentGeneric.instantiate()
-			current_content.undo_redo = undo_redo
+			current_content.setup_undo_redo_utensils(undo_redo, settings_tab_container.select_tab.bind(index))
 			current_content.setup([Configs.savedata.editor_formatter,
 					Configs.savedata.export_formatter] as Array[ConfigResource], current_content.setup_formatting_content)
 			current_content.preview_changed.connect(set_preview)
 		TabIndex.OPTIMIZER:
 			current_content = SettingsContentGeneric.instantiate()
-			current_content.undo_redo = undo_redo
+			current_content.setup_undo_redo_utensils(undo_redo, settings_tab_container.select_tab.bind(index))
 			current_content.setup([Configs.savedata.default_optimizer] as Array[ConfigResource], current_content.setup_optimizer_content)
 		TabIndex.PALETTES:
 			current_content = SettingsContentPalettes.instantiate()
@@ -89,7 +89,7 @@ func get_content(index: TabIndex) -> Control:
 					settings_tab_container.select_tab.bind(TabIndex.SHORTCUTS))
 		TabIndex.THEMING, TabIndex.TAB_BAR, TabIndex.OTHER:
 			current_content = SettingsContentGeneric.instantiate()
-			current_content.undo_redo = undo_redo
+			current_content.setup_undo_redo_utensils(undo_redo, settings_tab_container.select_tab.bind(index))
 			var callback := Callable()
 			match index:
 				TabIndex.THEMING: callback = current_content.setup_theming_content

--- a/src/ui_widgets/ContextButton.gd
+++ b/src/ui_widgets/ContextButton.gd
@@ -16,6 +16,7 @@ var custom_callback := Callable()
 var custom_icon: Texture2D
 var custom_text := ""
 var custom_dim_text := ""
+var custom_text_line: TextLine
 var toggled_on := true
 var submenu_button_builders: Array[Callable] = []
 var disabled := false
@@ -37,7 +38,9 @@ func _ready() -> void:
 	
 	# The size increase from icon spacing is based on the widest icon, so it's determined in the ContextPopup.
 	var min_width := PADDING * 2
-	if not text.is_empty():
+	if is_instance_valid(custom_text_line):
+		min_width += custom_text_line.get_line_width()
+	elif not text.is_empty():
 		min_width += font.get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
 	if not dim_text.is_empty():
 		min_width += DIM_TEXT_SPACING + font.get_string_size(dim_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x
@@ -160,6 +163,10 @@ func add_custom_icon(new_icon: Texture2D) -> ContextButton:
 
 func add_custom_dim_text(new_dim_text: String) -> ContextButton:
 	custom_dim_text = new_dim_text
+	return self
+
+func add_custom_text_line(new_text_line: TextLine) -> ContextButton:
+	custom_text_line = new_text_line
 	return self
 
 

--- a/src/ui_widgets/ContextPopup.gd
+++ b/src/ui_widgets/ContextPopup.gd
@@ -188,12 +188,25 @@ func _draw() -> void:
 				icon_color = button.get_theme_color("icon_focus_color")
 			
 			var icon_size := button_icon.get_size() * 16.0 / maxi(button_icon.get_width(), button_icon.get_height())
-			if button_text.is_empty() and not align_left:
+			if button_text.is_empty() and not is_instance_valid(button.custom_text_line) and not align_left:
 				button_icon.draw_rect(vbox_ci, Rect2(button_rect.get_center() - icon_size / 2, icon_size), false, icon_color)
 			else:
 				button_icon.draw_rect(vbox_ci, Rect2(button_rect.position + Vector2(1, 1) * ContextButton.PADDING, icon_size), false, icon_color)
 		
-		if not button_text.is_empty():
+		if is_instance_valid(button.custom_text_line):
+			var font_color := button.get_theme_color("font_color")
+			if button.disabled:
+				font_color = button.get_theme_color("font_disabled_color")
+			elif button_idx == focus_index:
+				font_color = button.get_theme_color("font_focus_color")
+			
+			var text_width := button.custom_text_line.get_line_width()
+			var text_pos := button_rect.position + Vector2(text_offset, (button_rect.size.y - button.custom_text_line.get_size().y) / 2.0)
+			if not align_left:
+				text_pos.x = button_rect.position.x + (button_rect.size.x - text_width) / 2.0
+			
+			button.custom_text_line.draw(vbox_ci, text_pos, font_color)
+		elif not button_text.is_empty():
 			var font := button.get_theme_font("font")
 			var font_size := button.get_theme_font_size("font_size")
 			var font_color := button.get_theme_color("font_color")

--- a/src/ui_widgets/UndoRedoRef.gd
+++ b/src/ui_widgets/UndoRedoRef.gd
@@ -11,8 +11,8 @@ var _undo_redo := UndoRedo.new()
 func _init() -> void:
 	_undo_redo.version_changed.connect(version_changed.emit)
 
-func create_action(name := "", merge_mode := UndoRedo.MERGE_DISABLE, backward_undo_ops := false) -> void:
-	_undo_redo.create_action(name, merge_mode, backward_undo_ops)
+func create_action(name := "") -> void:
+	_undo_redo.create_action(name)
 
 func add_do_method(callable: Callable) -> void:
 	_undo_redo.add_do_method(callable)

--- a/src/ui_widgets/setting_frame.gd
+++ b/src/ui_widgets/setting_frame.gd
@@ -186,8 +186,8 @@ func _checkbox_modification() -> void:
 	setter.call(not getter.call())
 	post_modification()
 
-func _color_modification(value: String, _is_final: bool, _old_final_value: String, alpha_enabled: bool) -> void:
-	setter.call(ColorParser.text_to_color(value, Color.BLACK, alpha_enabled))
+func _color_modification(value: String, is_final: bool, old_final_value: String, alpha_enabled: bool) -> void:
+	setter.call(ColorParser.text_to_color(value, Color.BLACK, alpha_enabled), is_final, ColorParser.text_to_color(old_final_value, Color.BLACK, alpha_enabled))
 	post_modification()
 
 func _generic_modification(value: Variant) -> void:
@@ -195,10 +195,7 @@ func _generic_modification(value: Variant) -> void:
 	post_modification()
 
 func _float_modification_with_nan_reset(value: float) -> void:
-	if is_nan(value):
-		setter.call(default)
-	else:
-		setter.call(value)
+	setter.call(default if is_nan(value) else value)
 	post_modification()
 
 

--- a/src/ui_widgets/setting_shortcut.gd
+++ b/src/ui_widgets/setting_shortcut.gd
@@ -208,7 +208,7 @@ func enter_listening_mode(index: int) -> void:
 		delete_btn.size = Vector2(btn.size.y - 2, btn.size.y - 2)
 		delete_btn.pressed.connect(delete_shortcut.bind(index))
 		# Fake delete icon to offset the main button's text.
-		btn.icon = ImageTexture.create_from_image(Image.create(delete_icon.get_width(), delete_icon.get_height(), false, Image.FORMAT_LA8))
+		btn.icon = ImageTexture.create_from_image(Image.create_empty(delete_icon.get_width(), delete_icon.get_height(), false, Image.FORMAT_LA8))
 	queue_redraw()
 
 func cancel_listening() -> void:

--- a/src/ui_widgets/settings_content_generic.gd
+++ b/src/ui_widgets/settings_content_generic.gd
@@ -11,6 +11,7 @@ var current_setup_resources: Array[ConfigResource]
 var setup_method: Callable
 
 var undo_redo: UndoRedoRef
+var settings_tab_change_callable: Callable
 
 var current_setup_setting := ""
 var current_setup_resource_index := 0
@@ -105,6 +106,11 @@ func _ready() -> void:
 	add_child(setting_container)
 	setup_content()
 
+func setup_undo_redo_utensils(new_undo_redo: UndoRedoRef, new_settings_tab_change_callable: Callable) -> void:
+	undo_redo = new_undo_redo
+	settings_tab_change_callable = new_settings_tab_change_callable
+
+
 func _get_current_setup_resource() -> ConfigResource:
 	return current_setup_resources[current_setup_resource_index]
 
@@ -125,6 +131,7 @@ func setup_content() -> void:
 	HandlerGUI.throw_mouse_motion_event()
 
 func _on_undo_redo_version_changed() -> void:
+	# Only rebuild if using undo/redo.
 	if not undo_redo.is_committing_action():
 		setup_content()
 
@@ -788,8 +795,7 @@ func add_checkbox(text: String, use_dim_text := false) -> Control:
 	frame.setup_checkbox()
 	current_setup_container.add_child(frame)
 	# Some checkboxes need to update the dimness of the text of other settings.
-	# There's no continuous editing with checkboxes, so it's safe to just rebuild
-	# the content for them.
+	# There's no continuous editing with checkboxes, so it's safe to just rebuild the content for them.
 	frame.value_changed.connect(setup_content)
 	return frame
 
@@ -837,12 +843,20 @@ func _add_file_path_edit(text: String, extensions_list: PackedStringArray) -> Co
 func setup_frame(frame: Control, has_default := true) -> void:
 	var bind := current_setup_setting
 	var resource_ref := _get_current_setup_resource()
-	frame.setter = func(p: Variant) -> void:
-		if resource_ref.get(bind) != p:
-			undo_redo.create_action(bind, UndoRedo.MERGE_ENDS, false)
-			undo_redo.add_do_method(resource_ref.set.bind(bind, p))
-			undo_redo.add_undo_method(resource_ref.set.bind(bind, resource_ref.get(bind)))
-			undo_redo.commit_action()
+	frame.setter =\
+		func(p: Variant, is_final := true, old_final_value: Variant = null) -> void:
+			if typeof(old_final_value) == TYPE_NIL:
+				old_final_value = resource_ref.get(bind)
+			if old_final_value != p:
+				if is_final:
+					undo_redo.create_action(bind)
+					undo_redo.add_do_method(resource_ref.set.bind(bind, p))
+					undo_redo.add_do_method(settings_tab_change_callable)
+					undo_redo.add_undo_method(resource_ref.set.bind(bind, old_final_value))
+					undo_redo.add_undo_method(settings_tab_change_callable)
+					undo_redo.commit_action()
+				else:
+					resource_ref.set(bind, p)
 	frame.getter = resource_ref.get.bind(bind)
 	if has_default:
 		frame.default = resource_ref.get_setting_default(current_setup_setting)

--- a/src/ui_widgets/settings_content_shortcuts.gd
+++ b/src/ui_widgets/settings_content_shortcuts.gd
@@ -89,11 +89,11 @@ func show_shortcuts_from_category(category: String) -> void:
 func _on_shortcuts_edited(action: String, new_shortcuts: Array[InputEvent], category: String) -> void:
 	undo_redo.create_action()
 	undo_redo.add_do_method(Configs.savedata.action_modify_shortcuts.bind(action, new_shortcuts))
-	undo_redo.add_do_method(highlight_action.bind(category, action))
 	undo_redo.add_do_method(settings_tab_change_callable)
+	undo_redo.add_do_method(highlight_action.bind(category, action))
 	undo_redo.add_undo_method(Configs.savedata.action_modify_shortcuts.bind(action, Configs.savedata.action_get_shortcuts(action)))
-	undo_redo.add_undo_method(highlight_action.bind(category, action))
 	undo_redo.add_undo_method(settings_tab_change_callable)
+	undo_redo.add_undo_method(highlight_action.bind(category, action))
 	undo_redo.commit_action(false)
 	# Only this method needs to run, so commit execution was disabled.
 	Configs.savedata.action_modify_shortcuts(action, new_shortcuts)

--- a/src/ui_widgets/transform_editor.gd
+++ b/src/ui_widgets/transform_editor.gd
@@ -1,9 +1,7 @@
 extends PanelContainer
 
-# Very reliant on the transform popup.
-# But that's fine, this isn't intended to be used elsewhere.
+# Very reliant on the transform popup. But that's fine, this isn't intended to be used elsewhere.
 
-var type: String
 var transform: Transform
 
 @onready var transform_list: VBoxContainer = $TransformList
@@ -13,22 +11,9 @@ var _fields: Array[BetterLineEdit]
 
 func setup(new_transform: Transform, new_fields: Array[BetterLineEdit]) -> void:
 	transform = new_transform
-	if transform is Transform.TransformMatrix:
-		type = "matrix"
-	elif transform is Transform.TransformTranslate:
-		type = "translate"
-	elif transform is Transform.TransformRotate:
-		type = "rotate"
-	elif transform is Transform.TransformScale:
-		type = "scale"
-	elif transform is Transform.TransformSkewX:
-		type = "skewX"
-	elif transform is Transform.TransformSkewY:
-		type = "skewY"
-	transform_button.text = type
-	
+	transform_button.text = transform.name
 	_fields = new_fields
-	match type:
+	match transform.name:
 		"matrix":
 			var transform_fields := HBoxContainer.new()
 			transform_fields.alignment = BoxContainer.ALIGNMENT_CENTER
@@ -86,7 +71,7 @@ func resync(new_transform: Transform) -> void:
 
 func setup_field_defaults_and_colors() -> void:
 	update_title_font_color()
-	match type:
+	match transform.name:
 		"translate":
 			_fields[1].default = 0
 			determine_field_font_color(_fields[1], transform.y == 0)

--- a/src/ui_widgets/transform_field.gd
+++ b/src/ui_widgets/transform_field.gd
@@ -43,7 +43,7 @@ func sync() -> void:
 
 func _on_pressed() -> void:
 	var transform_popup := TransformPopupScene.instantiate()
-	transform_popup.attribute_ref = element.get_attribute(attribute_name)
+	transform_popup.attribute = element.get_attribute(attribute_name)
 	HandlerGUI.popup_under_rect(transform_popup, get_global_rect(), get_viewport())
 
 

--- a/src/ui_widgets/transform_popup.gd
+++ b/src/ui_widgets/transform_popup.gd
@@ -15,7 +15,7 @@ const _icons_dict: Dictionary[String, Texture2D] = {
 	"skewY": preload("res://assets/icons/SkewY.svg"),
 }
 
-var attribute_ref: AttributeTransformList
+var attribute: AttributeTransformList
 var undo_redo := UndoRedoRef.new()
 
 @onready var x1_edit: NumberEdit = %FinalMatrix/X1
@@ -24,7 +24,7 @@ var undo_redo := UndoRedoRef.new()
 @onready var y2_edit: NumberEdit = %FinalMatrix/Y2
 @onready var o1_edit: NumberEdit = %FinalMatrix/O1
 @onready var o2_edit: NumberEdit = %FinalMatrix/O2
-@onready var transform_list: VBoxContainer = %TransformList
+@onready var transforms_container: VBoxContainer = %TransformList
 @onready var add_button: Button = %AddButton
 @onready var apply_matrix: Button = %ApplyMatrix
 
@@ -35,10 +35,10 @@ func _ready() -> void:
 	HandlerGUI.register_shortcuts(self, shortcuts)
 	
 	Configs.language_changed.connect(sync_localization)
+	sync_localization()
 	add_button.pressed.connect(popup_new_transform_context.bind(0, add_button))
 	apply_matrix.pressed.connect(_on_apply_matrix_pressed)
-	rebuild()
-	sync_localization()
+	sync()
 
 func _exit_tree() -> void:
 	State.save_svg()
@@ -46,32 +46,27 @@ func _exit_tree() -> void:
 func sync_localization() -> void:
 	apply_matrix.tooltip_text = Translator.translate("Apply the matrix")
 
-func rebuild() -> void:
-	var transform_count := attribute_ref.get_transform_count()
+func sync() -> void:
+	var transform_count := attribute.get_transform_count()
 	# Sync until the first different transform type is found; then rebuild the rest.
 	var i := 0
-	for transform_editor in transform_list.get_children():
+	for transform_editor in transforms_container.get_children():
 		if i >= transform_count:
 			break
-		var t := attribute_ref.get_transform(i)
-		if t is Transform.TransformMatrix and transform_editor.type == "matrix" or\
-		t is Transform.TransformTranslate and transform_editor.type == "translate" or\
-		t is Transform.TransformRotate and transform_editor.type == "rotate" or\
-		t is Transform.TransformScale and transform_editor.type == "scale" or\
-		t is Transform.TransformSkewX and transform_editor.type == "skewX" or\
-		t is Transform.TransformSkewY and transform_editor.type == "skewY":
+		var t := attribute.get_transform(i)
+		if t.name == transform_editor.transform.name:
 			transform_editor.resync(t)
 		else:
 			break
 		i += 1
 	
-	for child in transform_list.get_children():
+	for child in transforms_container.get_children():
 		if child.get_index() >= i:
 			child.queue_free()
 	while i < transform_count:
-		var t := attribute_ref.get_transform(i)
+		var t := attribute.get_transform(i)
 		var t_editor := TransformEditorScene.instantiate()
-		transform_list.add_child(t_editor)
+		transforms_container.add_child(t_editor)
 		var fields: Array[BetterLineEdit]
 		# Setup fields.
 		if t is Transform.TransformMatrix:
@@ -90,12 +85,11 @@ func rebuild() -> void:
 		elif t is Transform.TransformSkewY:
 			fields = [create_mini_number_field(i, "y")]
 		t_editor.setup(t, fields)
-		t_editor.transform_button.icon = _icons_dict[t_editor.type]
-		t_editor.transform_button.pressed.connect(
-				popup_transform_actions.bind(i, t_editor.transform_button))
+		t_editor.transform_button.icon = _icons_dict[t_editor.transform.name]
+		t_editor.transform_button.pressed.connect(popup_transform_actions.bind(i, t_editor.transform_button))
 		i += 1
 	# Show the add button if there are no transforms.
-	transform_list.visible = (transform_count != 0)
+	transforms_container.visible = (transform_count != 0)
 	add_button.visible = (transform_count == 0)
 	update_final_transform()
 
@@ -108,44 +102,41 @@ func create_mini_number_field(index: int, property: String) -> BetterLineEdit:
 	return field
 
 
+func edit(callback: Callable) -> void:
+	undo_redo.create_action()
+	undo_redo.add_do_method(callback)
+	undo_redo.add_do_method(sync)
+	undo_redo.add_undo_method(attribute.set_transform_list.bind(attribute.get_transforms()))
+	undo_redo.add_undo_method(sync)
+	undo_redo.commit_action()
+
 func update_value(new_value: float, index: int, property: String) -> void:
 	undo_redo.create_action()
-	undo_redo.add_do_method(attribute_ref.set_transform_property.bind(index, property, new_value))
-	undo_redo.add_do_method(rebuild)
-	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(attribute_ref.get_transform_list()))
-	undo_redo.add_undo_method(rebuild)
+	undo_redo.add_do_method(attribute.set_transform_property.bind(index, property, new_value))
+	undo_redo.add_do_method(sync)
+	undo_redo.add_undo_method(attribute.set_transform_property.bind(index, property, attribute.get_transform(index).get(property)))
+	undo_redo.add_undo_method(sync)
 	undo_redo.commit_action()
 
 func insert_transform(index: int, transform_type: String) -> void:
-	undo_redo.create_action()
-	undo_redo.add_do_method(attribute_ref.insert_transform.bind(index, transform_type))
-	undo_redo.add_do_method(rebuild)
-	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(attribute_ref.get_transform_list()))
-	undo_redo.add_undo_method(rebuild)
-	undo_redo.commit_action()
+	edit(attribute.insert_transform.bind(index, transform_type))
 
 func delete_transform(index: int) -> void:
-	undo_redo.create_action()
-	undo_redo.add_do_method(attribute_ref.delete_transform.bind(index))
-	undo_redo.add_do_method(rebuild)
-	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(attribute_ref.get_transform_list()))
-	undo_redo.add_undo_method(rebuild)
-	undo_redo.commit_action()
+	edit(attribute.delete_transform.bind(index))
+
+func replace_matrix(index: int, new_transform: Transform) -> void:
+	var new_transforms := attribute.get_transforms()
+	new_transforms[index] = new_transform
+	edit(attribute.set_transform_list.bind(new_transforms))
 
 func _on_apply_matrix_pressed() -> void:
-	var final_transform := attribute_ref.get_final_precise_transform()
-	undo_redo.create_action()
-	undo_redo.add_do_method(attribute_ref.set_transform_list.bind([
-			Transform.TransformMatrix.new(final_transform[0], final_transform[1],
-			final_transform[2], final_transform[3], final_transform[4],
-			final_transform[5])] as Array[Transform]))
-	undo_redo.add_do_method(rebuild)
-	undo_redo.add_undo_method(attribute_ref.set_transform_list.bind(attribute_ref.get_transform_list()))
-	undo_redo.add_undo_method(rebuild)
-	undo_redo.commit_action()
+	var final_transform := attribute.get_final_precise_transform()
+	edit(attribute.set_transform_list.bind([Transform.TransformMatrix.new(
+			final_transform[0], final_transform[1], final_transform[2], final_transform[3],
+			final_transform[4], final_transform[5])] as Array[Transform]))
 
 func update_final_transform() -> void:
-	var final_transform := attribute_ref.get_final_precise_transform()
+	var final_transform := attribute.get_final_precise_transform()
 	x1_edit.set_value(final_transform[0])
 	x2_edit.set_value(final_transform[1])
 	y1_edit.set_value(final_transform[2])
@@ -155,11 +146,34 @@ func update_final_transform() -> void:
 
 
 func popup_transform_actions(index: int, control: Control) -> void:
+	var transform := attribute.get_transform(index)
+	
 	var btn_arr: Array[ContextButton] = []
 	btn_arr.append(ContextButton.create_custom(Translator.translate("Insert after"),
 			popup_new_transform_context.bind(index + 1, control), preload("res://assets/icons/InsertAfter.svg")))
 	btn_arr.append(ContextButton.create_custom(Translator.translate("Insert before"),
 			popup_new_transform_context.bind(index, control), preload("res://assets/icons/InsertBefore.svg")))
+	
+	# Convert basic transforms to matrices, and matrices to basic transforms if possible.
+	if transform is Transform.TransformMatrix:
+		var basic_transform: Transform = transform.get_equivalent_basic_transform()
+		if is_instance_valid(basic_transform):
+			var text_line := TextLine.new()
+			text_line.add_string(Translator.translate("Convert to") + ": ", ThemeUtils.main_font, get_theme_font_size("font_size", "Button"))
+			text_line.add_string(basic_transform.name, ThemeUtils.mono_font, get_theme_font_size("font_size", "Button"))
+			
+			btn_arr.append(ContextButton.create_custom("", replace_matrix.bind(index, basic_transform),
+					_icons_dict[basic_transform.name]).add_custom_text_line(text_line))
+	else:
+		var t := transform.compute_precise_transform()
+		var matrix_transform := Transform.TransformMatrix.new(t[0], t[1], t[2], t[3], t[4], t[5])
+		var text_line := TextLine.new()
+		text_line.add_string(Translator.translate("Convert to") + ": ", ThemeUtils.main_font, get_theme_font_size("font_size", "Button"))
+		text_line.add_string("matrix", ThemeUtils.mono_font, get_theme_font_size("font_size", "Button"))
+		
+		btn_arr.append(ContextButton.create_custom("", replace_matrix.bind(index, matrix_transform),
+				_icons_dict["matrix"]).add_custom_text_line(text_line))
+	
 	btn_arr.append(ContextButton.create_custom(Translator.translate("Delete"),
 			delete_transform.bind(index), preload("res://assets/icons/Delete.svg")))
 	


### PR DESCRIPTION
Some renames. Fixed error when closing GodSVG with menus or popups open. Tweaked UndoRedo logic in the settings menu, its logic and going back to the tab where the change was made. Added functionality where matrices can be converted into basic transforms if possible, and vice versa. Some code style changes and rewriting to the transform popup. The context popup has a new way to set up the text using a custom TextLine, to be able to make buttons with multiple fonts. Fixed using deprecated method in the shortcut configs.