### PR TITLE
Add the Lolcat language

### DIFF
--- a/no_export/scripts/update_lolcat.gd
+++ b/no_export/scripts/update_lolcat.gd
@@ -1,0 +1,106 @@
+# Run with Ctrl+Shift+X.
+@tool
+extends EditorScript
+
+const CREDITS := "FlooferLand"
+
+func _run() -> void:
+	var input := FileAccess.get_file_as_string("res://translations/en.po")
+	var output := ""
+	var last_id := ""
+	var update_count := 0
+	for line in input.split("\n"):
+		line = line.strip_edges()
+		var line_out := line
+		if not line.begins_with("#"):
+			if line.begins_with("msgid"):
+				last_id = line.replace("msgid", "").strip_edges().trim_prefix("\"").trim_suffix("\"")
+			elif line.begins_with("msgstr") and not last_id.is_empty():
+				var new := _translate_str(last_id)
+				line_out = "msgstr \"%s\"" % new
+				last_id = ""
+				if new != last_id:
+					update_count += 1
+			else:
+				line_out = line_out.replace("Language: en", "Language: lolcat")
+		output += "%s\n" % line_out
+	
+	var file := FileAccess.open("res://translations/lolcat.po", FileAccess.WRITE)
+	var file_err := FileAccess.get_open_error()
+	if file_err != OK:
+		print("Error '%s' saving lolcat translation" % file_err)
+	file.store_string(output)
+	file.close()
+	print("Updated %s translations! =(^w^)=" % update_count)
+
+func _translate_str(input: String) -> String:
+	input = input.to_lower()
+	
+	# Quick replaces (should be careful here)
+	input = input\
+		.replace("translation-credits", CREDITS)\
+		.replace("to compare", "an compare")\
+		.replace("no other data is collected or transmitted", "no spywarez.. promis")\
+		.replace("do you", "does u")\
+		.replace("could not be", "cant b")\
+		.replace("can be", "can b")\
+		.replace("may be", "maybe")\
+		.replace("format", "fomat")\
+		.replace("ous ", "us ")\
+		.replace("?", "??")\
+		.replace("'s", "s")\
+		.replace("'t", "t")\
+		.replace(", ", " ")
+	
+	# The smarts
+	if input.ends_with("."):
+		input = input.trim_suffix(".")
+	
+	# Quick words (order matters)
+	var words := {
+		"quit": "kthxbye",
+		"want": "wants",
+		"when": "wen",
+		"this": "dis",
+		"the": "da",
+		"these": "deez",
+		"prettier": "pretty",
+		"graphic": "grafic",
+		"discarded": "boomed",
+		"zoom": "zoomie",
+		"ok": "okey",
+		"close": "byebye",
+		"view": "look",
+		"path": "paf",
+		"error": "bad",
+		"undefined": "undenfied",
+		"cancel": "cancelz",
+		"elements": "elementz",
+		"attributes": "attributez",
+		"versions": "versionz",
+		"colors": "colorz",
+		"exists": "exist",
+		"files": "filez",
+		"godsvgs": "godsvg",
+		"debug": "antibug",
+		"bug": "buggy",
+		"v-sync": "input lag (vsync)"
+	}
+	for key in words.keys():
+		var word: String = words[key]
+		if input == key: # Single-word translations
+			input = word
+		else:
+			input = _replace_word(input, key, word)
+		
+		# Prevents a bug with trailing S being duplicated
+		input = input.replace("ss ", "s ")
+	return input
+
+func _replace_word(input: String, what: String, forwhat: String) -> String:
+	return input\
+		.replace(" %s " % what, " %s " % forwhat)\
+		.replace(" %s." % what, " %s." % forwhat)\
+		.replace(" %s," % what, " %s," % forwhat)\
+		.replace(" %s!" % what, " %s!" % forwhat)\
+		.replace(" %s?" % what, " %s?" % forwhat)

--- a/no_export/scripts/update_lolcat.gd
+++ b/no_export/scripts/update_lolcat.gd
@@ -3,8 +3,10 @@
 extends EditorScript
 
 const CREDITS := "FlooferLand"
+var rand := RandomNumberGenerator.new()
 
 func _run() -> void:
+	rand.seed = 1294921
 	var input := FileAccess.get_file_as_string("res://translations/en.po")
 	var output := ""
 	var last_id := ""
@@ -36,6 +38,12 @@ func _run() -> void:
 func _translate_str(input: String) -> String:
 	input = input.to_lower()
 	
+	# The smarts
+	if input.ends_with("."):
+		input = input.trim_suffix(".") + "!".repeat(rand.randi_range(0, 3))
+	if input.ends_with("!") and input.count(" ") < 4:
+		input = input.to_upper() + "!".repeat(rand.randi_range(0, 2))
+	
 	# Quick replaces (should be careful here)
 	input = input\
 		.replace("translation-credits", CREDITS)\
@@ -52,10 +60,6 @@ func _translate_str(input: String) -> String:
 		.replace("'t", "t")\
 		.replace(", ", " ")
 	
-	# The smarts
-	if input.ends_with("."):
-		input = input.trim_suffix(".")
-	
 	# Quick words (order matters)
 	var words := {
 		"quit": "kthxbye",
@@ -68,7 +72,12 @@ func _translate_str(input: String) -> String:
 		"graphic": "grafic",
 		"discarded": "boomed",
 		"zoom": "zoomie",
+		"scroll": "zoom",
+		"be": "b",
+		"and": "n",
+		"for": "4",
 		"ok": "okey",
+		"accept": "YIPPEE",
 		"close": "byebye",
 		"view": "look",
 		"path": "paf",
@@ -83,6 +92,7 @@ func _translate_str(input: String) -> String:
 		"files": "filez",
 		"godsvgs": "godsvg",
 		"debug": "antibug",
+		"other": "otter",
 		"bug": "buggy",
 		"v-sync": "input lag (vsync)"
 	}
@@ -95,10 +105,11 @@ func _translate_str(input: String) -> String:
 		
 		# Prevents a bug with trailing S being duplicated
 		input = input.replace("ss ", "s ")
-	return input
+	return input.capitalize()
 
 func _replace_word(input: String, what: String, forwhat: String) -> String:
 	return input\
+		.replace("%s " % what, "%s " % forwhat)\
 		.replace(" %s " % what, " %s " % forwhat)\
 		.replace(" %s." % what, " %s." % forwhat)\
 		.replace(" %s," % what, " %s," % forwhat)\

--- a/no_export/scripts/update_lolcat.gd.uid
+++ b/no_export/scripts/update_lolcat.gd.uid
@@ -1,0 +1,1 @@
+uid://bqhg76nyyfjvf

--- a/project.godot
+++ b/project.godot
@@ -363,7 +363,7 @@ pointing/android/enable_pan_and_scale_gestures=true
 [internationalization]
 
 rendering/root_node_auto_translate=false
-locale/translations=PackedStringArray("res://translations/bg.po", "res://translations/pt_BR.po", "res://translations/zh_CN.po", "res://translations/de.po", "res://translations/en.po", "res://translations/es.po", "res://translations/et.po", "res://translations/fr.po", "res://translations/nl.po", "res://translations/ru.po", "res://translations/sl.po", "res://translations/uk.po")
+locale/translations=PackedStringArray("res://translations/bg.po", "res://translations/pt_BR.po", "res://translations/zh_CN.po", "res://translations/de.po", "res://translations/en.po", "res://translations/es.po", "res://translations/et.po", "res://translations/fr.po", "res://translations/nl.po", "res://translations/ru.po", "res://translations/sl.po", "res://translations/uk.po", "res://translations/lolcat.po")
 
 [physics]
 

--- a/translations/lolcat.po
+++ b/translations/lolcat.po
@@ -1,0 +1,1693 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: GodSVG\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: lolcat\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. Translators (comma-separated): Name or alias, optionally followed by an email in angle brackets <email@example.com>.
+#. Used for credits. Adding yourself is optional. New entries go at the end. Don't remove or rearrange existing entries.
+msgid "translation-credits"
+msgstr "FlooferLand"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Quit GodSVG"
+msgstr "quit godsvg"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Do you want to quit GodSVG?"
+msgstr "does u wants to kthxbye godsvg??"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Quit"
+msgstr "kthxbye"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Check for updates?"
+msgstr "check for updates??"
+
+#: src/autoload/HandlerGUI.gd
+msgid "This will connect to github.com to compare version numbers. No other data is collected or transmitted."
+msgstr "this will connect to github.com an compare version numbers. no spywarez.. promis"
+
+#: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
+msgid "OK"
+msgstr "okey"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Export SVG"
+msgstr "export svg"
+
+#: src/autoload/HandlerGUI.gd
+msgid "The graphic can only be exported as SVG because its size is undefined."
+msgstr "the grafic can only be exported as svg because its size is undefined"
+
+#: src/autoload/HandlerGUI.gd
+msgid "Do you want to proceed?"
+msgstr "does u wants to proceed??"
+
+#: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
+#: src/utils/TranslationUtils.gd
+msgid "Export"
+msgstr "export"
+
+#: src/autoload/State.gd
+msgid "The last edited state of this tab could not be found."
+msgstr "the last edited state of dis tab cant b found"
+
+#: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
+#: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
+msgid "Alert!"
+msgstr "alert!"
+
+#: src/autoload/State.gd src/utils/TranslationUtils.gd
+msgid "Close tab"
+msgstr "close tab"
+
+#: src/autoload/State.gd
+msgid "Restore"
+msgstr "restore"
+
+#: src/autoload/State.gd
+msgid "View in Inspector"
+msgstr "view in inspector"
+
+#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+msgid "Convert to"
+msgstr "convert to"
+
+#: src/autoload/State.gd src/ui_widgets/transform_popup.gd
+msgid "Insert after"
+msgstr "insert after"
+
+#: src/autoload/State.gd
+msgid "Insert multiple after"
+msgstr "insert multiple after"
+
+#: src/autoload/State.gd
+msgid "The tab is bound to the file path {file_path}. Do you want to restore the SVG from this path?"
+msgstr "the tab is bound to da file paf {file_path}. does u wants to restore da svg from dis paf??"
+
+#: src/config_classes/Formatter.gd
+msgid "Compact"
+msgstr "compact"
+
+#: src/config_classes/Formatter.gd
+msgid "Pretty"
+msgstr "pretty"
+
+#: src/config_classes/Formatter.gd
+msgid "Always"
+msgstr "always"
+
+#: src/config_classes/Formatter.gd
+msgid "All except containers"
+msgstr "all except containers"
+
+#: src/config_classes/Formatter.gd
+msgid "Never"
+msgstr "never"
+
+#: src/config_classes/Formatter.gd
+msgid "Spacious"
+msgstr "spacious"
+
+#: src/config_classes/Formatter.gd
+msgid "When shorter or equal"
+msgstr "when shorter or equal"
+
+#: src/config_classes/Formatter.gd
+msgid "When shorter"
+msgstr "when shorter"
+
+#: src/config_classes/Formatter.gd
+msgid "3-digit or 6-digit hex"
+msgstr "3-digit or 6-digit hex"
+
+#: src/config_classes/Formatter.gd
+msgid "6-digit hex"
+msgstr "6-digit hex"
+
+#: src/config_classes/PreviewPresentationJPG.gd
+#: src/config_classes/PreviewPresentationLossyWEBP.gd
+#: src/ui_widgets/export_properties_jpg.gd
+#: src/ui_widgets/export_properties_webp.gd
+#: src/ui_widgets/preview_presentation_popup.gd
+msgid "Quality"
+msgstr "quality"
+
+#: src/config_classes/PreviewPresentationLossless.gd
+#: src/ui_widgets/export_properties_webp.gd
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Lossless"
+msgstr "lossless"
+
+#: src/config_classes/PreviewPresentationLossyWEBP.gd
+msgid "Lossy"
+msgstr "lossy"
+
+#. Refers to a theme preset.
+#: src/config_classes/SaveData.gd
+msgid "Dark"
+msgstr "dark"
+
+#. Refers to a theme preset.
+#: src/config_classes/SaveData.gd
+msgid "Light"
+msgstr "light"
+
+#. Refers to a theme preset.
+#: src/config_classes/SaveData.gd
+msgid "Black (OLED)"
+msgstr "black (oled)"
+
+#. Refers to a theme preset.
+#: src/config_classes/SaveData.gd
+msgid "Gray"
+msgstr "gray"
+
+#: src/config_classes/SaveData.gd
+msgid "Default Dark"
+msgstr "default dark"
+
+#: src/config_classes/SaveData.gd
+msgid "Default Light"
+msgstr "default light"
+
+#: src/config_classes/TabData.gd
+msgid "Empty"
+msgstr "empty"
+
+#: src/config_classes/TabData.gd
+msgid "Unsaved"
+msgstr "unsaved"
+
+#: src/data_classes/BasicXNode.gd
+msgid "Comment"
+msgstr "comment"
+
+#: src/data_classes/BasicXNode.gd
+msgid "Text"
+msgstr "text"
+
+#: src/data_classes/Element.gd
+msgid "{element} must be inside {allowed} to have any effect."
+msgstr "{element} must be inside {allowed} to have any effect"
+
+#: src/data_classes/ElementBaseGradient.gd
+msgid "No \"id\" attribute defined."
+msgstr "no \"id\" attribute defined"
+
+#: src/data_classes/ElementBaseGradient.gd
+msgid "No <stop> elements under this gradient."
+msgstr "no <stop> elementz under dis gradient"
+
+#: src/data_classes/ElementBaseGradient.gd
+msgid "This gradient is a solid color."
+msgstr "this gradient is a solid color"
+
+#: src/data_classes/ElementG.gd
+msgid "This group has no elements."
+msgstr "this group has no elements"
+
+#: src/data_classes/ElementG.gd
+msgid "This group has only one element."
+msgstr "this group has only one element"
+
+#: src/data_classes/SVGParser.gd
+msgid "Doesn’t describe an SVG."
+msgstr "doesn’t describe an svg"
+
+#: src/data_classes/SVGParser.gd
+msgid "Improper nesting."
+msgstr "improper nesting"
+
+#. If the language has different gendered versions, prefer the most neutral-sounding one, i.e., the one used when you don't know the person's gender. If that's not possible, use feminine.
+#: src/ui_parts/about_authors.gd
+msgid "Project Founder and Manager"
+msgstr "project founder and manager"
+
+#: src/ui_parts/about_authors.gd
+msgid "Developers"
+msgstr "developers"
+
+#: src/ui_parts/about_authors.gd
+msgid "Translators"
+msgstr "translators"
+
+#: src/ui_parts/about_donors.gd src/ui_parts/about_menu.gd
+msgid "Donors"
+msgstr "donors"
+
+#: src/ui_parts/about_donors.gd
+msgid "Golden donors"
+msgstr "golden donors"
+
+#: src/ui_parts/about_donors.gd
+msgid "Diamond donors"
+msgstr "diamond donors"
+
+#: src/ui_parts/about_menu.gd
+msgid "Authors"
+msgstr "authors"
+
+#: src/ui_parts/about_menu.gd
+msgid "License"
+msgstr "license"
+
+#: src/ui_parts/about_menu.gd
+msgid "Third-party licenses"
+msgstr "third-party licenses"
+
+#: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
+#: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
+#: src/ui_parts/update_menu.gd
+msgid "Close"
+msgstr "byebye"
+
+#: src/ui_parts/current_file_button.gd src/ui_parts/tab_bar.gd
+msgid "Save SVG as…"
+msgstr "save svg as…"
+
+#: src/ui_parts/display.gd
+msgid "Visuals"
+msgstr "visuals"
+
+#: src/ui_parts/display.gd
+msgid "Snap size"
+msgstr "snap size"
+
+#: src/ui_parts/display.gd
+msgid "Paste reference image"
+msgstr "paste reference image"
+
+#: src/ui_parts/display.gd
+msgid "Clear reference image"
+msgstr "clear reference image"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Links to donation platforms"
+msgstr "links to donation platforms"
+
+#: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
+#: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
+#: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
+msgid "Cancel"
+msgstr "cancelz"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Hover a platform for details."
+msgstr "hover a platform for details"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Low extra fees"
+msgstr "low extra fees"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Can donate arbitrary amounts"
+msgstr "can donate arbitrary amounts"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Higher extra fees"
+msgstr "higher extra fees"
+
+#: src/ui_parts/donate_menu.gd
+msgid "Can't donate arbitrary amounts"
+msgstr "cant donate arbitrary amounts"
+
+#: src/ui_parts/element_container.gd
+msgid "New element"
+msgstr "new element"
+
+#: src/ui_parts/export_menu.gd
+msgid "Dimensions"
+msgstr "dimensions"
+
+#: src/ui_parts/export_menu.gd
+msgid "Preview image size is limited to {dimensions}"
+msgstr "preview image size is limited to {dimensions}"
+
+#: src/ui_parts/export_menu.gd
+msgid "Export Configuration"
+msgstr "export configuration"
+
+#: src/ui_parts/export_menu.gd
+msgid "Format"
+msgstr "fomat"
+
+#: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
+msgid "Copy"
+msgstr "copy"
+
+#: src/ui_parts/export_menu.gd src/ui_widgets/settings_content_generic.gd
+msgid "Size"
+msgstr "size"
+
+#: src/ui_parts/export_menu.gd
+msgid "Estimated size"
+msgstr "estimated size"
+
+#: src/ui_parts/global_actions.gd src/ui_parts/layout_configuration.gd
+#: src/ui_parts/shortcut_panel_config.gd
+msgid "Layout"
+msgstr "layout"
+
+#: src/ui_parts/global_actions.gd
+msgid "View savedata"
+msgstr "view savedata"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Refresh files"
+msgstr "refresh files"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Toggle the visibility of hidden files"
+msgstr "toggle da visibility of hidden files"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Search files"
+msgstr "search files"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Go back"
+msgstr "go back"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Go forward"
+msgstr "go forward"
+
+#: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
+msgid "Save"
+msgstr "save"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Select"
+msgstr "select"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Replace"
+msgstr "replace"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Create new folder"
+msgstr "create new folder"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Invalid name for a folder."
+msgstr "invalid name for a folder"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "A folder with this name already exists."
+msgstr "a folder with dis name already exists"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Failed to create a folder."
+msgstr "failed to create a folder"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Open"
+msgstr "open"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Copy path"
+msgstr "copy path"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "Open in File Manager"
+msgstr "open in file manager"
+
+#: src/ui_parts/good_file_dialog.gd
+msgid "A file named \"{file_name}\" already exists. Replacing will overwrite its contents!"
+msgstr "a file named \"{file_name}\" already exist. replacing will overwrite its contents!"
+
+#: src/ui_parts/import_warning_menu.gd
+msgid "Syntax error"
+msgstr "syntax error"
+
+#: src/ui_parts/import_warning_menu.gd
+msgid "Unrecognized element"
+msgstr "unrecognized element"
+
+#: src/ui_parts/import_warning_menu.gd
+msgid "Unrecognized attribute"
+msgstr "unrecognized attribute"
+
+#: src/ui_parts/import_warning_menu.gd
+msgid "Import Problems"
+msgstr "import problems"
+
+#: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
+msgid "Import"
+msgstr "import"
+
+#: src/ui_parts/inspector.gd
+msgid "Add element"
+msgstr "add element"
+
+#. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
+#: src/ui_parts/layout_configuration.gd
+msgid "Excluded"
+msgstr "excluded"
+
+#: src/ui_parts/layout_configuration.gd
+msgid "Drag and drop to change the layout"
+msgstr "drag and drop to change da layout"
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "File"
+msgstr "file"
+
+#: src/ui_parts/mac_menu.gd src/ui_parts/previews.gd
+#: src/ui_widgets/color_picker_layout_popup.gd
+#: src/ui_widgets/settings_content_shortcuts.gd
+msgid "Edit"
+msgstr "edit"
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Tool"
+msgstr "tool"
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "View"
+msgstr "look"
+
+#: src/ui_parts/mac_menu.gd
+msgid "Window"
+msgstr "window"
+
+#: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
+msgid "Help"
+msgstr "help"
+
+#: src/ui_parts/previews.gd
+msgid "Add preview"
+msgstr "add preview"
+
+#: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
+#: src/ui_widgets/setting_shortcut.gd src/ui_widgets/transform_popup.gd
+#: src/utils/TranslationUtils.gd
+msgid "Delete"
+msgstr "delete"
+
+#: src/ui_parts/previews.gd src/ui_widgets/setting_frame.gd
+#: src/ui_widgets/setting_shortcut.gd
+msgid "Reset to default"
+msgstr "reset to default"
+
+#: src/ui_parts/previews.gd
+msgid "Clear all"
+msgstr "clear all"
+
+#: src/ui_parts/previews.gd
+msgid "Sort"
+msgstr "sort"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Formatting"
+msgstr "fomatting"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Optimizer"
+msgstr "optimizer"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Palettes"
+msgstr "palettes"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Shortcuts"
+msgstr "shortcuts"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Theming"
+msgstr "theming"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Tab bar"
+msgstr "tab bar"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Other"
+msgstr "other"
+
+#: src/ui_parts/settings_menu.gd
+msgid "Language"
+msgstr "language"
+
+#: src/ui_parts/shortcut_panel.gd
+msgid "Horizontal strip"
+msgstr "horizontal strip"
+
+#: src/ui_parts/shortcut_panel.gd
+msgid "Vertical strip"
+msgstr "vertical strip"
+
+#: src/ui_parts/shortcut_panel.gd
+msgid "Horizontal with two rows"
+msgstr "horizontal with two rows"
+
+#: src/ui_parts/shortcut_panel_config.gd
+msgid "Configure Shortcut Panel"
+msgstr "configure shortcut panel"
+
+#: src/ui_parts/tab_bar.gd
+msgid "Close multiple"
+msgstr "close multiple"
+
+#: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
+msgid "Create a new tab"
+msgstr "create a new tab"
+
+#: src/ui_parts/tab_bar.gd
+msgid "Scroll backwards"
+msgstr "scroll backwards"
+
+#: src/ui_parts/tab_bar.gd
+msgid "Scroll forwards"
+msgstr "scroll forwards"
+
+#: src/ui_parts/tab_bar.gd
+msgid "This SVG is not bound to a file location yet."
+msgstr "this svg is not bound to a file location yet"
+
+#: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
+msgid "Retry"
+msgstr "retry"
+
+#: src/ui_parts/update_menu.gd
+msgid "Show prereleases"
+msgstr "show prereleases"
+
+#: src/ui_parts/update_menu.gd
+msgid "Current Version"
+msgstr "current version"
+
+#: src/ui_parts/update_menu.gd
+msgid "Retrieving information..."
+msgstr "retrieving infomation.."
+
+#. When checking for updates.
+#: src/ui_parts/update_menu.gd
+msgid "Update check failed"
+msgstr "update check failed"
+
+#: src/ui_parts/update_menu.gd
+msgid "View all releases"
+msgstr "view all releases"
+
+#: src/ui_parts/update_menu.gd
+msgid "GodSVG is up-to-date."
+msgstr "godsvg is up-to-date"
+
+#: src/ui_parts/update_menu.gd
+msgid "New versions available!"
+msgstr "new versionz available!"
+
+#: src/ui_widgets/PanelGrid.gd
+msgid "Copy email"
+msgstr "copy email"
+
+#: src/ui_widgets/choose_name_dialog.gd
+msgid "Create"
+msgstr "create"
+
+#: src/ui_widgets/color_configuration_popup.gd
+msgid "Edit color name"
+msgstr "edit color name"
+
+#: src/ui_widgets/color_configuration_popup.gd
+msgid "Delete color"
+msgstr "delete color"
+
+#: src/ui_widgets/color_configuration_popup.gd src/ui_widgets/palette_config.gd
+msgid "Unnamed"
+msgstr "unnamed"
+
+#. Ways to represent colors, like RGB, HSV, HSL.
+#: src/ui_widgets/color_picker_layout_popup.gd
+msgid "Color models"
+msgstr "color models"
+
+#: src/ui_widgets/color_picker_layout_popup.gd
+msgid "Move left"
+msgstr "move left"
+
+#: src/ui_widgets/color_picker_layout_popup.gd
+msgid "Move right"
+msgstr "move right"
+
+#: src/ui_widgets/color_picker_layout_popup.gd
+msgid "Remove"
+msgstr "remove"
+
+#: src/ui_widgets/color_popup.gd
+msgid "Color utilities"
+msgstr "color utilities"
+
+#: src/ui_widgets/color_popup.gd
+msgid "Back to color picker"
+msgstr "back to color picker"
+
+#: src/ui_widgets/color_utilities_area.gd
+msgid "Search color"
+msgstr "search color"
+
+#: src/ui_widgets/export_properties_jpg.gd
+#: src/ui_widgets/export_properties_raster_lossless.gd
+#: src/ui_widgets/export_properties_webp.gd
+#: src/ui_widgets/preview_presentation_popup.gd
+msgid "Background"
+msgstr "background"
+
+#: src/ui_widgets/export_scale_config.gd
+msgid "Scale"
+msgstr "scale"
+
+#: src/ui_widgets/export_scale_config.gd
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Width"
+msgstr "width"
+
+#: src/ui_widgets/export_scale_config.gd
+msgid "Height"
+msgstr "height"
+
+#: src/ui_widgets/file_path_edit.gd
+msgid "No file path"
+msgstr "no file path"
+
+#: src/ui_widgets/good_color_picker.gd
+msgid "Color keywords"
+msgstr "color keywords"
+
+#: src/ui_widgets/good_color_picker.gd
+msgid "Eyedropper"
+msgstr "eyedropper"
+
+#: src/ui_widgets/handles_manager.gd
+msgid "New shape"
+msgstr "new shape"
+
+#: src/ui_widgets/id_field.gd
+msgid "No ID"
+msgstr "no id"
+
+#. Refers to a number of points.
+#: src/ui_widgets/insert_multiple_points_popup.gd
+msgid "Points to insert"
+msgstr "points to insert"
+
+#: src/ui_widgets/invalid_syntax_warning.gd
+msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
+msgstr "the svg has invalid syntax. any edit not made through da code editor will reset it"
+
+#: src/ui_widgets/optimizer_setting_info.gd
+msgid "Before"
+msgstr "before"
+
+#: src/ui_widgets/optimizer_setting_info.gd
+msgid "After"
+msgstr "after"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Unnamed palettes won't be shown."
+msgstr "unnamed palettes wont be shown"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Multiple palettes can't have the same name."
+msgstr "multiple palettes cant have da same name"
+
+#: src/ui_widgets/palette_config.gd
+msgid "This palette has identically defined colors."
+msgstr "this palette has identically defined colors"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Rename"
+msgstr "rename"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Apply Preset"
+msgstr "apply preset"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Move Up"
+msgstr "move up"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Move Down"
+msgstr "move down"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Copy as XML"
+msgstr "copy as xml"
+
+#: src/ui_widgets/palette_config.gd
+msgid "Save as XML"
+msgstr "save as xml"
+
+#: src/ui_widgets/path_convert_popup.gd
+msgid "Exact conversions"
+msgstr "exact conversions"
+
+#: src/ui_widgets/path_convert_popup.gd
+msgid "Lossy conversions"
+msgstr "lossy conversions"
+
+#: src/ui_widgets/path_insert_popup.gd src/utils/TranslationUtils.gd
+msgid "Relative"
+msgstr "relative"
+
+#: src/ui_widgets/path_insert_popup.gd
+msgid "Keep open"
+msgstr "keep open"
+
+#: src/ui_widgets/path_insert_popup.gd
+msgid "If toggled off, you must hold {keys} when selecting a path command to keep the popup open."
+msgstr "if toggled off you must hold {keys} wen selecting a paf command to keep da popup open"
+
+#: src/ui_widgets/pathdata_field.gd
+msgid "No path data"
+msgstr "no paf data"
+
+#: src/ui_widgets/points_field.gd
+msgid "No points"
+msgstr "no points"
+
+#: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
+msgid "Also used by"
+msgstr "also used by"
+
+#: src/ui_widgets/profile_frame.gd
+msgid "Apply"
+msgstr "apply"
+
+#: src/ui_widgets/profile_frame.gd
+msgid "Apply all of this preset's defaults"
+msgstr "apply all of dis presets defaults"
+
+#. This is not an answer to a Yes/No question, but a statement about a state. Translate according to the language's natural state labels (e.g. Activated/Deactivated, Active/Inactive, Enabled/Disabled). Prefer short translations; if a common abbreviation exists, use it.
+#: src/ui_widgets/setting_frame.gd
+msgid "On"
+msgstr "on"
+
+#. This is not an answer to a Yes/No question, but a statement about a state. Translate according to the language's natural state labels (e.g. Activated/Deactivated, Active/Inactive, Enabled/Disabled). Prefer short translations; if a common abbreviation exists, use it.
+#: src/ui_widgets/setting_frame.gd
+msgid "Off"
+msgstr "off"
+
+#: src/ui_widgets/setting_frame.gd
+msgid "Clear"
+msgstr "clear"
+
+#: src/ui_widgets/setting_shortcut.gd
+msgid "Unused"
+msgstr "unused"
+
+#: src/ui_widgets/setting_shortcut.gd
+msgid "Add shortcut"
+msgstr "add shortcut"
+
+#: src/ui_widgets/setting_shortcut.gd
+msgid "Press keys…"
+msgstr "pres keys…"
+
+#. Refers to the formatter used for GodSVG's code editor.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Editor formatter"
+msgstr "editor fomatter"
+
+#. Refers to the formatter used when exporting.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Export formatter"
+msgstr "export fomatter"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines how SVG attributes and content appear in the GodSVG interface."
+msgstr "determines how svg attributez and content appear in da godsvg interface"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines how SVG attributes and content are formatted when saving the file."
+msgstr "determines how svg attributez and content are fomatted wen saving da file"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Preset"
+msgstr "preset"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Add trailing newline"
+msgstr "add trailing newline"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use shorthand tag syntax"
+msgstr "use shorthand tag syntax"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Space out the slash of shorthand tags"
+msgstr "space out da slash of shorthand tags"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Formatting style"
+msgstr "fomatting style"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use spaces instead of tabs"
+msgstr "use spaces instead of tabs"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Number of indentation spaces"
+msgstr "number of indentation spaces"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Numbers"
+msgstr "numbers"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Remove leading zero"
+msgstr "remove leading zero"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use exponential when shorter"
+msgstr "use exponential wen shorter"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Colors"
+msgstr "colorz"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use named colors"
+msgstr "use named colors"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Primary syntax"
+msgstr "primary syntax"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Capitalize hexadecimal letters"
+msgstr "capitalize hexadecimal letters"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Pathdata"
+msgstr "pathdata"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Compress numbers"
+msgstr "compres numbers"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Minimize spacing"
+msgstr "minimize spacing"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Remove spacing after flags"
+msgstr "remove spacing after flags"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Remove consecutive commands"
+msgstr "remove consecutive commands"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Transform lists"
+msgstr "transform lists"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Remove unnecessary parameters"
+msgstr "remove unnecessary parameters"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the settings for the default optimizer, used when manually running the \"{optimize}\" action."
+msgstr "determines da settings for da default optimizer used wen manually running da \"{optimize}\" action"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Remove comments"
+msgstr "remove comments"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Convert shapes"
+msgstr "convert shapes"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Simplify paths"
+msgstr "simplify paths"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Theme preset"
+msgstr "theme preset"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Primary theme colors"
+msgstr "primary theme colors"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Base color"
+msgstr "base color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Accent color"
+msgstr "accent color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Fonts"
+msgstr "fonts"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Main font"
+msgstr "main font"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Bold font"
+msgstr "bold font"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Mono font"
+msgstr "mono font"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "SVG Text colors"
+msgstr "svg text colors"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Highlighter preset"
+msgstr "highlighter preset"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the default values of SVG highlighter settings."
+msgstr "determines da default values of svg highlighter settings"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Symbol color"
+msgstr "symbol color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Element color"
+msgstr "element color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Attribute color"
+msgstr "attribute color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "String color"
+msgstr "string color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Comment color"
+msgstr "comment color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Text color"
+msgstr "text color"
+
+#. XML entities (&quot;, &amp;, &apos;, &gt;, and &lt;) are strings representing certain symbols with syntax importance that would break a text section if typed out.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "XML entity color"
+msgstr "xml entity color"
+
+#. CDATA shouldn't be translated. It's a type of XML section.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "CDATA color"
+msgstr "cdata color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Error color"
+msgstr "error color"
+
+#. Refers to the draggable gizmos.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Handles"
+msgstr "handles"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Inside color"
+msgstr "inside color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Normal color"
+msgstr "normal color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Hovered color"
+msgstr "hovered color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Selected color"
+msgstr "selected color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Hovered selected color"
+msgstr "hovered selected color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Selection rectangle"
+msgstr "selection rectangle"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Speed"
+msgstr "speed"
+
+#. Refers to the selection rectangle's animated dashed stroke.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Dash length"
+msgstr "dash length"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Color {index}"
+msgstr "color {index}"
+
+#: src/ui_widgets/settings_content_generic.gd src/utils/TranslationUtils.gd
+msgid "Canvas"
+msgstr "canvas"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Canvas color"
+msgstr "canvas color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Grid color"
+msgstr "grid color"
+
+#. Refers to the specially marked grid ticks, which are more distinct and have a coordinate.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Grid tick interval"
+msgstr "grid tick interval"
+
+#. Refers to the specially marked grid ticks, which are more distinct and have a coordinate.
+#: src/ui_widgets/settings_content_generic.gd
+msgid "No ticks"
+msgstr "no ticks"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Basic colors"
+msgstr "basic colors"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Valid color"
+msgstr "valid color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Warning color"
+msgstr "warning color"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Input"
+msgstr "input"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Close tabs with middle mouse button"
+msgstr "close tabs with middle mouse button"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Invert zoom direction"
+msgstr "invert zoomie direction"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Pan with left mouse button"
+msgstr "pan with left mouse button"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Wrap-around panning"
+msgstr "wrap-around panning"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Panning speed"
+msgstr "panning speed"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use CTRL for zooming"
+msgstr "use ctrl for zooming"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Display"
+msgstr "display"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "UI scale"
+msgstr "ui scale"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the scale factor for the interface."
+msgstr "determines da scale factor for da interface"
+
+#. Stands for "Vertical Synchronization".
+#: src/ui_widgets/settings_content_generic.gd
+msgid "V-Sync"
+msgstr "input lag (vsync)"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Maximum FPS"
+msgstr "maximum fps"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Unlimited"
+msgstr "unlimited"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the maximum number of frames per second."
+msgstr "determines da maximum number of frames per second"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Keep screen on"
+msgstr "keep screen on"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Miscellaneous"
+msgstr "miscellaneous"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Use native file dialog"
+msgstr "use native file dialog"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Sync window title to file name"
+msgstr "sync window title to file name"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "The setting has no effect in the current configuration."
+msgstr "the setting has no effect in da current configuration"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "The setting can't be changed on this platform."
+msgstr "the setting cant be changed on dis platform"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, the left mouse button can be used to pan the canvas."
+msgstr "when enabled da left mouse button can b used to pan da canvas"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Formatters can change the formatting of the SVG's content and attributes. These changes don't affect its structure or the structure of more complex attributes, such as pathdata. Formatters can be configured to make the SVG prettier or more compact."
+msgstr "fomatters can change da fomatting of da svgs content and attributez. deez changes dont affect its structure or da structure of more complex attributez such as pathdata. fomatters can b configured to make da svg pretty or more compact"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the default values of the formatter configs."
+msgstr "determines da default values of da fomatter configs"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, uses spaces instead of a single tab for indentation."
+msgstr "when enabled uses spaces instead of a single tab for indentation"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Optimizers can change the structure of the SVG and its complex attributes, such as pathdata. These changes reduce the SVG's complexity, usually leading to reductions in file size, but may be destructive and disrupt future editing, compared to optimizing the SVG manually."
+msgstr "optimizers can change da structure of da svg and its complex attributez such as pathdata. deez changes reduce da svgs complexity usually leading to reductions in file size but maybe destructive and disrupt future editing compared to optimizing da svg manually"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Convert shapes into ones that can be defined identically, but have a shorter representation, if possible."
+msgstr "convert shapes into ones that can b defined identically but have a shorter representation if possible"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Converts or simplifies path commands into ones with identical definition, but shorter representation, if possible."
+msgstr "converts or simplifies paf commands into ones with identical definition but shorter representation if possible"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the default values of theming-related settings, including the highlighter preset."
+msgstr "determines da default values of theming-related settings including da highlighter preset"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the base color of GodSVG's interface."
+msgstr "determines da base color of godsvg interface"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines the accent color used for highlighted elements in GodSVG's interface."
+msgstr "determines da accent color used for highlighted elementz in godsvg interface"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, clicking on a tab with the middle mouse button closes it instead of simply focusing it."
+msgstr "when enabled clicking on a tab with da middle mouse button closes it instead of simply focusing it"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Swaps the scroll directions for zooming in and zooming out."
+msgstr "swaps da scroll directions for zooming in and zooming out"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Warps the cursor to the opposite side whenever it reaches a canvas boundary while panning."
+msgstr "warps da cursor to da opposite side whenever it reaches a canvas boundary while panning"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Determines how much the view moves for scroll-based panning inputs."
+msgstr "determines how much da look moves for scroll-based panning inputs"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, scrolling pans the view instead of zooming in. To zoom, hold CTRL while scrolling."
+msgstr "when enabled scrolling pans da look instead of zooming in. to zoomie hold ctrl while scrolling"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. May increase input lag slightly."
+msgstr "synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. may increase input lag slightly"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "Keeps the screen on even after inactivity, so the screensaver does not take over."
+msgstr "keeps da screen on even after inactivity so da screensaver does not take over"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, uses your operating system's native file dialog instead of GodSVG's built-in one."
+msgstr "when enabled uses your operating systems native file dialog instead of godsvg built-in one"
+
+#: src/ui_widgets/settings_content_generic.gd
+msgid "When enabled, adds the current file name before the \"GodSVG\" window title."
+msgstr "when enabled adds da current file name before da \"godsvg\" window title"
+
+#: src/ui_widgets/settings_content_palettes.gd
+msgid "New palette"
+msgstr "new palette"
+
+#: src/ui_widgets/settings_content_palettes.gd
+msgid "New palette from XML"
+msgstr "new palette from xml"
+
+#: src/ui_widgets/settings_content_palettes.gd
+msgid "Import XML"
+msgstr "import xml"
+
+#: src/ui_widgets/settings_content_palettes.gd
+msgid "Paste XML"
+msgstr "paste xml"
+
+#: src/ui_widgets/transform_field.gd
+msgid "No transforms"
+msgstr "no transforms"
+
+#: src/ui_widgets/transform_popup.gd
+msgid "Apply the matrix"
+msgstr "apply da matrix"
+
+#: src/ui_widgets/transform_popup.gd
+msgid "Insert before"
+msgstr "insert before"
+
+#: src/ui_widgets/transform_popup.gd
+msgid "New transform"
+msgstr "new transform"
+
+#: src/ui_widgets/unrecognized_field.gd
+msgid "GodSVG doesn’t recognize this attribute"
+msgstr "godsvg doesn’t recognize dis attribute"
+
+#: src/utils/FileUtils.gd
+msgid "The following files were discarded:"
+msgstr "the following filez were discarded:"
+
+#: src/utils/FileUtils.gd
+msgid "{file_name} was discarded."
+msgstr "{file_name} was discarded"
+
+#: src/utils/FileUtils.gd
+msgid "Discarded files"
+msgstr "discarded files"
+
+#: src/utils/FileUtils.gd
+msgid "Proceed"
+msgstr "proceed"
+
+#: src/utils/FileUtils.gd
+msgid "{file_name} couldn't be opened."
+msgstr "{file_name} couldnt be opened"
+
+#: src/utils/FileUtils.gd
+msgid "Check if the file still exists in the selected file path."
+msgstr "check if da file still exist in da selected file path"
+
+#: src/utils/FileUtils.gd
+msgid "Proceed with importing the rest of the files?"
+msgstr "proceed with importing da rest of da filez??"
+
+#: src/utils/FileUtils.gd
+msgid "Proceed for all files that can't be opened"
+msgstr "proceed for all filez that cant be opened"
+
+#: src/utils/FileUtils.gd
+msgid "Save the file?"
+msgstr "save da file??"
+
+#: src/utils/FileUtils.gd
+msgid "Do you want to save this file?"
+msgstr "does u wants to save dis file??"
+
+#: src/utils/FileUtils.gd
+msgid "Save the changes?"
+msgstr "save da changes??"
+
+#: src/utils/FileUtils.gd
+msgid "Your changes will be lost if you don't save them."
+msgstr "your changes will be lost if you dont save them"
+
+#: src/utils/FileUtils.gd
+msgid "Don't save"
+msgstr "dont save"
+
+#: src/utils/FileUtils.gd
+msgid "{file_path} is already being edited inside GodSVG."
+msgstr "{file_path} is already being edited inside godsvg"
+
+#: src/utils/FileUtils.gd
+msgid "If you want to discard your edits and sync to the file's current content, use \"{reset_svg}\"."
+msgstr "if you wants to discard your edits and sync to da filez current content use \"{reset_svg}\""
+
+#: src/utils/FileUtils.gd
+msgid "Do you want to save the changes made to {file_name}?"
+msgstr "does u wants to save da changes made to {file_name}??"
+
+#: src/utils/TranslationUtils.gd
+msgid "Save SVG"
+msgstr "save svg"
+
+#: src/utils/TranslationUtils.gd
+msgid "Save SVG as"
+msgstr "save svg as"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close tabs to the left"
+msgstr "close tabs to da left"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close tabs to the right"
+msgstr "close tabs to da right"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close all other tabs"
+msgstr "close all other tabs"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close empty tabs"
+msgstr "close empty tabs"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close saved tabs"
+msgstr "close saved tabs"
+
+#: src/utils/TranslationUtils.gd
+msgid "Create tab"
+msgstr "create tab"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select the next tab"
+msgstr "select da next tab"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select the previous tab"
+msgstr "select da previus tab"
+
+#: src/utils/TranslationUtils.gd
+msgid "Optimize"
+msgstr "optimize"
+
+#: src/utils/TranslationUtils.gd
+msgid "Optimize SVG"
+msgstr "optimize svg"
+
+#: src/utils/TranslationUtils.gd
+msgid "Copy all text"
+msgstr "copy all text"
+
+#: src/utils/TranslationUtils.gd
+msgid "Copy the SVG text"
+msgstr "copy da svg text"
+
+#: src/utils/TranslationUtils.gd
+msgid "Reset SVG"
+msgstr "reset svg"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open externally"
+msgstr "open externally"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open SVG externally"
+msgstr "open svg externally"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show in File Manager"
+msgstr "show in file manager"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show SVG in File Manager"
+msgstr "show svg in file manager"
+
+#: src/utils/TranslationUtils.gd
+msgid "Undo"
+msgstr "undo"
+
+#: src/utils/TranslationUtils.gd
+msgid "Redo"
+msgstr "redo"
+
+#: src/utils/TranslationUtils.gd
+msgid "Paste"
+msgstr "paste"
+
+#: src/utils/TranslationUtils.gd
+msgid "Cut"
+msgstr "cut"
+
+#. Refers to evaluating an expression such as "sin(2*pi/5)".
+#: src/utils/TranslationUtils.gd
+msgid "Evaluate"
+msgstr "evaluate"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select all"
+msgstr "select all"
+
+#: src/utils/TranslationUtils.gd
+msgid "Duplicate"
+msgstr "duplicate"
+
+#: src/utils/TranslationUtils.gd
+msgid "Duplicate the selection"
+msgstr "duplicate da selection"
+
+#: src/utils/TranslationUtils.gd
+msgid "Delete the selection"
+msgstr "delete da selection"
+
+#: src/utils/TranslationUtils.gd
+msgid "Move up"
+msgstr "move up"
+
+#: src/utils/TranslationUtils.gd
+msgid "Move the selection up"
+msgstr "move da selection up"
+
+#: src/utils/TranslationUtils.gd
+msgid "Move down"
+msgstr "move down"
+
+#: src/utils/TranslationUtils.gd
+msgid "Move the selection down"
+msgstr "move da selection down"
+
+#. Refers to, for example, changing which point in a polygon counts as "first".
+#: src/utils/TranslationUtils.gd
+msgid "Set as initial"
+msgstr "set as initial"
+
+#: src/utils/TranslationUtils.gd
+msgid "Set point as initial"
+msgstr "set point as initial"
+
+#: src/utils/TranslationUtils.gd
+msgid "Reverse order"
+msgstr "reverse order"
+
+#: src/utils/TranslationUtils.gd
+msgid "Find"
+msgstr "find"
+
+#: src/utils/TranslationUtils.gd
+msgid "Zoom in"
+msgstr "zoom in"
+
+#: src/utils/TranslationUtils.gd
+msgid "Zoom out"
+msgstr "zoom out"
+
+#: src/utils/TranslationUtils.gd
+msgid "Zoom reset"
+msgstr "zoom reset"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show grid"
+msgstr "show grid"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show handles"
+msgstr "show handles"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show rasterized SVG"
+msgstr "show rasterized svg"
+
+#: src/utils/TranslationUtils.gd
+msgid "Toggle snapping"
+msgstr "toggle snapping"
+
+#: src/utils/TranslationUtils.gd
+msgid "Load reference image"
+msgstr "load reference image"
+
+#: src/utils/TranslationUtils.gd
+msgid "Show reference image"
+msgstr "show reference image"
+
+#: src/utils/TranslationUtils.gd
+msgid "Overlay reference image"
+msgstr "overlay reference image"
+
+#: src/utils/TranslationUtils.gd
+msgid "View debug information"
+msgstr "view antibug infomation"
+
+#: src/utils/TranslationUtils.gd
+msgid "View advanced debug information"
+msgstr "view advanced antibug infomation"
+
+#: src/utils/TranslationUtils.gd
+msgid "Settings"
+msgstr "settings"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open Settings menu"
+msgstr "open settings menu"
+
+#: src/utils/TranslationUtils.gd
+msgid "About…"
+msgstr "about…"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open About menu"
+msgstr "open about menu"
+
+#: src/utils/TranslationUtils.gd
+msgid "Donate…"
+msgstr "donate…"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open Donate menu"
+msgstr "open donate menu"
+
+#: src/utils/TranslationUtils.gd
+msgid "GodSVG repository"
+msgstr "godsvg repository"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open GodSVG repository"
+msgstr "open godsvg repository"
+
+#: src/utils/TranslationUtils.gd
+msgid "GodSVG website"
+msgstr "godsvg website"
+
+#: src/utils/TranslationUtils.gd
+msgid "Open GodSVG website"
+msgstr "open godsvg website"
+
+#: src/utils/TranslationUtils.gd
+msgid "Check for updates"
+msgstr "check for updates"
+
+#: src/utils/TranslationUtils.gd
+msgid "Quit the application"
+msgstr "quit da application"
+
+#: src/utils/TranslationUtils.gd
+msgid "Toggle fullscreen"
+msgstr "toggle fullscreen"
+
+#: src/utils/TranslationUtils.gd
+msgid "Move to"
+msgstr "move to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Line to"
+msgstr "line to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Horizontal Line to"
+msgstr "horizontal line to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Vertical Line to"
+msgstr "vertical line to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Close Path"
+msgstr "close path"
+
+#: src/utils/TranslationUtils.gd
+msgid "Elliptical Arc to"
+msgstr "elliptical arc to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Quadratic Bezier to"
+msgstr "quadratic bezier to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Shorthand Quadratic Bezier to"
+msgstr "shorthand quadratic bezier to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Cubic Bezier to"
+msgstr "cubic bezier to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Shorthand Cubic Bezier to"
+msgstr "shorthand cubic bezier to"
+
+#: src/utils/TranslationUtils.gd
+msgid "Absolute"
+msgstr "absolute"
+
+#: src/utils/TranslationUtils.gd
+msgid "Code Editor"
+msgstr "code editor"
+
+#: src/utils/TranslationUtils.gd
+msgid "Inspector"
+msgstr "inspector"
+
+#. Refers to a part of the layout where icons are previewed at various sizes.
+#: src/utils/TranslationUtils.gd
+msgid "Previews"
+msgstr "previews"
+
+#: src/utils/TranslationUtils.gd
+msgid "Only {extension_list} files are supported for this operation."
+msgstr "only {extension_list} filez are supported for dis operation"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select {format} files"
+msgstr "select {fomat} files"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select an image"
+msgstr "select an image"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select a font"
+msgstr "select a font"
+
+#: src/utils/TranslationUtils.gd
+msgid "Select an {format} file"
+msgstr "select an {fomat} file"
+
+#: src/utils/TranslationUtils.gd
+msgid "Save the {format} file"
+msgstr "save da {fomat} file"
+
+#: no_export/scripts/update_desktop_file.gd
+msgid "Vector graphics editor"
+msgstr "vector graphics editor"
+
+#: no_export/scripts/update_desktop_file.gd
+msgid "A vector graphics application for structured SVG editing"
+msgstr "a vector graphics application for structured svg editing"
+
+#. A list of keywords that should remain semicolon-separated. Doesn't need to be exactly translated. There can be more keywords or less, but they must remain similar to the English ones.
+#: no_export/scripts/update_desktop_file.gd
+msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
+msgstr "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2d;code;blue;fox"
+

--- a/translations/lolcat.po
+++ b/translations/lolcat.po
@@ -15,125 +15,125 @@ msgstr ""
 #. Translators (comma-separated): Name or alias, optionally followed by an email in angle brackets <email@example.com>.
 #. Used for credits. Adding yourself is optional. New entries go at the end. Don't remove or rearrange existing entries.
 msgid "translation-credits"
-msgstr "FlooferLand"
+msgstr "Floofer Land"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Quit GodSVG"
-msgstr "quit godsvg"
+msgstr "Kthxbye Godsvg"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Do you want to quit GodSVG?"
-msgstr "does u wants to kthxbye godsvg??"
+msgstr "Does U Wants To Kthxbye Godsvg??"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Quit"
-msgstr "kthxbye"
+msgstr "Kthxbye"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Check for updates?"
-msgstr "check for updates??"
+msgstr "Check 4 Updates??"
 
 #: src/autoload/HandlerGUI.gd
 msgid "This will connect to github.com to compare version numbers. No other data is collected or transmitted."
-msgstr "this will connect to github.com an compare version numbers. no spywarez.. promis"
+msgstr "Dis Will Connect To Github.com An Compare Version Numbers. No Spywarez.. Promis!!!"
 
 #: src/autoload/HandlerGUI.gd src/ui_widgets/alert_dialog.gd
 msgid "OK"
-msgstr "okey"
+msgstr "Okey"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Export SVG"
-msgstr "export svg"
+msgstr "Export Svg"
 
 #: src/autoload/HandlerGUI.gd
 msgid "The graphic can only be exported as SVG because its size is undefined."
-msgstr "the grafic can only be exported as svg because its size is undefined"
+msgstr "Da Grafic Can Only B Exported As Svg Because Its Size Is Undenfied!!"
 
 #: src/autoload/HandlerGUI.gd
 msgid "Do you want to proceed?"
-msgstr "does u wants to proceed??"
+msgstr "Does U Wants To Proceed??"
 
 #: src/autoload/HandlerGUI.gd src/ui_parts/export_menu.gd
 #: src/utils/TranslationUtils.gd
 msgid "Export"
-msgstr "export"
+msgstr "Export"
 
 #: src/autoload/State.gd
 msgid "The last edited state of this tab could not be found."
-msgstr "the last edited state of dis tab cant b found"
+msgstr "Da Last Edited State Of Dis Tab Cant B Found!"
 
 #: src/autoload/State.gd src/ui_parts/good_file_dialog.gd
 #: src/ui_widgets/alert_dialog.gd src/utils/FileUtils.gd
 msgid "Alert!"
-msgstr "alert!"
+msgstr "Alert!!"
 
 #: src/autoload/State.gd src/utils/TranslationUtils.gd
 msgid "Close tab"
-msgstr "close tab"
+msgstr "Byebye Tab"
 
 #: src/autoload/State.gd
 msgid "Restore"
-msgstr "restore"
+msgstr "Restore"
 
 #: src/autoload/State.gd
 msgid "View in Inspector"
-msgstr "view in inspector"
+msgstr "Look In Inspector"
 
 #: src/autoload/State.gd src/ui_widgets/transform_popup.gd
 msgid "Convert to"
-msgstr "convert to"
+msgstr "Convert To"
 
 #: src/autoload/State.gd src/ui_widgets/transform_popup.gd
 msgid "Insert after"
-msgstr "insert after"
+msgstr "Insert After"
 
 #: src/autoload/State.gd
 msgid "Insert multiple after"
-msgstr "insert multiple after"
+msgstr "Insert Multiple After"
 
 #: src/autoload/State.gd
 msgid "The tab is bound to the file path {file_path}. Do you want to restore the SVG from this path?"
-msgstr "the tab is bound to da file paf {file_path}. does u wants to restore da svg from dis paf??"
+msgstr "Da Tab Is Bound To Da File Paf {file Path}. Does U Wants To Restore Da Svg From Dis Paf??"
 
 #: src/config_classes/Formatter.gd
 msgid "Compact"
-msgstr "compact"
+msgstr "Compact"
 
 #: src/config_classes/Formatter.gd
 msgid "Pretty"
-msgstr "pretty"
+msgstr "Pretty"
 
 #: src/config_classes/Formatter.gd
 msgid "Always"
-msgstr "always"
+msgstr "Always"
 
 #: src/config_classes/Formatter.gd
 msgid "All except containers"
-msgstr "all except containers"
+msgstr "All Except Containers"
 
 #: src/config_classes/Formatter.gd
 msgid "Never"
-msgstr "never"
+msgstr "Never"
 
 #: src/config_classes/Formatter.gd
 msgid "Spacious"
-msgstr "spacious"
+msgstr "Spacious"
 
 #: src/config_classes/Formatter.gd
 msgid "When shorter or equal"
-msgstr "when shorter or equal"
+msgstr "Wen Shorter Or Equal"
 
 #: src/config_classes/Formatter.gd
 msgid "When shorter"
-msgstr "when shorter"
+msgstr "Wen Shorter"
 
 #: src/config_classes/Formatter.gd
 msgid "3-digit or 6-digit hex"
-msgstr "3-digit or 6-digit hex"
+msgstr "3 Digit Or 6 Digit Hex"
 
 #: src/config_classes/Formatter.gd
 msgid "6-digit hex"
-msgstr "6-digit hex"
+msgstr "6 Digit Hex"
 
 #: src/config_classes/PreviewPresentationJPG.gd
 #: src/config_classes/PreviewPresentationLossyWEBP.gd
@@ -141,1553 +141,1553 @@ msgstr "6-digit hex"
 #: src/ui_widgets/export_properties_webp.gd
 #: src/ui_widgets/preview_presentation_popup.gd
 msgid "Quality"
-msgstr "quality"
+msgstr "Quality"
 
 #: src/config_classes/PreviewPresentationLossless.gd
 #: src/ui_widgets/export_properties_webp.gd
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Lossless"
-msgstr "lossless"
+msgstr "Lossless"
 
 #: src/config_classes/PreviewPresentationLossyWEBP.gd
 msgid "Lossy"
-msgstr "lossy"
+msgstr "Lossy"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd
 msgid "Dark"
-msgstr "dark"
+msgstr "Dark"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd
 msgid "Light"
-msgstr "light"
+msgstr "Light"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd
 msgid "Black (OLED)"
-msgstr "black (oled)"
+msgstr "Black (oled)"
 
 #. Refers to a theme preset.
 #: src/config_classes/SaveData.gd
 msgid "Gray"
-msgstr "gray"
+msgstr "Gray"
 
 #: src/config_classes/SaveData.gd
 msgid "Default Dark"
-msgstr "default dark"
+msgstr "Default Dark"
 
 #: src/config_classes/SaveData.gd
 msgid "Default Light"
-msgstr "default light"
+msgstr "Default Light"
 
 #: src/config_classes/TabData.gd
 msgid "Empty"
-msgstr "empty"
+msgstr "Empty"
 
 #: src/config_classes/TabData.gd
 msgid "Unsaved"
-msgstr "unsaved"
+msgstr "Unsaved"
 
 #: src/data_classes/BasicXNode.gd
 msgid "Comment"
-msgstr "comment"
+msgstr "Comment"
 
 #: src/data_classes/BasicXNode.gd
 msgid "Text"
-msgstr "text"
+msgstr "Text"
 
 #: src/data_classes/Element.gd
 msgid "{element} must be inside {allowed} to have any effect."
-msgstr "{element} must be inside {allowed} to have any effect"
+msgstr "{element} Must B Inside {allowed} To Have Any Effect!"
 
 #: src/data_classes/ElementBaseGradient.gd
 msgid "No \"id\" attribute defined."
-msgstr "no \"id\" attribute defined"
+msgstr "No \"id\" Attribute Defined"
 
 #: src/data_classes/ElementBaseGradient.gd
 msgid "No <stop> elements under this gradient."
-msgstr "no <stop> elementz under dis gradient"
+msgstr "No <stop> Elementz Under Dis Gradient"
 
 #: src/data_classes/ElementBaseGradient.gd
 msgid "This gradient is a solid color."
-msgstr "this gradient is a solid color"
+msgstr "Dis Gradient Is A Solid Color!!!"
 
 #: src/data_classes/ElementG.gd
 msgid "This group has no elements."
-msgstr "this group has no elements"
+msgstr "Dis Group Has No Elementz!"
 
 #: src/data_classes/ElementG.gd
 msgid "This group has only one element."
-msgstr "this group has only one element"
+msgstr "Dis Group Has Only One Element!!"
 
 #: src/data_classes/SVGParser.gd
 msgid "Doesn’t describe an SVG."
-msgstr "doesn’t describe an svg"
+msgstr "Doesn’t Describe An Svg!!"
 
 #: src/data_classes/SVGParser.gd
 msgid "Improper nesting."
-msgstr "improper nesting"
+msgstr "Improper Nesting!!!"
 
 #. If the language has different gendered versions, prefer the most neutral-sounding one, i.e., the one used when you don't know the person's gender. If that's not possible, use feminine.
 #: src/ui_parts/about_authors.gd
 msgid "Project Founder and Manager"
-msgstr "project founder and manager"
+msgstr "Project Founder N Manager"
 
 #: src/ui_parts/about_authors.gd
 msgid "Developers"
-msgstr "developers"
+msgstr "Developers"
 
 #: src/ui_parts/about_authors.gd
 msgid "Translators"
-msgstr "translators"
+msgstr "Translators"
 
 #: src/ui_parts/about_donors.gd src/ui_parts/about_menu.gd
 msgid "Donors"
-msgstr "donors"
+msgstr "Donors"
 
 #: src/ui_parts/about_donors.gd
 msgid "Golden donors"
-msgstr "golden donors"
+msgstr "Golden Donors"
 
 #: src/ui_parts/about_donors.gd
 msgid "Diamond donors"
-msgstr "diamond donors"
+msgstr "Diamond Donors"
 
 #: src/ui_parts/about_menu.gd
 msgid "Authors"
-msgstr "authors"
+msgstr "Authors"
 
 #: src/ui_parts/about_menu.gd
 msgid "License"
-msgstr "license"
+msgstr "License"
 
 #: src/ui_parts/about_menu.gd
 msgid "Third-party licenses"
-msgstr "third-party licenses"
+msgstr "Third Party Licenses"
 
 #: src/ui_parts/about_menu.gd src/ui_parts/good_file_dialog.gd
 #: src/ui_parts/settings_menu.gd src/ui_parts/shortcut_panel_config.gd
 #: src/ui_parts/update_menu.gd
 msgid "Close"
-msgstr "byebye"
+msgstr "Byebye"
 
 #: src/ui_parts/current_file_button.gd src/ui_parts/tab_bar.gd
 msgid "Save SVG as…"
-msgstr "save svg as…"
+msgstr "Save Svg As…"
 
 #: src/ui_parts/display.gd
 msgid "Visuals"
-msgstr "visuals"
+msgstr "Visuals"
 
 #: src/ui_parts/display.gd
 msgid "Snap size"
-msgstr "snap size"
+msgstr "Snap Size"
 
 #: src/ui_parts/display.gd
 msgid "Paste reference image"
-msgstr "paste reference image"
+msgstr "Paste Reference Image"
 
 #: src/ui_parts/display.gd
 msgid "Clear reference image"
-msgstr "clear reference image"
+msgstr "Clear Reference Image"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Links to donation platforms"
-msgstr "links to donation platforms"
+msgstr "Links To Donation Platforms"
 
 #: src/ui_parts/donate_menu.gd src/ui_parts/export_menu.gd
 #: src/ui_parts/import_warning_menu.gd src/ui_widgets/choose_name_dialog.gd
 #: src/ui_widgets/confirm_dialog.gd src/ui_widgets/options_dialog.gd
 msgid "Cancel"
-msgstr "cancelz"
+msgstr "Cancelz"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Hover a platform for details."
-msgstr "hover a platform for details"
+msgstr "Hover A Platform 4 Details"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Low extra fees"
-msgstr "low extra fees"
+msgstr "Low Extra Fees"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Can donate arbitrary amounts"
-msgstr "can donate arbitrary amounts"
+msgstr "Can Donate Arbitrary Amounts"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Higher extra fees"
-msgstr "higher extra fees"
+msgstr "Higher Extra Fees"
 
 #: src/ui_parts/donate_menu.gd
 msgid "Can't donate arbitrary amounts"
-msgstr "cant donate arbitrary amounts"
+msgstr "Cant Donate Arbitrary Amounts"
 
 #: src/ui_parts/element_container.gd
 msgid "New element"
-msgstr "new element"
+msgstr "New Element"
 
 #: src/ui_parts/export_menu.gd
 msgid "Dimensions"
-msgstr "dimensions"
+msgstr "Dimensions"
 
 #: src/ui_parts/export_menu.gd
 msgid "Preview image size is limited to {dimensions}"
-msgstr "preview image size is limited to {dimensions}"
+msgstr "Prelook Image Size Is Limited To {dimensions}"
 
 #: src/ui_parts/export_menu.gd
 msgid "Export Configuration"
-msgstr "export configuration"
+msgstr "Export Configuration"
 
 #: src/ui_parts/export_menu.gd
 msgid "Format"
-msgstr "fomat"
+msgstr "Fomat"
 
 #: src/ui_parts/export_menu.gd src/utils/TranslationUtils.gd
 msgid "Copy"
-msgstr "copy"
+msgstr "Copy"
 
 #: src/ui_parts/export_menu.gd src/ui_widgets/settings_content_generic.gd
 msgid "Size"
-msgstr "size"
+msgstr "Size"
 
 #: src/ui_parts/export_menu.gd
 msgid "Estimated size"
-msgstr "estimated size"
+msgstr "Estimated Size"
 
 #: src/ui_parts/global_actions.gd src/ui_parts/layout_configuration.gd
 #: src/ui_parts/shortcut_panel_config.gd
 msgid "Layout"
-msgstr "layout"
+msgstr "Layout"
 
 #: src/ui_parts/global_actions.gd
 msgid "View savedata"
-msgstr "view savedata"
+msgstr "Look Savedata"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Refresh files"
-msgstr "refresh files"
+msgstr "Refresh Files"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Toggle the visibility of hidden files"
-msgstr "toggle da visibility of hidden files"
+msgstr "Toggle Da Visibility Of Hidden Files"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Search files"
-msgstr "search files"
+msgstr "Search Files"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Go back"
-msgstr "go back"
+msgstr "Go Back"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Go forward"
-msgstr "go forward"
+msgstr "Go Forward"
 
 #: src/ui_parts/good_file_dialog.gd src/utils/FileUtils.gd
 msgid "Save"
-msgstr "save"
+msgstr "Save"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Select"
-msgstr "select"
+msgstr "Select"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Replace"
-msgstr "replace"
+msgstr "Replace"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Create new folder"
-msgstr "create new folder"
+msgstr "Create New Folder"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Invalid name for a folder."
-msgstr "invalid name for a folder"
+msgstr "Invalid Name 4 A Folder!!"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "A folder with this name already exists."
-msgstr "a folder with dis name already exists"
+msgstr "A Folder With Dis Name Already Exist!!"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Failed to create a folder."
-msgstr "failed to create a folder"
+msgstr "Failed To Create A Folder"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Open"
-msgstr "open"
+msgstr "Open"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Copy path"
-msgstr "copy path"
+msgstr "Copy Path"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "Open in File Manager"
-msgstr "open in file manager"
+msgstr "Open In File Manager"
 
 #: src/ui_parts/good_file_dialog.gd
 msgid "A file named \"{file_name}\" already exists. Replacing will overwrite its contents!"
-msgstr "a file named \"{file_name}\" already exist. replacing will overwrite its contents!"
+msgstr "A File Named \"{file Name}\" Already Exist. Replacing Will Overwrite Its Contents!"
 
 #: src/ui_parts/import_warning_menu.gd
 msgid "Syntax error"
-msgstr "syntax error"
+msgstr "Syntax Error"
 
 #: src/ui_parts/import_warning_menu.gd
 msgid "Unrecognized element"
-msgstr "unrecognized element"
+msgstr "Unrecognized Element"
 
 #: src/ui_parts/import_warning_menu.gd
 msgid "Unrecognized attribute"
-msgstr "unrecognized attribute"
+msgstr "Unrecognized Attribute"
 
 #: src/ui_parts/import_warning_menu.gd
 msgid "Import Problems"
-msgstr "import problems"
+msgstr "Import Problems"
 
 #: src/ui_parts/import_warning_menu.gd src/utils/TranslationUtils.gd
 msgid "Import"
-msgstr "import"
+msgstr "Import"
 
 #: src/ui_parts/inspector.gd
 msgid "Add element"
-msgstr "add element"
+msgstr "Add Element"
 
 #. Refers to the zero, one, or multiple UI parts to not be shown in the final layout. It's of plural cardinality.
 #: src/ui_parts/layout_configuration.gd
 msgid "Excluded"
-msgstr "excluded"
+msgstr "Excluded"
 
 #: src/ui_parts/layout_configuration.gd
 msgid "Drag and drop to change the layout"
-msgstr "drag and drop to change da layout"
+msgstr "Drag N Drop To Change Da Layout"
 
 #: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
 msgid "File"
-msgstr "file"
+msgstr "File"
 
 #: src/ui_parts/mac_menu.gd src/ui_parts/previews.gd
 #: src/ui_widgets/color_picker_layout_popup.gd
 #: src/ui_widgets/settings_content_shortcuts.gd
 msgid "Edit"
-msgstr "edit"
+msgstr "Edit"
 
 #: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
 msgid "Tool"
-msgstr "tool"
+msgstr "Tool"
 
 #: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
 msgid "View"
-msgstr "look"
+msgstr "Look"
 
 #: src/ui_parts/mac_menu.gd
 msgid "Window"
-msgstr "window"
+msgstr "Window"
 
 #: src/ui_parts/mac_menu.gd src/ui_widgets/settings_content_shortcuts.gd
 msgid "Help"
-msgstr "help"
+msgstr "Help"
 
 #: src/ui_parts/previews.gd
 msgid "Add preview"
-msgstr "add preview"
+msgstr "Add Preview"
 
 #: src/ui_parts/previews.gd src/ui_widgets/palette_config.gd
 #: src/ui_widgets/setting_shortcut.gd src/ui_widgets/transform_popup.gd
 #: src/utils/TranslationUtils.gd
 msgid "Delete"
-msgstr "delete"
+msgstr "Delete"
 
 #: src/ui_parts/previews.gd src/ui_widgets/setting_frame.gd
 #: src/ui_widgets/setting_shortcut.gd
 msgid "Reset to default"
-msgstr "reset to default"
+msgstr "Reset To Default"
 
 #: src/ui_parts/previews.gd
 msgid "Clear all"
-msgstr "clear all"
+msgstr "Clear All"
 
 #: src/ui_parts/previews.gd
 msgid "Sort"
-msgstr "sort"
+msgstr "Sort"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Formatting"
-msgstr "fomatting"
+msgstr "Fomatting"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Optimizer"
-msgstr "optimizer"
+msgstr "Optimizer"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Palettes"
-msgstr "palettes"
+msgstr "Palettes"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Shortcuts"
-msgstr "shortcuts"
+msgstr "Shortcuts"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Theming"
-msgstr "theming"
+msgstr "Theming"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Tab bar"
-msgstr "tab bar"
+msgstr "Tab Bar"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Other"
-msgstr "other"
+msgstr "Otter"
 
 #: src/ui_parts/settings_menu.gd
 msgid "Language"
-msgstr "language"
+msgstr "Language"
 
 #: src/ui_parts/shortcut_panel.gd
 msgid "Horizontal strip"
-msgstr "horizontal strip"
+msgstr "Horizontal Strip"
 
 #: src/ui_parts/shortcut_panel.gd
 msgid "Vertical strip"
-msgstr "vertical strip"
+msgstr "Vertical Strip"
 
 #: src/ui_parts/shortcut_panel.gd
 msgid "Horizontal with two rows"
-msgstr "horizontal with two rows"
+msgstr "Horizontal With Two Rows"
 
 #: src/ui_parts/shortcut_panel_config.gd
 msgid "Configure Shortcut Panel"
-msgstr "configure shortcut panel"
+msgstr "Configure Shortcut Panel"
 
 #: src/ui_parts/tab_bar.gd
 msgid "Close multiple"
-msgstr "close multiple"
+msgstr "Byebye Multiple"
 
 #: src/ui_parts/tab_bar.gd src/utils/TranslationUtils.gd
 msgid "Create a new tab"
-msgstr "create a new tab"
+msgstr "Create A New Tab"
 
 #: src/ui_parts/tab_bar.gd
 msgid "Scroll backwards"
-msgstr "scroll backwards"
+msgstr "Zoom Backwards"
 
 #: src/ui_parts/tab_bar.gd
 msgid "Scroll forwards"
-msgstr "scroll forwards"
+msgstr "Zoom Forwards"
 
 #: src/ui_parts/tab_bar.gd
 msgid "This SVG is not bound to a file location yet."
-msgstr "this svg is not bound to a file location yet"
+msgstr "Dis Svg Is Not Bound To A File Location Yet!!"
 
 #: src/ui_parts/update_menu.gd src/utils/FileUtils.gd
 msgid "Retry"
-msgstr "retry"
+msgstr "Retry"
 
 #: src/ui_parts/update_menu.gd
 msgid "Show prereleases"
-msgstr "show prereleases"
+msgstr "Show Prereleases"
 
 #: src/ui_parts/update_menu.gd
 msgid "Current Version"
-msgstr "current version"
+msgstr "Current Version"
 
 #: src/ui_parts/update_menu.gd
 msgid "Retrieving information..."
-msgstr "retrieving infomation.."
+msgstr "Retrieving Information..!!!"
 
 #. When checking for updates.
 #: src/ui_parts/update_menu.gd
 msgid "Update check failed"
-msgstr "update check failed"
+msgstr "Update Check Failed"
 
 #: src/ui_parts/update_menu.gd
 msgid "View all releases"
-msgstr "view all releases"
+msgstr "Look All Releases"
 
 #: src/ui_parts/update_menu.gd
 msgid "GodSVG is up-to-date."
-msgstr "godsvg is up-to-date"
+msgstr "Godsvg Is Up To Date!!"
 
 #: src/ui_parts/update_menu.gd
 msgid "New versions available!"
-msgstr "new versionz available!"
+msgstr "New Versions Available!!!"
 
 #: src/ui_widgets/PanelGrid.gd
 msgid "Copy email"
-msgstr "copy email"
+msgstr "Copy Email"
 
 #: src/ui_widgets/choose_name_dialog.gd
 msgid "Create"
-msgstr "create"
+msgstr "Create"
 
 #: src/ui_widgets/color_configuration_popup.gd
 msgid "Edit color name"
-msgstr "edit color name"
+msgstr "Edit Color Name"
 
 #: src/ui_widgets/color_configuration_popup.gd
 msgid "Delete color"
-msgstr "delete color"
+msgstr "Delete Color"
 
 #: src/ui_widgets/color_configuration_popup.gd src/ui_widgets/palette_config.gd
 msgid "Unnamed"
-msgstr "unnamed"
+msgstr "Unnamed"
 
 #. Ways to represent colors, like RGB, HSV, HSL.
 #: src/ui_widgets/color_picker_layout_popup.gd
 msgid "Color models"
-msgstr "color models"
+msgstr "Color Models"
 
 #: src/ui_widgets/color_picker_layout_popup.gd
 msgid "Move left"
-msgstr "move left"
+msgstr "Move Left"
 
 #: src/ui_widgets/color_picker_layout_popup.gd
 msgid "Move right"
-msgstr "move right"
+msgstr "Move Right"
 
 #: src/ui_widgets/color_picker_layout_popup.gd
 msgid "Remove"
-msgstr "remove"
+msgstr "Remove"
 
 #: src/ui_widgets/color_popup.gd
 msgid "Color utilities"
-msgstr "color utilities"
+msgstr "Color Utilities"
 
 #: src/ui_widgets/color_popup.gd
 msgid "Back to color picker"
-msgstr "back to color picker"
+msgstr "Back To Color Picker"
 
 #: src/ui_widgets/color_utilities_area.gd
 msgid "Search color"
-msgstr "search color"
+msgstr "Search Color"
 
 #: src/ui_widgets/export_properties_jpg.gd
 #: src/ui_widgets/export_properties_raster_lossless.gd
 #: src/ui_widgets/export_properties_webp.gd
 #: src/ui_widgets/preview_presentation_popup.gd
 msgid "Background"
-msgstr "background"
+msgstr "Background"
 
 #: src/ui_widgets/export_scale_config.gd
 msgid "Scale"
-msgstr "scale"
+msgstr "Scale"
 
 #: src/ui_widgets/export_scale_config.gd
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Width"
-msgstr "width"
+msgstr "Width"
 
 #: src/ui_widgets/export_scale_config.gd
 msgid "Height"
-msgstr "height"
+msgstr "Height"
 
 #: src/ui_widgets/file_path_edit.gd
 msgid "No file path"
-msgstr "no file path"
+msgstr "No File Path"
 
 #: src/ui_widgets/good_color_picker.gd
 msgid "Color keywords"
-msgstr "color keywords"
+msgstr "Color Keywords"
 
 #: src/ui_widgets/good_color_picker.gd
 msgid "Eyedropper"
-msgstr "eyedropper"
+msgstr "Eyedropper"
 
 #: src/ui_widgets/handles_manager.gd
 msgid "New shape"
-msgstr "new shape"
+msgstr "New Shape"
 
 #: src/ui_widgets/id_field.gd
 msgid "No ID"
-msgstr "no id"
+msgstr "No Id"
 
 #. Refers to a number of points.
 #: src/ui_widgets/insert_multiple_points_popup.gd
 msgid "Points to insert"
-msgstr "points to insert"
+msgstr "Points To Insert"
 
 #: src/ui_widgets/invalid_syntax_warning.gd
 msgid "The SVG has invalid syntax. Any edit not made through the code editor will reset it."
-msgstr "the svg has invalid syntax. any edit not made through da code editor will reset it"
+msgstr "Da Svg Has Invalid Syntax. Any Edit Not Made Through Da Code Editor Will Reset It"
 
 #: src/ui_widgets/optimizer_setting_info.gd
 msgid "Before"
-msgstr "before"
+msgstr "Before"
 
 #: src/ui_widgets/optimizer_setting_info.gd
 msgid "After"
-msgstr "after"
+msgstr "After"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Unnamed palettes won't be shown."
-msgstr "unnamed palettes wont be shown"
+msgstr "Unnamed Palettes Wont B Shown"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Multiple palettes can't have the same name."
-msgstr "multiple palettes cant have da same name"
+msgstr "Multiple Palettes Cant Have Da Same Name!"
 
 #: src/ui_widgets/palette_config.gd
 msgid "This palette has identically defined colors."
-msgstr "this palette has identically defined colors"
+msgstr "Dis Palette Has Identically Defined Colorz!!!"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Rename"
-msgstr "rename"
+msgstr "Rename"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Apply Preset"
-msgstr "apply preset"
+msgstr "Apply Preset"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Move Up"
-msgstr "move up"
+msgstr "Move Up"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Move Down"
-msgstr "move down"
+msgstr "Move Down"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Copy as XML"
-msgstr "copy as xml"
+msgstr "Copy As Xml"
 
 #: src/ui_widgets/palette_config.gd
 msgid "Save as XML"
-msgstr "save as xml"
+msgstr "Save As Xml"
 
 #: src/ui_widgets/path_convert_popup.gd
 msgid "Exact conversions"
-msgstr "exact conversions"
+msgstr "Exact Conversions"
 
 #: src/ui_widgets/path_convert_popup.gd
 msgid "Lossy conversions"
-msgstr "lossy conversions"
+msgstr "Lossy Conversions"
 
 #: src/ui_widgets/path_insert_popup.gd src/utils/TranslationUtils.gd
 msgid "Relative"
-msgstr "relative"
+msgstr "Relative"
 
 #: src/ui_widgets/path_insert_popup.gd
 msgid "Keep open"
-msgstr "keep open"
+msgstr "Keep Open"
 
 #: src/ui_widgets/path_insert_popup.gd
 msgid "If toggled off, you must hold {keys} when selecting a path command to keep the popup open."
-msgstr "if toggled off you must hold {keys} wen selecting a paf command to keep da popup open"
+msgstr "If Toggled Off You Must Hold {keys} Wen Selecting A Paf Commn To Keep Da Popup Open!"
 
 #: src/ui_widgets/pathdata_field.gd
 msgid "No path data"
-msgstr "no paf data"
+msgstr "No Paf Data"
 
 #: src/ui_widgets/points_field.gd
 msgid "No points"
-msgstr "no points"
+msgstr "No Points"
 
 #: src/ui_widgets/presented_shortcut.gd src/ui_widgets/setting_shortcut.gd
 msgid "Also used by"
-msgstr "also used by"
+msgstr "Also Used By"
 
 #: src/ui_widgets/profile_frame.gd
 msgid "Apply"
-msgstr "apply"
+msgstr "Apply"
 
 #: src/ui_widgets/profile_frame.gd
 msgid "Apply all of this preset's defaults"
-msgstr "apply all of dis presets defaults"
+msgstr "Apply All Of Dis Presets Defaults"
 
 #. This is not an answer to a Yes/No question, but a statement about a state. Translate according to the language's natural state labels (e.g. Activated/Deactivated, Active/Inactive, Enabled/Disabled). Prefer short translations; if a common abbreviation exists, use it.
 #: src/ui_widgets/setting_frame.gd
 msgid "On"
-msgstr "on"
+msgstr "On"
 
 #. This is not an answer to a Yes/No question, but a statement about a state. Translate according to the language's natural state labels (e.g. Activated/Deactivated, Active/Inactive, Enabled/Disabled). Prefer short translations; if a common abbreviation exists, use it.
 #: src/ui_widgets/setting_frame.gd
 msgid "Off"
-msgstr "off"
+msgstr "Off"
 
 #: src/ui_widgets/setting_frame.gd
 msgid "Clear"
-msgstr "clear"
+msgstr "Clear"
 
 #: src/ui_widgets/setting_shortcut.gd
 msgid "Unused"
-msgstr "unused"
+msgstr "Unused"
 
 #: src/ui_widgets/setting_shortcut.gd
 msgid "Add shortcut"
-msgstr "add shortcut"
+msgstr "Add Shortcut"
 
 #: src/ui_widgets/setting_shortcut.gd
 msgid "Press keys…"
-msgstr "pres keys…"
+msgstr "Pres Keys…"
 
 #. Refers to the formatter used for GodSVG's code editor.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Editor formatter"
-msgstr "editor fomatter"
+msgstr "Editor Fomatter"
 
 #. Refers to the formatter used when exporting.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Export formatter"
-msgstr "export fomatter"
+msgstr "Export Fomatter"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines how SVG attributes and content appear in the GodSVG interface."
-msgstr "determines how svg attributez and content appear in da godsvg interface"
+msgstr "Determines How Svg Attributez N Content Appear In Da Godsvg Interface!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines how SVG attributes and content are formatted when saving the file."
-msgstr "determines how svg attributez and content are fomatted wen saving da file"
+msgstr "Determines How Svg Attributez N Content Are Fomatted Wen Saving Da File"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Preset"
-msgstr "preset"
+msgstr "Preset"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Add trailing newline"
-msgstr "add trailing newline"
+msgstr "Add Trailing Newline"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use shorthand tag syntax"
-msgstr "use shorthand tag syntax"
+msgstr "Use Shorthn Tag Syntax"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Space out the slash of shorthand tags"
-msgstr "space out da slash of shorthand tags"
+msgstr "Space Out Da Slash Of Shorthn Tags"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Formatting style"
-msgstr "fomatting style"
+msgstr "Fomatting Style"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use spaces instead of tabs"
-msgstr "use spaces instead of tabs"
+msgstr "Use Spaces Instead Of Tabs"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Number of indentation spaces"
-msgstr "number of indentation spaces"
+msgstr "Number Of Indentation Spaces"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Numbers"
-msgstr "numbers"
+msgstr "Numbers"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Remove leading zero"
-msgstr "remove leading zero"
+msgstr "Remove Leading Zero"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use exponential when shorter"
-msgstr "use exponential wen shorter"
+msgstr "Use Exponential Wen Shorter"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Colors"
-msgstr "colorz"
+msgstr "Colorz"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use named colors"
-msgstr "use named colors"
+msgstr "Use Named Colors"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Primary syntax"
-msgstr "primary syntax"
+msgstr "Primary Syntax"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Capitalize hexadecimal letters"
-msgstr "capitalize hexadecimal letters"
+msgstr "Capitalize Hexadecimal Letters"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Pathdata"
-msgstr "pathdata"
+msgstr "Pathdata"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Compress numbers"
-msgstr "compres numbers"
+msgstr "Compres Numbers"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Minimize spacing"
-msgstr "minimize spacing"
+msgstr "Minimize Spacing"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Remove spacing after flags"
-msgstr "remove spacing after flags"
+msgstr "Remove Spacing After Flags"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Remove consecutive commands"
-msgstr "remove consecutive commands"
+msgstr "Remove Consecutive Commands"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Transform lists"
-msgstr "transform lists"
+msgstr "Transform Lists"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Remove unnecessary parameters"
-msgstr "remove unnecessary parameters"
+msgstr "Remove Unnecessary Parameters"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the settings for the default optimizer, used when manually running the \"{optimize}\" action."
-msgstr "determines da settings for da default optimizer used wen manually running da \"{optimize}\" action"
+msgstr "Determines Da Settings 4 Da Default Optimizer Used Wen Manually Running Da \"{optimize}\" Action!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Remove comments"
-msgstr "remove comments"
+msgstr "Remove Comments"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Convert shapes"
-msgstr "convert shapes"
+msgstr "Convert Shapes"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Simplify paths"
-msgstr "simplify paths"
+msgstr "Simplify Paths"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Theme preset"
-msgstr "theme preset"
+msgstr "Theme Preset"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Primary theme colors"
-msgstr "primary theme colors"
+msgstr "Primary Theme Colors"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Base color"
-msgstr "base color"
+msgstr "Base Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Accent color"
-msgstr "accent color"
+msgstr "Accent Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Fonts"
-msgstr "fonts"
+msgstr "Fonts"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Main font"
-msgstr "main font"
+msgstr "Main Font"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Bold font"
-msgstr "bold font"
+msgstr "Bold Font"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Mono font"
-msgstr "mono font"
+msgstr "Mono Font"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "SVG Text colors"
-msgstr "svg text colors"
+msgstr "Svg Text Colors"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Highlighter preset"
-msgstr "highlighter preset"
+msgstr "Highlighter Preset"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the default values of SVG highlighter settings."
-msgstr "determines da default values of svg highlighter settings"
+msgstr "Determines Da Default Values Of Svg Highlighter Settings!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Symbol color"
-msgstr "symbol color"
+msgstr "Symbol Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Element color"
-msgstr "element color"
+msgstr "Element Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Attribute color"
-msgstr "attribute color"
+msgstr "Attribute Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "String color"
-msgstr "string color"
+msgstr "String Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Comment color"
-msgstr "comment color"
+msgstr "Comment Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Text color"
-msgstr "text color"
+msgstr "Text Color"
 
 #. XML entities (&quot;, &amp;, &apos;, &gt;, and &lt;) are strings representing certain symbols with syntax importance that would break a text section if typed out.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "XML entity color"
-msgstr "xml entity color"
+msgstr "Xml Entity Color"
 
 #. CDATA shouldn't be translated. It's a type of XML section.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "CDATA color"
-msgstr "cdata color"
+msgstr "Cdata Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Error color"
-msgstr "error color"
+msgstr "Bad Color"
 
 #. Refers to the draggable gizmos.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Handles"
-msgstr "handles"
+msgstr "Handles"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Inside color"
-msgstr "inside color"
+msgstr "Inside Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Normal color"
-msgstr "normal color"
+msgstr "Normal Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Hovered color"
-msgstr "hovered color"
+msgstr "Hovered Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Selected color"
-msgstr "selected color"
+msgstr "Selected Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Hovered selected color"
-msgstr "hovered selected color"
+msgstr "Hovered Selected Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Selection rectangle"
-msgstr "selection rectangle"
+msgstr "Selection Rectangle"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Speed"
-msgstr "speed"
+msgstr "Speed"
 
 #. Refers to the selection rectangle's animated dashed stroke.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Dash length"
-msgstr "dash length"
+msgstr "Dash Length"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Color {index}"
-msgstr "color {index}"
+msgstr "Color {index}"
 
 #: src/ui_widgets/settings_content_generic.gd src/utils/TranslationUtils.gd
 msgid "Canvas"
-msgstr "canvas"
+msgstr "Canvas"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Canvas color"
-msgstr "canvas color"
+msgstr "Canvas Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Grid color"
-msgstr "grid color"
+msgstr "Grid Color"
 
 #. Refers to the specially marked grid ticks, which are more distinct and have a coordinate.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Grid tick interval"
-msgstr "grid tick interval"
+msgstr "Grid Tick Interval"
 
 #. Refers to the specially marked grid ticks, which are more distinct and have a coordinate.
 #: src/ui_widgets/settings_content_generic.gd
 msgid "No ticks"
-msgstr "no ticks"
+msgstr "No Ticks"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Basic colors"
-msgstr "basic colors"
+msgstr "Basic Colors"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Valid color"
-msgstr "valid color"
+msgstr "Valid Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Warning color"
-msgstr "warning color"
+msgstr "Warning Color"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Input"
-msgstr "input"
+msgstr "Input"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Close tabs with middle mouse button"
-msgstr "close tabs with middle mouse button"
+msgstr "Byebye Tabs With Middle Mouse Button"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Invert zoom direction"
-msgstr "invert zoomie direction"
+msgstr "Invert Zoomie Direction"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Pan with left mouse button"
-msgstr "pan with left mouse button"
+msgstr "Pan With Left Mouse Button"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Wrap-around panning"
-msgstr "wrap-around panning"
+msgstr "Wrap Around Panning"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Panning speed"
-msgstr "panning speed"
+msgstr "Panning Speed"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use CTRL for zooming"
-msgstr "use ctrl for zooming"
+msgstr "Use Ctrl 4 Zooming"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Display"
-msgstr "display"
+msgstr "Display"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "UI scale"
-msgstr "ui scale"
+msgstr "Ui Scale"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the scale factor for the interface."
-msgstr "determines da scale factor for da interface"
+msgstr "Determines Da Scale Factor 4 Da Interface"
 
 #. Stands for "Vertical Synchronization".
 #: src/ui_widgets/settings_content_generic.gd
 msgid "V-Sync"
-msgstr "input lag (vsync)"
+msgstr "Input Lag (vsync)"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Maximum FPS"
-msgstr "maximum fps"
+msgstr "Maximum Fps"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Unlimited"
-msgstr "unlimited"
+msgstr "Unlimited"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the maximum number of frames per second."
-msgstr "determines da maximum number of frames per second"
+msgstr "Determines Da Maximum Number Of Frames Per Second!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Keep screen on"
-msgstr "keep screen on"
+msgstr "Keep Screen On"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Miscellaneous"
-msgstr "miscellaneous"
+msgstr "Miscellaneous"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Use native file dialog"
-msgstr "use native file dialog"
+msgstr "Use Native File Dialog"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Sync window title to file name"
-msgstr "sync window title to file name"
+msgstr "Sync Window Title To File Name"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "The setting has no effect in the current configuration."
-msgstr "the setting has no effect in da current configuration"
+msgstr "Da Setting Has No Effect In Da Current Configuration!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "The setting can't be changed on this platform."
-msgstr "the setting cant be changed on dis platform"
+msgstr "Da Setting Cant B Changed On Dis Platform!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, the left mouse button can be used to pan the canvas."
-msgstr "when enabled da left mouse button can b used to pan da canvas"
+msgstr "Wen Enabled Da Left Mouse Button Can B Used To Pan Da Canvas!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Formatters can change the formatting of the SVG's content and attributes. These changes don't affect its structure or the structure of more complex attributes, such as pathdata. Formatters can be configured to make the SVG prettier or more compact."
-msgstr "fomatters can change da fomatting of da svgs content and attributez. deez changes dont affect its structure or da structure of more complex attributez such as pathdata. fomatters can b configured to make da svg pretty or more compact"
+msgstr "Fomatters Can Change Da Fomatting Of Da Svgs Content N Attributez. Deez Changes Dont Affect Its Structure Or Da Structure Of More Complex Attributez Such As Pathdata. Fomatters Can B Configured To Make Da Svg Pretty Or More Compact!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the default values of the formatter configs."
-msgstr "determines da default values of da fomatter configs"
+msgstr "Determines Da Default Values Of Da Fomatter Configs!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, uses spaces instead of a single tab for indentation."
-msgstr "when enabled uses spaces instead of a single tab for indentation"
+msgstr "Wen Enabled Uses Spaces Instead Of A Single Tab 4 Indentation!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Optimizers can change the structure of the SVG and its complex attributes, such as pathdata. These changes reduce the SVG's complexity, usually leading to reductions in file size, but may be destructive and disrupt future editing, compared to optimizing the SVG manually."
-msgstr "optimizers can change da structure of da svg and its complex attributez such as pathdata. deez changes reduce da svgs complexity usually leading to reductions in file size but maybe destructive and disrupt future editing compared to optimizing da svg manually"
+msgstr "Optimizers Can Change Da Structure Of Da Svg N Its Complex Attributez Such As Pathdata. Deez Changes Reduce Da Svgs Complexity Usually Leading To Reductions In File Size But Mayb Destructive N Disrupt Future Editing Compared To Optimizing Da Svg Manually!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Convert shapes into ones that can be defined identically, but have a shorter representation, if possible."
-msgstr "convert shapes into ones that can b defined identically but have a shorter representation if possible"
+msgstr "Convert Shapes Into Ones That Can B Defined Identically But Have A Shorter Representation If Possible!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Converts or simplifies path commands into ones with identical definition, but shorter representation, if possible."
-msgstr "converts or simplifies paf commands into ones with identical definition but shorter representation if possible"
+msgstr "Converts Or Simplifies Paf Commands Into Ones With Identical Definition But Shorter Representation If Possible"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the default values of theming-related settings, including the highlighter preset."
-msgstr "determines da default values of theming-related settings including da highlighter preset"
+msgstr "Determines Da Default Values Of Theming Related Settings Including Da Highlighter Preset!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the base color of GodSVG's interface."
-msgstr "determines da base color of godsvg interface"
+msgstr "Determines Da Base Color Of Godsvg Interface!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines the accent color used for highlighted elements in GodSVG's interface."
-msgstr "determines da accent color used for highlighted elementz in godsvg interface"
+msgstr "Determines Da Accent Color Used 4 Highlighted Elementz In Godsvg Interface!!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, clicking on a tab with the middle mouse button closes it instead of simply focusing it."
-msgstr "when enabled clicking on a tab with da middle mouse button closes it instead of simply focusing it"
+msgstr "Wen Enabled Clicking On A Tab With Da Middle Mouse Button Closes It Instead Of Simply Focusing It"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Swaps the scroll directions for zooming in and zooming out."
-msgstr "swaps da scroll directions for zooming in and zooming out"
+msgstr "Swaps Da Zoom Directions 4 Zooming In N Zooming Out!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Warps the cursor to the opposite side whenever it reaches a canvas boundary while panning."
-msgstr "warps da cursor to da opposite side whenever it reaches a canvas boundary while panning"
+msgstr "Warps Da Cursor To Da Opposite Side Whenever It Reaches A Canvas Boundary While Panning"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Determines how much the view moves for scroll-based panning inputs."
-msgstr "determines how much da look moves for scroll-based panning inputs"
+msgstr "Determines How Much Da Look Moves 4 Scroll Based Panning Inputs"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, scrolling pans the view instead of zooming in. To zoom, hold CTRL while scrolling."
-msgstr "when enabled scrolling pans da look instead of zooming in. to zoomie hold ctrl while scrolling"
+msgstr "Wen Enabled Scrolling Pans Da Look Instead Of Zooming In. To Zoomie Hold Ctrl While Scrolling!!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. May increase input lag slightly."
-msgstr "synchronizes graphics rendering with display refresh rate to prevent screen tearing artifacts. may increase input lag slightly"
+msgstr "Synchronizes Graphics Rendering With Display Refresh Rate To Prevent Screen Tearing Artifacts. May Increase Input Lag Slightly"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "Keeps the screen on even after inactivity, so the screensaver does not take over."
-msgstr "keeps da screen on even after inactivity so da screensaver does not take over"
+msgstr "Keeps Da Screen On Even After Inactivity So Da Screensaver Does Not Take Over"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, uses your operating system's native file dialog instead of GodSVG's built-in one."
-msgstr "when enabled uses your operating systems native file dialog instead of godsvg built-in one"
+msgstr "Wen Enabled Uses Your Operating Systems Native File Dialog Instead Of Godsvg Built In One!"
 
 #: src/ui_widgets/settings_content_generic.gd
 msgid "When enabled, adds the current file name before the \"GodSVG\" window title."
-msgstr "when enabled adds da current file name before da \"godsvg\" window title"
+msgstr "Wen Enabled Adds Da Current File Name Before Da \"godsvg\" Window Title"
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "New palette"
-msgstr "new palette"
+msgstr "New Palette"
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "New palette from XML"
-msgstr "new palette from xml"
+msgstr "New Palette From Xml"
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Import XML"
-msgstr "import xml"
+msgstr "Import Xml"
 
 #: src/ui_widgets/settings_content_palettes.gd
 msgid "Paste XML"
-msgstr "paste xml"
+msgstr "Paste Xml"
 
 #: src/ui_widgets/transform_field.gd
 msgid "No transforms"
-msgstr "no transforms"
+msgstr "No Transforms"
 
 #: src/ui_widgets/transform_popup.gd
 msgid "Apply the matrix"
-msgstr "apply da matrix"
+msgstr "Apply Da Matrix"
 
 #: src/ui_widgets/transform_popup.gd
 msgid "Insert before"
-msgstr "insert before"
+msgstr "Insert Before"
 
 #: src/ui_widgets/transform_popup.gd
 msgid "New transform"
-msgstr "new transform"
+msgstr "New Transform"
 
 #: src/ui_widgets/unrecognized_field.gd
 msgid "GodSVG doesn’t recognize this attribute"
-msgstr "godsvg doesn’t recognize dis attribute"
+msgstr "Godsvg Doesn’t Recognize Dis Attribute"
 
 #: src/utils/FileUtils.gd
 msgid "The following files were discarded:"
-msgstr "the following filez were discarded:"
+msgstr "Da Following Filez Were Discarded:"
 
 #: src/utils/FileUtils.gd
 msgid "{file_name} was discarded."
-msgstr "{file_name} was discarded"
+msgstr "{file Name} Was Discarded!"
 
 #: src/utils/FileUtils.gd
 msgid "Discarded files"
-msgstr "discarded files"
+msgstr "Boomed Files"
 
 #: src/utils/FileUtils.gd
 msgid "Proceed"
-msgstr "proceed"
+msgstr "Proceed"
 
 #: src/utils/FileUtils.gd
 msgid "{file_name} couldn't be opened."
-msgstr "{file_name} couldnt be opened"
+msgstr "{file Name} Couldn't Be Opened!!!!!"
 
 #: src/utils/FileUtils.gd
 msgid "Check if the file still exists in the selected file path."
-msgstr "check if da file still exist in da selected file path"
+msgstr "Check If Da File Still Exist In Da Selected File Paf!!"
 
 #: src/utils/FileUtils.gd
 msgid "Proceed with importing the rest of the files?"
-msgstr "proceed with importing da rest of da filez??"
+msgstr "Proceed With Importing Da Rest Of Da Filez??"
 
 #: src/utils/FileUtils.gd
 msgid "Proceed for all files that can't be opened"
-msgstr "proceed for all filez that cant be opened"
+msgstr "Proceed 4 All Filez That Cant B Opened"
 
 #: src/utils/FileUtils.gd
 msgid "Save the file?"
-msgstr "save da file??"
+msgstr "Save Da File??"
 
 #: src/utils/FileUtils.gd
 msgid "Do you want to save this file?"
-msgstr "does u wants to save dis file??"
+msgstr "Does U Wants To Save Dis File??"
 
 #: src/utils/FileUtils.gd
 msgid "Save the changes?"
-msgstr "save da changes??"
+msgstr "Save Da Changes??"
 
 #: src/utils/FileUtils.gd
 msgid "Your changes will be lost if you don't save them."
-msgstr "your changes will be lost if you dont save them"
+msgstr "Your Changes Will B Lost If You Dont Save Them!"
 
 #: src/utils/FileUtils.gd
 msgid "Don't save"
-msgstr "dont save"
+msgstr "Dont Save"
 
 #: src/utils/FileUtils.gd
 msgid "{file_path} is already being edited inside GodSVG."
-msgstr "{file_path} is already being edited inside godsvg"
+msgstr "{file Path} Is Already Being Edited Inside Godsvg"
 
 #: src/utils/FileUtils.gd
 msgid "If you want to discard your edits and sync to the file's current content, use \"{reset_svg}\"."
-msgstr "if you wants to discard your edits and sync to da filez current content use \"{reset_svg}\""
+msgstr "If You Wants To Discard Your Edits N Sync To Da Filez Current Content Use \"{reset Svg}\"!!!"
 
 #: src/utils/FileUtils.gd
 msgid "Do you want to save the changes made to {file_name}?"
-msgstr "does u wants to save da changes made to {file_name}??"
+msgstr "Does U Wants To Save Da Changes Made To {file Name}??"
 
 #: src/utils/TranslationUtils.gd
 msgid "Save SVG"
-msgstr "save svg"
+msgstr "Save Svg"
 
 #: src/utils/TranslationUtils.gd
 msgid "Save SVG as"
-msgstr "save svg as"
+msgstr "Save Svg As"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close tabs to the left"
-msgstr "close tabs to da left"
+msgstr "Byebye Tabs To Da Left"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close tabs to the right"
-msgstr "close tabs to da right"
+msgstr "Byebye Tabs To Da Right"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close all other tabs"
-msgstr "close all other tabs"
+msgstr "Byebye All Otter Tabs"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close empty tabs"
-msgstr "close empty tabs"
+msgstr "Byebye Empty Tabs"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close saved tabs"
-msgstr "close saved tabs"
+msgstr "Byebye Saved Tabs"
 
 #: src/utils/TranslationUtils.gd
 msgid "Create tab"
-msgstr "create tab"
+msgstr "Create Tab"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select the next tab"
-msgstr "select da next tab"
+msgstr "Select Da Next Tab"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select the previous tab"
-msgstr "select da previus tab"
+msgstr "Select Da Previus Tab"
 
 #: src/utils/TranslationUtils.gd
 msgid "Optimize"
-msgstr "optimize"
+msgstr "Optimize"
 
 #: src/utils/TranslationUtils.gd
 msgid "Optimize SVG"
-msgstr "optimize svg"
+msgstr "Optimize Svg"
 
 #: src/utils/TranslationUtils.gd
 msgid "Copy all text"
-msgstr "copy all text"
+msgstr "Copy All Text"
 
 #: src/utils/TranslationUtils.gd
 msgid "Copy the SVG text"
-msgstr "copy da svg text"
+msgstr "Copy Da Svg Text"
 
 #: src/utils/TranslationUtils.gd
 msgid "Reset SVG"
-msgstr "reset svg"
+msgstr "Reset Svg"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open externally"
-msgstr "open externally"
+msgstr "Open Externally"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open SVG externally"
-msgstr "open svg externally"
+msgstr "Open Svg Externally"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show in File Manager"
-msgstr "show in file manager"
+msgstr "Show In File Manager"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show SVG in File Manager"
-msgstr "show svg in file manager"
+msgstr "Show Svg In File Manager"
 
 #: src/utils/TranslationUtils.gd
 msgid "Undo"
-msgstr "undo"
+msgstr "Undo"
 
 #: src/utils/TranslationUtils.gd
 msgid "Redo"
-msgstr "redo"
+msgstr "Redo"
 
 #: src/utils/TranslationUtils.gd
 msgid "Paste"
-msgstr "paste"
+msgstr "Paste"
 
 #: src/utils/TranslationUtils.gd
 msgid "Cut"
-msgstr "cut"
+msgstr "Cut"
 
 #. Refers to evaluating an expression such as "sin(2*pi/5)".
 #: src/utils/TranslationUtils.gd
 msgid "Evaluate"
-msgstr "evaluate"
+msgstr "Evaluate"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select all"
-msgstr "select all"
+msgstr "Select All"
 
 #: src/utils/TranslationUtils.gd
 msgid "Duplicate"
-msgstr "duplicate"
+msgstr "Duplicate"
 
 #: src/utils/TranslationUtils.gd
 msgid "Duplicate the selection"
-msgstr "duplicate da selection"
+msgstr "Duplicate Da Selection"
 
 #: src/utils/TranslationUtils.gd
 msgid "Delete the selection"
-msgstr "delete da selection"
+msgstr "Delete Da Selection"
 
 #: src/utils/TranslationUtils.gd
 msgid "Move up"
-msgstr "move up"
+msgstr "Move Up"
 
 #: src/utils/TranslationUtils.gd
 msgid "Move the selection up"
-msgstr "move da selection up"
+msgstr "Move Da Selection Up"
 
 #: src/utils/TranslationUtils.gd
 msgid "Move down"
-msgstr "move down"
+msgstr "Move Down"
 
 #: src/utils/TranslationUtils.gd
 msgid "Move the selection down"
-msgstr "move da selection down"
+msgstr "Move Da Selection Down"
 
 #. Refers to, for example, changing which point in a polygon counts as "first".
 #: src/utils/TranslationUtils.gd
 msgid "Set as initial"
-msgstr "set as initial"
+msgstr "Set As Initial"
 
 #: src/utils/TranslationUtils.gd
 msgid "Set point as initial"
-msgstr "set point as initial"
+msgstr "Set Point As Initial"
 
 #: src/utils/TranslationUtils.gd
 msgid "Reverse order"
-msgstr "reverse order"
+msgstr "Reverse Order"
 
 #: src/utils/TranslationUtils.gd
 msgid "Find"
-msgstr "find"
+msgstr "Find"
 
 #: src/utils/TranslationUtils.gd
 msgid "Zoom in"
-msgstr "zoom in"
+msgstr "Zoomie In"
 
 #: src/utils/TranslationUtils.gd
 msgid "Zoom out"
-msgstr "zoom out"
+msgstr "Zoomie Out"
 
 #: src/utils/TranslationUtils.gd
 msgid "Zoom reset"
-msgstr "zoom reset"
+msgstr "Zoomie Reset"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show grid"
-msgstr "show grid"
+msgstr "Show Grid"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show handles"
-msgstr "show handles"
+msgstr "Show Handles"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show rasterized SVG"
-msgstr "show rasterized svg"
+msgstr "Show Rasterized Svg"
 
 #: src/utils/TranslationUtils.gd
 msgid "Toggle snapping"
-msgstr "toggle snapping"
+msgstr "Toggle Snapping"
 
 #: src/utils/TranslationUtils.gd
 msgid "Load reference image"
-msgstr "load reference image"
+msgstr "Load Reference Image"
 
 #: src/utils/TranslationUtils.gd
 msgid "Show reference image"
-msgstr "show reference image"
+msgstr "Show Reference Image"
 
 #: src/utils/TranslationUtils.gd
 msgid "Overlay reference image"
-msgstr "overlay reference image"
+msgstr "Overlay Reference Image"
 
 #: src/utils/TranslationUtils.gd
 msgid "View debug information"
-msgstr "view antibug infomation"
+msgstr "Look Antibuggy Infomation"
 
 #: src/utils/TranslationUtils.gd
 msgid "View advanced debug information"
-msgstr "view advanced antibug infomation"
+msgstr "Look Advanced Antibuggy Infomation"
 
 #: src/utils/TranslationUtils.gd
 msgid "Settings"
-msgstr "settings"
+msgstr "Settings"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open Settings menu"
-msgstr "open settings menu"
+msgstr "Open Settings Menu"
 
 #: src/utils/TranslationUtils.gd
 msgid "About…"
-msgstr "about…"
+msgstr "About…"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open About menu"
-msgstr "open about menu"
+msgstr "Open About Menu"
 
 #: src/utils/TranslationUtils.gd
 msgid "Donate…"
-msgstr "donate…"
+msgstr "Donate…"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open Donate menu"
-msgstr "open donate menu"
+msgstr "Open Donate Menu"
 
 #: src/utils/TranslationUtils.gd
 msgid "GodSVG repository"
-msgstr "godsvg repository"
+msgstr "Godsvg Repository"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open GodSVG repository"
-msgstr "open godsvg repository"
+msgstr "Open Godsvg Repository"
 
 #: src/utils/TranslationUtils.gd
 msgid "GodSVG website"
-msgstr "godsvg website"
+msgstr "Godsvg Website"
 
 #: src/utils/TranslationUtils.gd
 msgid "Open GodSVG website"
-msgstr "open godsvg website"
+msgstr "Open Godsvg Website"
 
 #: src/utils/TranslationUtils.gd
 msgid "Check for updates"
-msgstr "check for updates"
+msgstr "Check 4 Updates"
 
 #: src/utils/TranslationUtils.gd
 msgid "Quit the application"
-msgstr "quit da application"
+msgstr "Kthxbye Da Application"
 
 #: src/utils/TranslationUtils.gd
 msgid "Toggle fullscreen"
-msgstr "toggle fullscreen"
+msgstr "Toggle Fullscreen"
 
 #: src/utils/TranslationUtils.gd
 msgid "Move to"
-msgstr "move to"
+msgstr "Move To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Line to"
-msgstr "line to"
+msgstr "Line To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Horizontal Line to"
-msgstr "horizontal line to"
+msgstr "Horizontal Line To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Vertical Line to"
-msgstr "vertical line to"
+msgstr "Vertical Line To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Close Path"
-msgstr "close path"
+msgstr "Byebye Path"
 
 #: src/utils/TranslationUtils.gd
 msgid "Elliptical Arc to"
-msgstr "elliptical arc to"
+msgstr "Elliptical Arc To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Quadratic Bezier to"
-msgstr "quadratic bezier to"
+msgstr "Quadratic Bezier To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Quadratic Bezier to"
-msgstr "shorthand quadratic bezier to"
+msgstr "Shorthn Quadratic Bezier To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Cubic Bezier to"
-msgstr "cubic bezier to"
+msgstr "Cubic Bezier To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Shorthand Cubic Bezier to"
-msgstr "shorthand cubic bezier to"
+msgstr "Shorthn Cubic Bezier To"
 
 #: src/utils/TranslationUtils.gd
 msgid "Absolute"
-msgstr "absolute"
+msgstr "Absolute"
 
 #: src/utils/TranslationUtils.gd
 msgid "Code Editor"
-msgstr "code editor"
+msgstr "Code Editor"
 
 #: src/utils/TranslationUtils.gd
 msgid "Inspector"
-msgstr "inspector"
+msgstr "Inspector"
 
 #. Refers to a part of the layout where icons are previewed at various sizes.
 #: src/utils/TranslationUtils.gd
 msgid "Previews"
-msgstr "previews"
+msgstr "Previews"
 
 #: src/utils/TranslationUtils.gd
 msgid "Only {extension_list} files are supported for this operation."
-msgstr "only {extension_list} filez are supported for dis operation"
+msgstr "Only {extension List} Filez Are Supported 4 Dis Operation!"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select {format} files"
-msgstr "select {fomat} files"
+msgstr "Select {fomat} Files"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select an image"
-msgstr "select an image"
+msgstr "Select An Image"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select a font"
-msgstr "select a font"
+msgstr "Select A Font"
 
 #: src/utils/TranslationUtils.gd
 msgid "Select an {format} file"
-msgstr "select an {fomat} file"
+msgstr "Select An {fomat} File"
 
 #: src/utils/TranslationUtils.gd
 msgid "Save the {format} file"
-msgstr "save da {fomat} file"
+msgstr "Save Da {fomat} File"
 
 #: no_export/scripts/update_desktop_file.gd
 msgid "Vector graphics editor"
-msgstr "vector graphics editor"
+msgstr "Vector Graphics Editor"
 
 #: no_export/scripts/update_desktop_file.gd
 msgid "A vector graphics application for structured SVG editing"
-msgstr "a vector graphics application for structured svg editing"
+msgstr "A Vector Graphics Application 4 Structured Svg Editing"
 
 #. A list of keywords that should remain semicolon-separated. Doesn't need to be exactly translated. There can be more keywords or less, but they must remain similar to the English ones.
 #: no_export/scripts/update_desktop_file.gd
 msgid "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2D;code;blue;fox"
-msgstr "svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2d;code;blue;fox"
+msgstr "Svg;vector;graphics;draw;design;illustration;image;art;diagram;icon;logo;editor;path;shape;2d;code;blue;fox"
 


### PR DESCRIPTION
Adds the LOLCAT (Kingdom of Cats) language.

Silly language originating from early 2010s cat memes

Relatively easy to maintain since I made it a script that generates the language file from the normal English `en.po`

<img width="667" height="500" alt="image" src="https://github.com/user-attachments/assets/3e2f2a69-e786-49c0-bdb0-b82eeef49143" />

<img width="663" height="421" alt="image" src="https://github.com/user-attachments/assets/4ae70f0e-fa1b-437d-a06e-708adf554c7b" />

<img width="660" height="424" alt="image" src="https://github.com/user-attachments/assets/98cc9b36-dbfc-44a7-82a1-640451efe66a" />

Somewhat based on the Minecraft Lolcat language that was removed at some point (https://gist.github.com/Darkhax/e5519fe36f0b51fcb1c8)

If anything breaks in the future it shouldn't matter much as the language itself is meant to essentially be broken English.

Replace strings shouldn't be affected since my `update_lolcat.gd` script tries to specifically replace words