### PR TITLE
Fix Chinese string

### DIFF
--- a/translations/zh_CN.po
+++ b/translations/zh_CN.po
@@ -842,7 +842,7 @@ msgstr "预设"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Add trailing newline"
-msgstr "在文件末尾添加"
+msgstr "在文件末尾添加换行"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use shorthand tag syntax"


### PR DESCRIPTION
Fixed missing "newline" in translation for "Add trailing newline"